### PR TITLE
Extract classes for testability

### DIFF
--- a/src/main/scala/com/effiban/scala2java/AlternativeTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/AlternativeTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Pat.Alternative
 
 trait AlternativeTraverser extends ScalaTreeTraverser[Alternative]
 
-object AlternativeTraverser extends AlternativeTraverser {
+private[scala2java] class AlternativeTraverserImpl(patTraverser: => PatTraverser) extends AlternativeTraverser {
 
   // Pattern match alternative, e.g. 2 | 3. In Java - separated by comma
   override def traverse(patternAlternative: Alternative): Unit = {
-    PatTraverser.traverse(patternAlternative.lhs)
+    patTraverser.traverse(patternAlternative.lhs)
     emit(", ")
-    PatTraverser.traverse(patternAlternative.rhs)
+    patTraverser.traverse(patternAlternative.rhs)
   }
 }
+
+object AlternativeTraverser extends AlternativeTraverserImpl(PatTraverser)

--- a/src/main/scala/com/effiban/scala2java/AnnotListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/AnnotListTraverser.scala
@@ -7,13 +7,15 @@ import scala.meta.Mod.Annot
 
 trait AnnotListTraverser {
   def traverseAnnotations(annotations: List[Annot], onSameLine: Boolean = false): Unit
+
+  def traverseMods(mods: List[Mod], onSameLine: Boolean = false): Unit
 }
 
-object AnnotListTraverser extends AnnotListTraverser {
+private[scala2java] class AnnotListTraverserImpl(annotTraverser: => AnnotTraverser) extends AnnotListTraverser {
 
   override def traverseAnnotations(annotations: List[Annot], onSameLine: Boolean = false): Unit = {
     annotations.foreach(annotation => {
-      AnnotTraverser.traverse(annotation)
+      annotTraverser.traverse(annotation)
       if (onSameLine) {
         emit(" ")
       } else {
@@ -22,9 +24,12 @@ object AnnotListTraverser extends AnnotListTraverser {
     })
   }
 
-  def traverseMods(mods: List[Mod], onSameLine: Boolean = false): Unit = {
+  override def traverseMods(mods: List[Mod], onSameLine: Boolean = false): Unit = {
     traverseAnnotations(annotations = mods.collect { case annot: Annot => annot },
       onSameLine = onSameLine)
   }
 
 }
+
+object AnnotListTraverser extends AnnotListTraverserImpl(AnnotTraverser)
+

--- a/src/main/scala/com/effiban/scala2java/AnnotTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/AnnotTraverser.scala
@@ -6,10 +6,12 @@ import scala.meta.Mod.Annot
 
 trait AnnotTraverser extends ScalaTreeTraverser[Annot]
 
-object AnnotTraverser extends AnnotTraverser {
+private[scala2java] class AnnotTraverserImpl(initTraverser: => InitTraverser) extends AnnotTraverser {
 
   override def traverse(annotation: Annot): Unit = {
     emit("@")
-    InitTraverser.traverse(annotation.init)
+    initTraverser.traverse(annotation.init)
   }
 }
+
+object AnnotTraverser extends AnnotTraverserImpl(InitTraverser)

--- a/src/main/scala/com/effiban/scala2java/AnonymousFunctionTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/AnonymousFunctionTraverser.scala
@@ -7,11 +7,13 @@ import scala.meta.Term.{AnonymousFunction, Param}
 
 trait AnonymousFunctionTraverser extends ScalaTreeTraverser[AnonymousFunction]
 
-object AnonymousFunctionTraverser extends AnonymousFunctionTraverser {
+private[scala2java] class AnonymousFunctionTraverserImpl(termFunctionTraverser: => TermFunctionTraverser) extends AnonymousFunctionTraverser {
 
   override def traverse(anonymousFunction: AnonymousFunction): Unit = {
-    TermFunctionTraverser.traverse(Term.Function(
+    termFunctionTraverser.traverse(Term.Function(
       params = List(Param(name = Term.Name(JavaPlaceholder), mods = Nil, decltpe = None, default = None)),
       body = anonymousFunction.body))
   }
 }
+
+object AnonymousFunctionTraverser extends AnonymousFunctionTraverserImpl(TermFunctionTraverser)

--- a/src/main/scala/com/effiban/scala2java/ApplyUnaryTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ApplyUnaryTraverser.scala
@@ -4,10 +4,13 @@ import scala.meta.Term.ApplyUnary
 
 trait ApplyUnaryTraverser extends ScalaTreeTraverser[ApplyUnary]
 
-object ApplyUnaryTraverser extends ApplyUnaryTraverser {
+private[scala2java] class ApplyUnaryTraverserImpl(termNameTraverser: => TermNameTraverser,
+                                                  termTraverser: => TermTraverser) extends ApplyUnaryTraverser {
 
   override def traverse(applyUnary: ApplyUnary): Unit = {
-    TermNameTraverser.traverse(applyUnary.op)
-    TermTraverser.traverse(applyUnary.arg)
+    termNameTraverser.traverse(applyUnary.op)
+    termTraverser.traverse(applyUnary.arg)
   }
 }
+
+object ApplyUnaryTraverser extends ApplyUnaryTraverserImpl(TermNameTraverser, TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/AscribeTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/AscribeTraverser.scala
@@ -6,14 +6,17 @@ import scala.meta.Term.Ascribe
 
 trait AscribeTraverser extends ScalaTreeTraverser[Ascribe]
 
-object AscribeTraverser extends AscribeTraverser {
+private[scala2java] class AscribeTraverserImpl(typeTraverser: => TypeTraverser,
+                                               termTraverser: => TermTraverser) extends AscribeTraverser {
 
   // Explicitly specified type, e.g.: x = 2:Short
   // Java equivalent is casting. e.g. x = (short)2
   override def traverse(ascribe: Ascribe): Unit = {
     emit("(")
-    TypeTraverser.traverse(ascribe.tpe)
+    typeTraverser.traverse(ascribe.tpe)
     emit(")")
-    TermTraverser.traverse(ascribe.expr)
+    termTraverser.traverse(ascribe.expr)
   }
 }
+
+object AscribeTraverser extends AscribeTraverserImpl(TypeTraverser, TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/AssignTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/AssignTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Term.Assign
 
 trait AssignTraverser extends ScalaTreeTraverser[Assign]
 
-object AssignTraverser extends AssignTraverser {
+private[scala2java] class AssignTraverserImpl(termTraverser: => TermTraverser) extends AssignTraverser {
 
   // Variable assignment
   override def traverse(assign: Assign): Unit = {
-    TermTraverser.traverse(assign.lhs)
+    termTraverser.traverse(assign.lhs)
     emit(" = ")
-    TermTraverser.traverse(assign.rhs)
+    termTraverser.traverse(assign.rhs)
   }
 }
+
+object AssignTraverser extends AssignTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/BindTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/BindTraverser.scala
@@ -7,13 +7,15 @@ import scala.meta.Pat.Bind
 
 trait BindTraverser extends ScalaTreeTraverser[Pat.Bind]
 
-object BindTraverser extends BindTraverser {
+private[scala2java] class BindTraverserImpl(patTraverser: => PatTraverser) extends BindTraverser {
 
   // Pattern match bind variable, e.g.: a @ A()
   override def traverse(patternBind: Bind): Unit = {
     // In Java (when supported) the order is reversed
-    PatTraverser.traverse(patternBind.rhs)
+    patTraverser.traverse(patternBind.rhs)
     emit(" ")
-    PatTraverser.traverse(patternBind.lhs)
+    patTraverser.traverse(patternBind.lhs)
   }
 }
+
+object BindTraverser extends BindTraverserImpl(PatTraverser)

--- a/src/main/scala/com/effiban/scala2java/CaseTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/CaseTraverser.scala
@@ -6,18 +6,21 @@ import scala.meta.Case
 
 trait CaseTraverser extends ScalaTreeTraverser[Case]
 
-object CaseTraverser extends CaseTraverser {
+private[scala2java] class CaseTraverserImpl(patTraverser: => PatTraverser,
+                                            termTraverser: => TermTraverser) extends CaseTraverser {
 
   def traverse(`case`: Case): Unit = {
     emit("case ")
-    PatTraverser.traverse(`case`.pat)
+    patTraverser.traverse(`case`.pat)
     `case`.cond.foreach(cond => {
       emit(" && (")
-      TermTraverser.traverse(cond)
+      termTraverser.traverse(cond)
       emit(")")
     })
     emitArrow()
-    TermTraverser.traverse(`case`.body)
+    termTraverser.traverse(`case`.body)
     emitStatementEnd()
   }
 }
+
+object CaseTraverser extends CaseTraverserImpl(PatTraverser, TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/DeclTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DeclTraverser.scala
@@ -6,13 +6,21 @@ import scala.meta.Decl
 
 trait DeclTraverser extends ScalaTreeTraverser[Decl]
 
-object DeclTraverser extends DeclTraverser {
+private[scala2java] class DeclTraverserImpl(declValTraverser: => DeclValTraverser,
+                                            declVarTraverser: => DeclVarTraverser,
+                                            declDefTraverser: => DeclDefTraverser,
+                                            declTypeTraverser: => DeclTypeTraverser) extends DeclTraverser {
 
   override def traverse(decl: Decl): Unit = decl match {
-    case valDecl: Decl.Val => DeclValTraverser.traverse(valDecl)
-    case varDecl: Decl.Var => DeclVarTraverser.traverse(varDecl)
-    case defDecl: Decl.Def => DeclDefTraverser.traverse(defDecl)
-    case typeDecl: Decl.Type => DeclTypeTraverser.traverse(typeDecl)
+    case valDecl: Decl.Val => declValTraverser.traverse(valDecl)
+    case varDecl: Decl.Var => declVarTraverser.traverse(varDecl)
+    case defDecl: Decl.Def => declDefTraverser.traverse(defDecl)
+    case typeDecl: Decl.Type => declTypeTraverser.traverse(typeDecl)
     case _ => emitComment(s"UNSUPPORTED: $decl")
   }
 }
+
+object DeclTraverser extends DeclTraverserImpl(DeclValTraverser,
+  DeclVarTraverser,
+  DeclDefTraverser,
+  DeclTypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/DeclTypeTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DeclTypeTraverser.scala
@@ -6,14 +6,17 @@ import scala.meta.Decl
 
 trait DeclTypeTraverser extends ScalaTreeTraverser[Decl.Type]
 
-object DeclTypeTraverser extends DeclTypeTraverser {
+private[scala2java] class DeclTypeTraverserImpl(typeParamListTraverser: => TypeParamListTraverser,
+                                                javaModifiersResolver: JavaModifiersResolver) extends DeclTypeTraverser {
 
   // Scala type declaration : Closest thing in Java is an empty interface with same params
   override def traverse(typeDecl: Decl.Type): Unit = {
-    emitTypeDeclaration(modifiers = JavaModifiersResolver.resolveForInterface(typeDecl.mods),
+    emitTypeDeclaration(modifiers = javaModifiersResolver.resolveForInterface(typeDecl.mods),
       typeKeyword = "interface",
       name = typeDecl.name.toString)
-    TypeParamListTraverser.traverse(typeDecl.tparams)
+    typeParamListTraverser.traverse(typeDecl.tparams)
     // TODO handle bounds properly
   }
 }
+
+object DeclTypeTraverser extends DeclTypeTraverserImpl(TypeParamListTraverser, JavaModifiersResolver)

--- a/src/main/scala/com/effiban/scala2java/DeclVarTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DeclVarTraverser.scala
@@ -8,19 +8,29 @@ import scala.meta.Mod.ValParam
 
 trait DeclVarTraverser extends ScalaTreeTraverser[Decl.Var]
 
-object DeclVarTraverser extends DeclVarTraverser {
+private[scala2java] class DeclVarTraverserImpl(annotListTraverser: => AnnotListTraverser,
+                                               typeTraverser: => TypeTraverser,
+                                               patListTraverser: => PatListTraverser,
+                                               javaModifiersResolver: JavaModifiersResolver) extends DeclVarTraverser {
 
   override def traverse(varDecl: Decl.Var): Unit = {
     val annotationsOnSameLine = varDecl.mods.exists(_.isInstanceOf[ValParam])
-    AnnotListTraverser.traverseMods(varDecl.mods, annotationsOnSameLine)
+    annotListTraverser.traverseMods(varDecl.mods, annotationsOnSameLine)
     val modifierNames = javaOwnerContext match {
-      case Class => JavaModifiersResolver.resolveForClassDataMember(varDecl.mods)
+      case Class => javaModifiersResolver.resolveForClassDataMember(varDecl.mods)
       case _ => Nil
     }
     emitModifiers(modifierNames)
-    TypeTraverser.traverse(varDecl.decltpe)
+    typeTraverser.traverse(varDecl.decltpe)
     emit(" ")
     // TODO - verify when not simple case
-    PatListTraverser.traverse(varDecl.pats)
+    patListTraverser.traverse(varDecl.pats)
   }
 }
+
+object DeclVarTraverser extends DeclVarTraverserImpl(
+  AnnotListTraverser,
+  TypeTraverser,
+  PatListTraverser,
+  JavaModifiersResolver
+)

--- a/src/main/scala/com/effiban/scala2java/DefnDefTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DefnDefTraverser.scala
@@ -8,20 +8,25 @@ import scala.meta.{Defn, Term, Type}
 
 trait DefnDefTraverser extends ScalaTreeTraverser[Defn.Def]
 
-object DefnDefTraverser extends DefnDefTraverser {
+private[scala2java] class DefnDefTraverserImpl(annotListTraverser: => AnnotListTraverser,
+                                               termNameTraverser: => TermNameTraverser,
+                                               typeTraverser: => TypeTraverser,
+                                               termParamListTraverser: => TermParamListTraverser,
+                                               blockTraverser: => BlockTraverser,
+                                               javaModifiersResolver: JavaModifiersResolver) extends DefnDefTraverser {
 
   override def traverse(defDef: Defn.Def): Unit = {
     emitLine()
-    AnnotListTraverser.traverseMods(defDef.mods)
+    annotListTraverser.traverseMods(defDef.mods)
     val resolvedModifierNames = javaOwnerContext match {
-      case Interface => JavaModifiersResolver.resolveForInterfaceMethod(defDef.mods, hasBody = true)
-      case Class => JavaModifiersResolver.resolveForClassMethod(defDef.mods)
+      case Interface => javaModifiersResolver.resolveForInterfaceMethod(defDef.mods, hasBody = true)
+      case Class => javaModifiersResolver.resolveForClassMethod(defDef.mods)
       case _ => Nil
     }
     emitModifiers(resolvedModifierNames)
-    defDef.decltpe.foreach(TypeTraverser.traverse)
+    defDef.decltpe.foreach(typeTraverser.traverse)
     emit(" ")
-    TermNameTraverser.traverse(defDef.name)
+    termNameTraverser.traverse(defDef.name)
     // TODO handle method type params
 
     val outerJavaOwnerContext = javaOwnerContext
@@ -31,7 +36,7 @@ object DefnDefTraverser extends DefnDefTraverser {
   }
 
   private def traverseMethodParamsAndBody(defDef: Defn.Def): Unit = {
-    TermParamListTraverser.traverse(defDef.paramss.flatten)
+    termParamListTraverser.traverse(defDef.paramss.flatten)
     val withReturnValue = defDef.decltpe match {
       case Some(Type.Name("Unit")) => false
       case Some(_) => true
@@ -40,8 +45,17 @@ object DefnDefTraverser extends DefnDefTraverser {
       case None => true
     }
     defDef.body match {
-      case block: Block => BlockTraverser.traverse(block = block, shouldReturnValue = withReturnValue)
-      case term: Term => BlockTraverser.traverse(block = Block(List(term)), shouldReturnValue = withReturnValue)
+      case block: Block => blockTraverser.traverse(block = block, shouldReturnValue = withReturnValue)
+      case term: Term => blockTraverser.traverse(block = Block(List(term)), shouldReturnValue = withReturnValue)
     }
   }
 }
+
+object DefnDefTraverser extends DefnDefTraverserImpl(
+  AnnotListTraverser,
+  TermNameTraverser,
+  TypeTraverser,
+  TermParamListTraverser,
+  BlockTraverser,
+  JavaModifiersResolver
+)

--- a/src/main/scala/com/effiban/scala2java/DefnTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DefnTraverser.scala
@@ -7,16 +7,32 @@ import scala.meta.Defn.Trait
 
 trait DefnTraverser extends ScalaTreeTraverser[Defn]
 
-object DefnTraverser extends DefnTraverser {
+private[scala2java] class DefnTraverserImpl(defnValTraverser: => DefnValTraverser,
+                                            defnVarTraverser: => DefnVarTraverser,
+                                            defnDefTraverser: => DefnDefTraverser,
+                                            defnTypeTraverser: => DefnTypeTraverser,
+                                            classTraverser: => ClassTraverser,
+                                            traitTraverser: => TraitTraverser,
+                                            objectTraverser: => ObjectTraverser) extends DefnTraverser {
 
   override def traverse(defn: Defn): Unit = defn match {
-    case valDef: Defn.Val => DefnValTraverser.traverse(valDef)
-    case varDef: Defn.Var => DefnVarTraverser.traverse(varDef)
-    case defDef: Defn.Def => DefnDefTraverser.traverse(defDef)
-    case typeDef: Defn.Type => DefnTypeTraverser.traverse(typeDef)
-    case classDef: Defn.Class => ClassTraverser.traverse(classDef)
-    case traitDef: Trait => TraitTraverser.traverse(traitDef)
-    case objectDef: Defn.Object => ObjectTraverser.traverse(objectDef)
+    case valDef: Defn.Val => defnValTraverser.traverse(valDef)
+    case varDef: Defn.Var => defnVarTraverser.traverse(varDef)
+    case defDef: Defn.Def => defnDefTraverser.traverse(defDef)
+    case typeDef: Defn.Type => defnTypeTraverser.traverse(typeDef)
+    case classDef: Defn.Class => classTraverser.traverse(classDef)
+    case traitDef: Trait => traitTraverser.traverse(traitDef)
+    case objectDef: Defn.Object => objectTraverser.traverse(objectDef)
     case _ => emitComment(s"UNSUPPORTED: $defn")
   }
 }
+
+object DefnTraverser extends DefnTraverserImpl(
+  DefnValTraverser,
+  DefnVarTraverser,
+  DefnDefTraverser,
+  DefnTypeTraverser,
+  ClassTraverser,
+  TraitTraverser,
+  ObjectTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/DefnTypeTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DefnTypeTraverser.scala
@@ -7,18 +7,25 @@ import scala.meta.Defn
 
 trait DefnTypeTraverser extends ScalaTreeTraverser[Defn.Type]
 
-object DefnTypeTraverser extends DefnTypeTraverser {
+private[scala2java] class DefnTypeTraverserImpl(typeParamListTraverser: => TypeParamListTraverser,
+                                                typeTraverser: => TypeTraverser,
+                                                javaModifiersResolver: JavaModifiersResolver) extends DefnTypeTraverser {
 
   // Scala type definition : Closest thing in Java is an empty interface extending the same RHS
   override def traverse(typeDef: Defn.Type): Unit = {
-    emitTypeDeclaration(modifiers = JavaModifiersResolver.resolveForInterface(typeDef.mods),
+    emitTypeDeclaration(modifiers = javaModifiersResolver.resolveForInterface(typeDef.mods),
       typeKeyword = "interface",
       name = typeDef.name.toString)
-    TypeParamListTraverser.traverse(typeDef.tparams)
+    typeParamListTraverser.traverse(typeDef.tparams)
     emit(" extends ") // TODO handle bounds properly
     val outerJavaOwnerContext = javaOwnerContext
     javaOwnerContext = Interface
-    TypeTraverser.traverse(typeDef.body)
+    typeTraverser.traverse(typeDef.body)
     javaOwnerContext = outerJavaOwnerContext
   }
 }
+
+object DefnTypeTraverser extends DefnTypeTraverserImpl(
+  TypeParamListTraverser,
+  TypeTraverser,
+  JavaModifiersResolver)

--- a/src/main/scala/com/effiban/scala2java/DoTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/DoTraverser.scala
@@ -6,13 +6,15 @@ import scala.meta.Term.Do
 
 trait DoTraverser extends ScalaTreeTraverser[Do]
 
-object DoTraverser extends DoTraverser {
+private[scala2java] class DoTraverserImpl(termTraverser: => TermTraverser) extends DoTraverser {
 
   override def traverse(`do`: Do): Unit = {
     emit("do ")
-    TermTraverser.traverse(`do`.body)
+    termTraverser.traverse(`do`.body)
     emit("while (")
-    TermTraverser.traverse(`do`.expr)
+    termTraverser.traverse(`do`.expr)
     emit(")")
   }
 }
+
+object DoTraverser extends DoTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/EtaTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/EtaTraverser.scala
@@ -5,11 +5,13 @@ import scala.meta.Term.Eta
 
 trait EtaTraverser extends ScalaTreeTraverser[Eta]
 
-object EtaTraverser extends EtaTraverser {
+private[scala2java] class EtaTraverserImpl(termTraverser: => TermTraverser) extends EtaTraverser {
 
   // Eta expansion: Method translated into function, e.g.:  myMethod _
   def traverse(eta: Term.Eta): Unit = {
     // TODO - this will probably not compile in Java, see how it can be improved
-    TermTraverser.traverse(eta.expr)
+    termTraverser.traverse(eta.expr)
   }
 }
+
+object EtaTraverser extends EtaTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/ForTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ForTraverser.scala
@@ -4,9 +4,11 @@ import scala.meta.Term.For
 
 trait ForTraverser extends ScalaTreeTraverser[For]
 
-object ForTraverser extends ForTraverser {
+private[scala2java] class ForTraverserImpl(forVariantsTraverser: => ForVariantsTraverser) extends ForTraverser {
 
   override def traverse(`for`: For): Unit = {
-    ForVariantsTraverser.traverse(`for`.enums, `for`.body)
+    forVariantsTraverser.traverse(`for`.enums, `for`.body)
   }
 }
+
+object ForTraverser extends ForTraverserImpl(ForVariantsTraverser)

--- a/src/main/scala/com/effiban/scala2java/ForVariantsTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ForVariantsTraverser.scala
@@ -10,10 +10,10 @@ trait ForVariantsTraverser {
   def traverse(enumerators: List[Enumerator], body: Term): Unit
 }
 
-object ForVariantsTraverser extends ForVariantsTraverser {
+private[scala2java] class ForVariantsTraverserImpl(termTraverser: => TermTraverser) extends ForVariantsTraverser {
 
   override def traverse(enumerators: List[Enumerator], body: Term): Unit = {
-    TermTraverser.traverse(translateFor(enumerators, body))
+    termTraverser.traverse(translateFor(enumerators, body))
   }
 
   private def translateFor(enumerators: List[Enumerator],
@@ -61,3 +61,5 @@ object ForVariantsTraverser extends ForVariantsTraverser {
     Param(mods = List.empty, name = Term.Name(name), decltpe = None, default = None)
   }
 }
+
+object ForVariantsTraverser extends ForVariantsTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/ForYieldTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ForYieldTraverser.scala
@@ -4,9 +4,11 @@ import scala.meta.Term.ForYield
 
 trait ForYieldTraverser extends ScalaTreeTraverser[ForYield]
 
-object ForYieldTraverser extends ForYieldTraverser {
+private[scala2java] class ForYieldTraverserImpl(forVariantsTraverser: => ForVariantsTraverser) extends ForYieldTraverser {
 
   override def traverse(forYield: ForYield): Unit = {
-    ForVariantsTraverser.traverse(forYield.enums, forYield.body)
+    forVariantsTraverser.traverse(forYield.enums, forYield.body)
   }
 }
+
+object ForYieldTraverser extends ForYieldTraverserImpl(ForVariantsTraverser)

--- a/src/main/scala/com/effiban/scala2java/ImportTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ImportTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Import
 
 trait ImportTraverser extends ScalaTreeTraverser[Import]
 
-object ImportTraverser extends ImportTraverser {
+private[scala2java] class ImportTraverserImpl(importerTraverser: => ImporterTraverser) extends ImportTraverser {
 
   override def traverse(`import`: Import): Unit = {
     `import`.importers match {
       case List() => emitComment("Invalid import with no inner importers")
-      case importers => importers.foreach(ImporterTraverser.traverse)
+      case importers => importers.foreach(importerTraverser.traverse)
     }
   }
 }
+
+object ImportTraverser extends ImportTraverserImpl(ImporterTraverser)

--- a/src/main/scala/com/effiban/scala2java/ImporteeTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ImporteeTraverser.scala
@@ -6,19 +6,21 @@ import scala.meta.Importee
 
 trait ImporteeTraverser extends ScalaTreeTraverser[Importee]
 
-object ImporteeTraverser extends ImporteeTraverser {
+private[scala2java] class ImporteeTraverserImpl(nameTraverser: => NameTraverser) extends ImporteeTraverser {
 
   // A single imported element within an Importer (can be one name, wildcard etc. see below)
   override def traverse(importee: Importee): Unit = {
     importee match {
-      case Importee.Name(name) => NameTraverser.traverse(name)
+      case Importee.Name(name) => nameTraverser.traverse(name)
       case Importee.Wildcard() => emit("*")
       case Importee.Rename(name, rename) =>
-        NameTraverser.traverse(name)
+        nameTraverser.traverse(name)
         emitComment(s" Renamed in Scala to ${rename.toString}")
       case Importee.Unimport(name) =>
-        NameTraverser.traverse(name)
+        nameTraverser.traverse(name)
         emitComment(s" Hidden (unimported) in Scala")
     }
   }
 }
+
+object ImporteeTraverser extends ImporteeTraverserImpl(NameTraverser)

--- a/src/main/scala/com/effiban/scala2java/ImporterTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ImporterTraverser.scala
@@ -7,7 +7,8 @@ import scala.meta.{Importer, Term}
 
 trait ImporterTraverser extends ScalaTreeTraverser[Importer]
 
-object ImporterTraverser extends ImporterTraverser {
+private[scala2java] class ImporterTraverserImpl(termRefTraverser: => TermRefTraverser,
+                                                importeeTraverser: => ImporteeTraverser) extends ImporterTraverser {
 
   // In Scala there can be several `import` statements on same line (not just the final name) - each one is called an 'Importer'
   override def traverse(importer: Importer): Unit = {
@@ -16,11 +17,13 @@ object ImporterTraverser extends ImporterTraverser {
       case ref =>
         importer.importees.foreach(importee => {
           emit("import ")
-          TermRefTraverser.traverse(ref)
+          termRefTraverser.traverse(ref)
           emit(".")
-          ImporteeTraverser.traverse(importee)
+          importeeTraverser.traverse(importee)
           emitStatementEnd()
         })
     }
   }
 }
+
+object ImporterTraverser extends ImporterTraverserImpl(TermRefTraverser, ImporteeTraverser)

--- a/src/main/scala/com/effiban/scala2java/InitListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/InitListTraverser.scala
@@ -6,11 +6,14 @@ trait InitListTraverser {
   def traverse(inits: List[Init]): Unit
 }
 
-object InitListTraverser extends InitListTraverser {
+private[scala2java] class InitListTraverserImpl(argumentListTraverser: => ArgumentListTraverser,
+                                                initTraverser: => InitTraverser) extends InitListTraverser {
 
   override def traverse(inits: List[Init]): Unit = {
     if (inits.nonEmpty) {
-      ArgumentListTraverser.traverse(args = inits, argTraverser = InitTraverser)
+      argumentListTraverser.traverse(args = inits, argTraverser = initTraverser)
     }
   }
 }
+
+object InitListTraverser extends InitListTraverserImpl(ArgumentListTraverser, InitTraverser)

--- a/src/main/scala/com/effiban/scala2java/InitTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/InitTraverser.scala
@@ -6,20 +6,24 @@ import scala.meta.{Init, Name}
 
 trait InitTraverser extends ScalaTreeTraverser[Init]
 
-object InitTraverser extends InitTraverser {
+private[scala2java] class InitTraverserImpl(typeTraverser: => TypeTraverser,
+                                            nameTraverser: => NameTraverser,
+                                            termListTraverser: => TermListTraverser) extends InitTraverser {
 
   // An 'Init' is a parent of a type in its declaration
   override def traverse(init: Init): Unit = {
-    TypeTraverser.traverse(init.tpe)
+    typeTraverser.traverse(init.tpe)
     init.name match {
       case Name.Anonymous() =>
       case name =>
         emit(" ")
-        NameTraverser.traverse(name)
+        nameTraverser.traverse(name)
     }
     val args = init.argss.flatten
     if (args.nonEmpty) {
-      TermListTraverser.traverse(init.argss.flatten, maybeDelimiterType = Some(Parentheses))
+      termListTraverser.traverse(init.argss.flatten, maybeDelimiterType = Some(Parentheses))
     }
   }
 }
+
+object InitTraverser extends InitTraverserImpl(TypeTraverser, NameTraverser, TermListTraverser)

--- a/src/main/scala/com/effiban/scala2java/NameTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/NameTraverser.scala
@@ -6,14 +6,24 @@ import scala.meta.{Name, Term, Type}
 
 trait NameTraverser extends ScalaTreeTraverser[Name]
 
-object NameTraverser extends NameTraverser {
+private[scala2java] class NameTraverserImpl(nameAnonymousTraverser: => NameAnonymousTraverser,
+                                            nameIndeterminateTraverser: => NameIndeterminateTraverser,
+                                            termNameTraverser: => TermNameTraverser,
+                                            typeNameTraverser: => TypeNameTraverser) extends NameTraverser {
 
   override def traverse(name: Name): Unit = name match {
-    case anonName: Name.Anonymous => NameAnonymousTraverser.traverse(anonName)
-    case indeterminateName: Name.Indeterminate => NameIndeterminateTraverser.traverse(indeterminateName)
-    case termName: Term.Name => TermNameTraverser.traverse(termName)
-    case typeName: Type.Name => TypeNameTraverser.traverse(typeName)
+    case anonName: Name.Anonymous => nameAnonymousTraverser.traverse(anonName)
+    case indeterminateName: Name.Indeterminate => nameIndeterminateTraverser.traverse(indeterminateName)
+    case termName: Term.Name => termNameTraverser.traverse(termName)
+    case typeName: Type.Name => typeNameTraverser.traverse(typeName)
     case other => emitComment(s"UNSUPPORTED: $other")
   }
 
 }
+
+object NameTraverser extends NameTraverserImpl(
+  NameAnonymousTraverser,
+  NameIndeterminateTraverser,
+  TermNameTraverser,
+  TypeNameTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/NewAnonymousTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/NewAnonymousTraverser.scala
@@ -6,10 +6,12 @@ import scala.meta.Term.NewAnonymous
 
 trait NewAnonymousTraverser extends ScalaTreeTraverser[NewAnonymous]
 
-object NewAnonymousTraverser extends NewAnonymousTraverser {
+private[scala2java] class NewAnonymousTraverserImpl(templateTraverser: => TemplateTraverser) extends NewAnonymousTraverser {
 
   override def traverse(newAnonymous: NewAnonymous): Unit = {
     emit("new ")
-    TemplateTraverser.traverse(newAnonymous.templ)
+    templateTraverser.traverse(newAnonymous.templ)
   }
 }
+
+object NewAnonymousTraverser extends NewAnonymousTraverserImpl(TemplateTraverser)

--- a/src/main/scala/com/effiban/scala2java/NewTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/NewTraverser.scala
@@ -6,10 +6,12 @@ import scala.meta.Term.New
 
 trait NewTraverser extends ScalaTreeTraverser[New]
 
-object NewTraverser extends NewTraverser {
+private[scala2java] class NewTraverserImpl(initTraverser: => InitTraverser) extends NewTraverser {
 
   override def traverse(`new`: New): Unit = {
     emit("new ")
-    InitTraverser.traverse(`new`.init)
+    initTraverser.traverse(`new`.init)
   }
 }
+
+object NewTraverser extends NewTraverserImpl(InitTraverser)

--- a/src/main/scala/com/effiban/scala2java/ObjectTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ObjectTraverser.scala
@@ -7,18 +7,22 @@ import scala.meta.Defn
 
 trait ObjectTraverser extends ScalaTreeTraverser[Defn.Object]
 
-object ObjectTraverser extends ObjectTraverser {
+private[scala2java] class ObjectTraverserImpl(templateTraverser: => TemplateTraverser,
+                                              javaModifiersResolver: JavaModifiersResolver) extends ObjectTraverser {
 
   override def traverse(objectDef: Defn.Object): Unit = {
     emitLine()
     emitComment("originally a Scala object")
     emitLine()
-    emitTypeDeclaration(modifiers = JavaModifiersResolver.resolveForClass(objectDef.mods),
+    emitTypeDeclaration(modifiers = javaModifiersResolver.resolveForClass(objectDef.mods),
       typeKeyword = "class",
       name = s"${objectDef.name.toString}")
     val outerJavaOwnerContext = javaOwnerContext
     javaOwnerContext = Class
-    TemplateTraverser.traverse(objectDef.templ)
+    templateTraverser.traverse(objectDef.templ)
     javaOwnerContext = outerJavaOwnerContext
   }
 }
+
+object ObjectTraverser extends ObjectTraverserImpl(TemplateTraverser, JavaModifiersResolver)
+

--- a/src/main/scala/com/effiban/scala2java/PartialFunctionTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/PartialFunctionTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Term
 
 trait PartialFunctionTraverser extends ScalaTreeTraverser[Term.PartialFunction]
 
-object PartialFunctionTraverser extends PartialFunctionTraverser {
+private[scala2java] class PartialFunctionTraverserImpl(termMatchTraverser: => TermMatchTraverser) extends PartialFunctionTraverser {
 
   override def traverse(partialFunction: Term.PartialFunction): Unit = {
     val dummyArgName = "arg"
     emit(dummyArgName)
     emitArrow()
-    TermMatchTraverser.traverse(Term.Match(expr = Term.Name(dummyArgName), cases = partialFunction.cases))
+    termMatchTraverser.traverse(Term.Match(expr = Term.Name(dummyArgName), cases = partialFunction.cases))
   }
 }
+
+object PartialFunctionTraverser extends PartialFunctionTraverserImpl(TermMatchTraverser)

--- a/src/main/scala/com/effiban/scala2java/PatListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/PatListTraverser.scala
@@ -6,13 +6,16 @@ trait PatListTraverser {
   def traverse(pats: List[Pat]): Unit
 }
 
-object PatListTraverser extends PatListTraverser {
+private[scala2java] class PatListTraverserImpl(argumentListTraverser: => ArgumentListTraverser,
+                                               patTraverser: => PatTraverser) extends PatListTraverser {
 
   override def traverse(pats: List[Pat]): Unit = {
     if (pats.nonEmpty) {
-      ArgumentListTraverser.traverse(args = pats,
-        argTraverser = PatTraverser,
+      argumentListTraverser.traverse(args = pats,
+        argTraverser = patTraverser,
         onSameLine = true)
     }
   }
 }
+
+object PatListTraverser extends PatListTraverserImpl(ArgumentListTraverser, PatTraverser)

--- a/src/main/scala/com/effiban/scala2java/PatTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/PatTraverser.scala
@@ -7,22 +7,48 @@ import scala.meta.{Lit, Pat, Term}
 
 trait PatTraverser extends ScalaTreeTraverser[Pat]
 
-object PatTraverser extends PatTraverser {
+private[scala2java] class PatTraverserImpl(termNameTraverser: => TermNameTraverser,
+                                           patWildcardTraverser: => PatWildcardTraverser,
+                                           patSeqWildcardTraverser: => PatSeqWildcardTraverser,
+                                           patVarTraverser: => PatVarTraverser,
+                                           bindTraverser: => BindTraverser,
+                                           alternativeTraverser: => AlternativeTraverser,
+                                           patTupleTraverser: => PatTupleTraverser,
+                                           patExtractTraverser: => PatExtractTraverser,
+                                           patExtractInfixTraverser: => PatExtractInfixTraverser,
+                                           patInterpolateTraverser: => PatInterpolateTraverser,
+                                           patXmlTraverser: => PatXmlTraverser,
+                                           patTypedTraverser: => PatTypedTraverser) extends PatTraverser {
 
   override def traverse(pat: Pat): Unit = pat match {
     case lit: Lit => LitTraverser.traverse(lit)
-    case termName: Term.Name => TermNameTraverser.traverse(termName)
-    case patternWildcard: Pat.Wildcard => PatWildcardTraverser.traverse(patternWildcard)
-    case patternSeqWildcard: Pat.SeqWildcard => PatSeqWildcardTraverser.traverse(patternSeqWildcard)
-    case patternVar: Pat.Var => PatVarTraverser.traverse(patternVar)
-    case patternBind: Bind => BindTraverser.traverse(patternBind)
-    case patternAlternative: Alternative => AlternativeTraverser.traverse(patternAlternative)
-    case patternTuple: Pat.Tuple => PatTupleTraverser.traverse(patternTuple)
-    case patternExtract: Pat.Extract => PatExtractTraverser.traverse(patternExtract)
-    case patternExtractInfix: Pat.ExtractInfix => PatExtractInfixTraverser.traverse(patternExtractInfix)
-    case patternInterpolate: Pat.Interpolate => PatInterpolateTraverser.traverse(patternInterpolate)
-    case patternXml: Pat.Xml => PatXmlTraverser.traverse(patternXml)
-    case patternTyped: Pat.Typed => PatTypedTraverser.traverse(patternTyped)
+    case termName: Term.Name => termNameTraverser.traverse(termName)
+    case patternWildcard: Pat.Wildcard => patWildcardTraverser.traverse(patternWildcard)
+    case patternSeqWildcard: Pat.SeqWildcard => patSeqWildcardTraverser.traverse(patternSeqWildcard)
+    case patternVar: Pat.Var => patVarTraverser.traverse(patternVar)
+    case patternBind: Bind => bindTraverser.traverse(patternBind)
+    case patternAlternative: Alternative => alternativeTraverser.traverse(patternAlternative)
+    case patternTuple: Pat.Tuple => patTupleTraverser.traverse(patternTuple)
+    case patternExtract: Pat.Extract => patExtractTraverser.traverse(patternExtract)
+    case patternExtractInfix: Pat.ExtractInfix => patExtractInfixTraverser.traverse(patternExtractInfix)
+    case patternInterpolate: Pat.Interpolate => patInterpolateTraverser.traverse(patternInterpolate)
+    case patternXml: Pat.Xml => patXmlTraverser.traverse(patternXml)
+    case patternTyped: Pat.Typed => patTypedTraverser.traverse(patternTyped)
     case _ => emitComment(s"UNSUPPORTED: $pat")
   }
 }
+
+object PatTraverser extends PatTraverserImpl(
+  TermNameTraverser,
+  PatWildcardTraverser,
+  PatSeqWildcardTraverser,
+  PatVarTraverser,
+  BindTraverser,
+  AlternativeTraverser,
+  PatTupleTraverser,
+  PatExtractTraverser,
+  PatExtractInfixTraverser,
+  PatInterpolateTraverser,
+  PatXmlTraverser,
+  PatTypedTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/PatTypedTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/PatTypedTraverser.scala
@@ -6,12 +6,15 @@ import scala.meta.Pat
 
 trait PatTypedTraverser extends ScalaTreeTraverser[Pat.Typed]
 
-object PatTypedTraverser extends PatTypedTraverser {
+private[scala2java] class PatTypedTraverserImpl(typeTraverser: => TypeTraverser,
+                                                patTraverser: => PatTraverser) extends PatTypedTraverser {
 
   // Typed pattern expression, e.g. a: Int (in lhs of case clause)
   override def traverse(typedPattern: Pat.Typed): Unit = {
-    TypeTraverser.traverse(typedPattern.rhs)
+    typeTraverser.traverse(typedPattern.rhs)
     emit(" ")
-    PatTraverser.traverse(typedPattern.lhs)
+    patTraverser.traverse(typedPattern.lhs)
   }
 }
+
+object PatTypedTraverser extends PatTypedTraverserImpl(TypeTraverser, PatTraverser)

--- a/src/main/scala/com/effiban/scala2java/PatVarTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/PatVarTraverser.scala
@@ -4,10 +4,12 @@ import scala.meta.Pat
 
 trait PatVarTraverser extends ScalaTreeTraverser[Pat.Var]
 
-object PatVarTraverser extends PatVarTraverser {
+private[scala2java] class PatVarTraverserImpl(termNameTraverser: => TermNameTraverser) extends PatVarTraverser {
 
   // Pattern match variable, e.g. `a` in case a =>
   override def traverse(patternVar: Pat.Var): Unit = {
-    TermNameTraverser.traverse(patternVar.name)
+    termNameTraverser.traverse(patternVar.name)
   }
 }
+
+object PatVarTraverser extends PatVarTraverserImpl(TermNameTraverser)

--- a/src/main/scala/com/effiban/scala2java/PkgTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/PkgTraverser.scala
@@ -6,13 +6,16 @@ import scala.meta.Pkg
 
 trait PkgTraverser extends ScalaTreeTraverser[Pkg]
 
-object PkgTraverser extends PkgTraverser {
+private[scala2java] class PkgTraverserImpl(termRefTraverser: => TermRefTraverser,
+                                           statTraverser: => StatTraverser) extends PkgTraverser {
 
   override def traverse(pkg: Pkg): Unit = {
     emit("package ")
-    TermRefTraverser.traverse(pkg.ref)
+    termRefTraverser.traverse(pkg.ref)
     emitStatementEnd()
     emitLine()
-    pkg.stats.foreach(StatTraverser.traverse)
+    pkg.stats.foreach(statTraverser.traverse)
   }
 }
+
+object PkgTraverser extends PkgTraverserImpl(TermRefTraverser, StatTraverser)

--- a/src/main/scala/com/effiban/scala2java/ReturnTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ReturnTraverser.scala
@@ -6,10 +6,12 @@ import scala.meta.Term.Return
 
 trait ReturnTraverser extends ScalaTreeTraverser[Return]
 
-object ReturnTraverser extends ReturnTraverser {
+private[scala2java] class ReturnTraverserImpl(termTraverser: => TermTraverser) extends ReturnTraverser {
 
   override def traverse(`return`: Return): Unit = {
     emit("return ")
-    TermTraverser.traverse(`return`.expr)
+    termTraverser.traverse(`return`.expr)
   }
 }
+
+object ReturnTraverser extends ReturnTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/SourceTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/SourceTraverser.scala
@@ -4,10 +4,12 @@ import scala.meta.Source
 
 trait SourceTraverser extends ScalaTreeTraverser[Source]
 
-object SourceTraverser extends SourceTraverser {
+private[scala2java] class SourceTraverserImpl(statTraverser: => StatTraverser) extends SourceTraverser {
 
   // source file
   def traverse(source: Source): Unit = {
-    source.stats.foreach(StatTraverser.traverse)
+    source.stats.foreach(statTraverser.traverse)
   }
 }
+
+object SourceTraverser extends SourceTraverserImpl(StatTraverser)

--- a/src/main/scala/com/effiban/scala2java/StatTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/StatTraverser.scala
@@ -6,15 +6,27 @@ import scala.meta.{Decl, Defn, Import, Pkg, Stat, Term}
 
 trait StatTraverser extends ScalaTreeTraverser[Stat]
 
-object StatTraverser extends StatTraverser {
+private[scala2java] class StatTraverserImpl(termTraverser: => TermTraverser,
+                                            importTraverser: => ImportTraverser,
+                                            pkgTraverser: => PkgTraverser,
+                                            defnTraverser: => DefnTraverser,
+                                            declTraverser: => DeclTraverser) extends StatTraverser {
 
   override def traverse(stat: Stat): Unit = stat match {
-    case term: Term => TermTraverser.traverse(term)
-    case `import`: Import => ImportTraverser.traverse(`import`)
-    case pkg: Pkg => PkgTraverser.traverse(pkg)
-    case defn: Defn => DefnTraverser.traverse(defn)
+    case term: Term => termTraverser.traverse(term)
+    case `import`: Import => importTraverser.traverse(`import`)
+    case pkg: Pkg => pkgTraverser.traverse(pkg)
+    case defn: Defn => defnTraverser.traverse(defn)
     case decl: Decl => DeclTraverser.traverse(decl)
     case other => emitComment(s"UNSUPPORTED: $other")
   }
 
 }
+
+object StatTraverser extends StatTraverserImpl(
+  TermTraverser,
+  ImportTraverser,
+  PkgTraverser,
+  DefnTraverser,
+  DeclTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/SuperTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/SuperTraverser.scala
@@ -7,7 +7,7 @@ import scala.meta.Term.Super
 
 trait SuperTraverser extends ScalaTreeTraverser[Super]
 
-object SuperTraverser extends SuperTraverser {
+private[scala2java] class SuperTraverserImpl(nameTraverser: => NameTraverser) extends SuperTraverser {
 
   def traverse(`super`: Super): Unit = {
     `super`.thisp match {
@@ -22,3 +22,5 @@ object SuperTraverser extends SuperTraverser {
     }
   }
 }
+
+object SuperTraverser extends SuperTraverserImpl(NameTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermAnnotateTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermAnnotateTraverser.scala
@@ -6,14 +6,17 @@ import scala.meta.Term
 
 trait TermAnnotateTraverser extends ScalaTreeTraverser[Term.Annotate]
 
-object TermAnnotateTraverser extends TermAnnotateTraverser {
+private[scala2java] class TermAnnotateTraverserImpl(annotListTraverser: => AnnotListTraverser,
+                                                    termTraverser: => TermTraverser) extends TermAnnotateTraverser {
 
   // Expression annotation, e.g.:  (x: @annot) match ....
   // Partially supported in Java, so it will be rendered properly if it is a Java annotation
   override def traverse(termAnnotation: Term.Annotate): Unit = {
     emit("(")
-    AnnotListTraverser.traverseAnnotations(termAnnotation.annots, onSameLine = true)
-    TermTraverser.traverse(termAnnotation.expr)
+    annotListTraverser.traverseAnnotations(termAnnotation.annots, onSameLine = true)
+    termTraverser.traverse(termAnnotation.expr)
     emit(")")
   }
 }
+
+object TermAnnotateTraverser extends TermAnnotateTraverserImpl(AnnotListTraverser, TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermApplyInfixTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermApplyInfixTraverser.scala
@@ -6,15 +6,19 @@ import scala.meta.Term
 
 trait TermApplyInfixTraverser extends ScalaTreeTraverser[Term.ApplyInfix]
 
-object TermApplyInfixTraverser extends TermApplyInfixTraverser {
+private[scala2java] class TermApplyInfixTraverserImpl(termTraverser: => TermTraverser,
+                                                      termNameTraverser: => TermNameTraverser,
+                                                      termListTraverser: => TermListTraverser) extends TermApplyInfixTraverser {
 
   // Infix method invocation, e.g.: a + b
   override def traverse(termApplyInfix: Term.ApplyInfix): Unit = {
     // TODO - verify implementation for multiple RHS args
-    TermTraverser.traverse(termApplyInfix.lhs)
+    termTraverser.traverse(termApplyInfix.lhs)
     emit(" ")
-    TermNameTraverser.traverse(termApplyInfix.op)
+    termNameTraverser.traverse(termApplyInfix.op)
     emit(" ")
-    TermListTraverser.traverse(termApplyInfix.args, onSameLine = true)
+    termListTraverser.traverse(termApplyInfix.args, onSameLine = true)
   }
 }
+
+object TermApplyInfixTraverser extends TermApplyInfixTraverserImpl(TermTraverser, TermNameTraverser, TermListTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermApplyTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermApplyTraverser.scala
@@ -2,11 +2,16 @@ package com.effiban.scala2java
 
 import scala.meta.Term
 
-object TermApplyTraverser extends ScalaTreeTraverser[Term.Apply] {
+trait TermApplyTraverser extends ScalaTreeTraverser[Term.Apply]
+
+private[scala2java] class TermApplyTraverserImpl(termTraverser: => TermTraverser,
+                                                 termListTraverser: => TermListTraverser) extends TermApplyTraverser {
 
   // method invocation
   override def traverse(termApply: Term.Apply): Unit = {
-    TermTraverser.traverse(termApply.fun)
-    TermListTraverser.traverse(termApply.args, maybeDelimiterType = Some(Parentheses))
+    termTraverser.traverse(termApply.fun)
+    termListTraverser.traverse(termApply.args, maybeDelimiterType = Some(Parentheses))
   }
 }
+
+object TermApplyTraverser extends TermApplyTraverserImpl(TermTraverser, TermListTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermFunctionTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermFunctionTraverser.scala
@@ -7,7 +7,9 @@ import scala.meta.Term
 
 trait TermFunctionTraverser extends ScalaTreeTraverser[Term.Function]
 
-object TermFunctionTraverser extends TermFunctionTraverser {
+private[scala2java] class TermFunctionTraverserImpl(termParamTraverser: => TermParamTraverser,
+                                                    termParamListTraverser: => TermParamListTraverser,
+                                                    termTraverser: => TermTraverser) extends TermFunctionTraverser {
 
   // lambda definition
   override def traverse(function: Term.Function): Unit = {
@@ -15,11 +17,17 @@ object TermFunctionTraverser extends TermFunctionTraverser {
     javaOwnerContext = Lambda
     function.params match {
       case Nil =>
-      case param :: Nil => TermParamTraverser.traverse(param)
-      case _ => TermParamListTraverser.traverse(function.params)
+      case param :: Nil => termParamTraverser.traverse(param)
+      case _ => termParamListTraverser.traverse(function.params)
     }
     emitArrow()
-    TermTraverser.traverse(function.body)
+    termTraverser.traverse(function.body)
     javaOwnerContext = outerJavaOwnerContext
   }
 }
+
+object TermFunctionTraverser extends TermFunctionTraverserImpl(
+  TermParamTraverser,
+  TermParamListTraverser,
+    TermTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/TermInterpolateTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermInterpolateTraverser.scala
@@ -7,12 +7,12 @@ import scala.meta.{Lit, Term}
 
 trait TermInterpolateTraverser extends ScalaTreeTraverser[Term.Interpolate]
 
-object TermInterpolateTraverser extends TermInterpolateTraverser {
+private[scala2java] class TermInterpolateTraverserImpl(termApplyTraverser: => TermApplyTraverser) extends TermInterpolateTraverser {
 
   override def traverse(termInterpolate: Term.Interpolate): Unit = {
     // Transform Scala string interpolation to Java String.format()
     termInterpolate.prefix match {
-      case Term.Name("s") => TermApplyTraverser.traverse(toJavaStringFormatInvocation(termInterpolate.parts, termInterpolate.args))
+      case Term.Name("s") => termApplyTraverser.traverse(toJavaStringFormatInvocation(termInterpolate.parts, termInterpolate.args))
       case _ => emitComment(s"UNRECOGNIZED interpolation: $termInterpolate")
     }
   }
@@ -21,3 +21,5 @@ object TermInterpolateTraverser extends TermInterpolateTraverser {
     Apply(Select(Term.Name("String"), Term.Name("format")), List(Lit.String(formatParts.mkString("%s"))) ++ interpolationArgs)
   }
 }
+
+object TermInterpolateTraverser extends TermInterpolateTraverserImpl(TermApplyTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermListTraverser.scala
@@ -9,16 +9,19 @@ trait TermListTraverser {
                maybeDelimiterType: Option[DualDelimiterType] = None): Unit
 }
 
-object TermListTraverser extends TermListTraverser {
+private[scala2java] class TermListTraverserImpl(argumentListTraverser: => ArgumentListTraverser,
+                                                termTraverser: => TermTraverser) extends TermListTraverser {
 
   override def traverse(terms: List[Term],
                         onSameLine: Boolean = false,
                         maybeDelimiterType: Option[DualDelimiterType] = None): Unit = {
     if (terms.nonEmpty) {
-      ArgumentListTraverser.traverse(args = terms,
-        argTraverser = TermTraverser,
+      argumentListTraverser.traverse(args = terms,
+        argTraverser = termTraverser,
         onSameLine = onSameLine,
         maybeDelimiterType = maybeDelimiterType)
     }
   }
 }
+
+object TermListTraverser extends TermListTraverserImpl(ArgumentListTraverser, TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermMatchTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermMatchTraverser.scala
@@ -6,16 +6,18 @@ import scala.meta.Term
 
 trait TermMatchTraverser extends ScalaTreeTraverser[Term.Match]
 
-object TermMatchTraverser extends TermMatchTraverser {
+private[scala2java] class TermMatchTraverserImpl(termTraverser: => TermTraverser) extends TermMatchTraverser {
 
   override def traverse(termMatch: Term.Match): Unit = {
     // TODO handle mods (what is this in a 'match'?...)
     emit("switch ")
     emit("(")
-    TermTraverser.traverse(termMatch.expr)
+    termTraverser.traverse(termMatch.expr)
     emit(")")
     emitBlockStart()
     termMatch.cases.foreach(CaseTraverser.traverse)
     emitBlockEnd()
   }
 }
+
+object TermMatchTraverser extends TermMatchTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermNameTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermNameTraverser.scala
@@ -4,7 +4,9 @@ import com.effiban.scala2java.JavaEmitter.emit
 
 import scala.meta.Term
 
-object TermNameTraverser extends ScalaTreeTraverser[Term.Name] {
+trait TermNameTraverser extends ScalaTreeTraverser[Term.Name]
+
+object TermNameTraverser extends TermNameTraverser {
 
   override def traverse(name: Term.Name): Unit = {
     emit(toJavaName(name))

--- a/src/main/scala/com/effiban/scala2java/TermParamListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermParamListTraverser.scala
@@ -2,11 +2,18 @@ package com.effiban.scala2java
 
 import scala.meta.Term
 
-object TermParamListTraverser {
+trait TermParamListTraverser {
+  def traverse(termParams: List[Term.Param]): Unit
+}
 
-  def traverse(termParams: List[Term.Param]): Unit = {
-      ArgumentListTraverser.traverse(args = termParams,
-        argTraverser = TermParamTraverser,
+private[scala2java] class TermParamListTraverserImpl(argumentListTraverser: => ArgumentListTraverser,
+                                                     termParamTraverser: => TermParamTraverser) extends TermParamListTraverser {
+
+  override def traverse(termParams: List[Term.Param]): Unit = {
+      argumentListTraverser.traverse(args = termParams,
+        argTraverser = termParamTraverser,
         maybeDelimiterType = Some(Parentheses))
   }
 }
+
+object TermParamListTraverser extends TermParamListTraverserImpl(ArgumentListTraverser, TermParamTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermRefTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermRefTraverser.scala
@@ -7,14 +7,26 @@ import scala.meta.Term.{ApplyUnary, Super, This}
 
 trait TermRefTraverser extends ScalaTreeTraverser[Term.Ref]
 
-object TermRefTraverser extends TermRefTraverser {
+private[scala2java] class TermRefTraverserImpl(thisTraverser: => ThisTraverser,
+                                               superTraverser: => SuperTraverser,
+                                               termNameTraverser: => TermNameTraverser,
+                                               termSelectTraverser: => TermSelectTraverser,
+                                               applyUnaryTraverser: => ApplyUnaryTraverser) extends TermRefTraverser {
 
   override def traverse(termRef: Term.Ref): Unit = termRef match {
-    case `this`: This => ThisTraverser.traverse(`this`)
-    case `super`: Super => SuperTraverser.traverse(`super`)
-    case termName: Term.Name => TermNameTraverser.traverse(termName)
-    case termSelect: Term.Select => TermSelectTraverser.traverse(termSelect)
-    case applyUnary: ApplyUnary => ApplyUnaryTraverser.traverse(applyUnary)
+    case `this`: This => thisTraverser.traverse(`this`)
+    case `super`: Super => superTraverser.traverse(`super`)
+    case termName: Term.Name => termNameTraverser.traverse(termName)
+    case termSelect: Term.Select => termSelectTraverser.traverse(termSelect)
+    case applyUnary: ApplyUnary => applyUnaryTraverser.traverse(applyUnary)
     case _ => emitComment(s"UNSUPPORTED: $termRef")
   }
 }
+
+object TermRefTraverser extends TermRefTraverserImpl(
+  ThisTraverser,
+  SuperTraverser,
+  TermNameTraverser,
+  TermSelectTraverser,
+  ApplyUnaryTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/TermRepeatedTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermRepeatedTraverser.scala
@@ -4,11 +4,13 @@ import scala.meta.Term
 
 trait TermRepeatedTraverser extends ScalaTreeTraverser[Term.Repeated]
 
-object TermRepeatedTraverser extends TermRepeatedTraverser {
+private[scala2java] class TermRepeatedTraverserImpl(termTraverser: => TermTraverser) extends TermRepeatedTraverser {
 
   // Passing vararg param
   override def traverse(termRepeated: Term.Repeated): Unit = {
     // TODO may need to transform to array in Java
-    TermTraverser.traverse(termRepeated.expr)
+    termTraverser.traverse(termRepeated.expr)
   }
 }
+
+object TermRepeatedTraverser extends TermRepeatedTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/TermSelectTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermSelectTraverser.scala
@@ -7,7 +7,9 @@ import scala.meta.Term.Select
 
 trait TermSelectTraverser extends ScalaTreeTraverser[Term.Select]
 
-object TermSelectTraverser extends TermSelectTraverser {
+private[scala2java] class TermSelectTraverserImpl(termTraverser: => TermTraverser,
+                                                  termNameTraverser: => TermNameTraverser,
+                                                  termRefTraverser: => TermRefTraverser) extends TermSelectTraverser {
 
   // qualified name
   override def traverse(termSelect: Term.Select): Unit = {
@@ -22,12 +24,18 @@ object TermSelectTraverser extends TermSelectTraverser {
 
     adjustedTermRef match {
       case select: Select =>
-        TermTraverser.traverse(select.qual)
+        termTraverser.traverse(select.qual)
         emit(".")
-        TermNameTraverser.traverse(select.name)
-      case name: Term.Name => TermNameTraverser.traverse(name)
-      case termRef: Term.Ref => TermRefTraverser.traverse(termRef)
+        termNameTraverser.traverse(select.name)
+      case name: Term.Name => termNameTraverser.traverse(name)
+      case termRef: Term.Ref => termRefTraverser.traverse(termRef)
     }
   }
 
 }
+
+object TermSelectTraverser extends TermSelectTraverserImpl(
+  TermTraverser,
+  TermNameTraverser,
+  TermRefTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/TermTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermTraverser.scala
@@ -7,39 +7,101 @@ import scala.meta.{Lit, Term}
 
 trait TermTraverser extends ScalaTreeTraverser[Term]
 
-object TermTraverser extends TermTraverser {
+private[scala2java] class TermTraverserImpl(termRefTraverser: => TermRefTraverser,
+                                            termApplyTraverser: => TermApplyTraverser,
+                                            applyTypeTraverser: => ApplyTypeTraverser,
+                                            termApplyInfixTraverser: => TermApplyInfixTraverser,
+                                            assignTraverser: => AssignTraverser,
+                                            returnTraverser: => ReturnTraverser,
+                                            throwTraverser: => ThrowTraverser,
+                                            ascribeTraverser: => AscribeTraverser,
+                                            termAnnotateTraverser: => TermAnnotateTraverser,
+                                            termTupleTraverser: => TermTupleTraverser,
+                                            blockTraverser: => BlockTraverser,
+                                            ifTraverser: => IfTraverser,
+                                            termMatchTraverser: => TermMatchTraverser,
+                                            tryTraverser: => TryTraverser,
+                                            tryWithHandlerTraverser: => TryWithHandlerTraverser,
+                                            termFunctionTraverser: => TermFunctionTraverser,
+                                            partialFunctionTraverser: => PartialFunctionTraverser,
+                                            anonymousFunctionTraverser: => AnonymousFunctionTraverser,
+                                            whileTraverser: => WhileTraverser,
+                                            doTraverser: => DoTraverser,
+                                            forTraverser: => ForTraverser,
+                                            forYieldTraverser: => ForYieldTraverser,
+                                            newTraverser: => NewTraverser,
+                                            newAnonymousTraverser: => NewAnonymousTraverser,
+                                            termPlaceholderTraverser: => TermPlaceholderTraverser,
+                                            etaTraverser: => EtaTraverser,
+                                            termRepeatedTraverser: => TermRepeatedTraverser,
+                                            termInterpolateTraverser: => TermInterpolateTraverser,
+                                            termXmlTraverser: => TermXmlTraverser,
+                                            litTraverser: => LitTraverser) extends TermTraverser {
 
   override def traverse(term: Term): Unit = term match {
-    case termRef: Term.Ref => TermRefTraverser.traverse(termRef)
-    case apply: Term.Apply => TermApplyTraverser.traverse(apply)
-    case applyType: ApplyType => ApplyTypeTraverser.traverse(applyType)
-    case applyInfix: Term.ApplyInfix => TermApplyInfixTraverser.traverse(applyInfix)
-    case assign: Assign => AssignTraverser.traverse(assign)
-    case `return`: Return => ReturnTraverser.traverse(`return`)
-    case `throw`: Throw => ThrowTraverser.traverse(`throw`)
-    case ascribe: Ascribe => AscribeTraverser.traverse(ascribe)
-    case annotate: Term.Annotate => TermAnnotateTraverser.traverse(annotate)
-    case tuple: Term.Tuple => TermTupleTraverser.traverse(tuple)
-    case block: Block => BlockTraverser.traverse(block)
-    case `if`: If => IfTraverser.traverse(`if`)
-    case `match`: Term.Match => TermMatchTraverser.traverse(`match`)
-    case `try`: Try => TryTraverser.traverse(`try`)
-    case tryWithHandler: TryWithHandler => TryWithHandlerTraverser.traverse(tryWithHandler)
-    case `function`: Term.Function => TermFunctionTraverser.traverse(`function`)
-    case partialFunction: Term.PartialFunction => PartialFunctionTraverser.traverse(partialFunction)
-    case anonFunction: AnonymousFunction => AnonymousFunctionTraverser.traverse(anonFunction)
-    case `while`: While => WhileTraverser.traverse(`while`)
-    case `do`: Do => DoTraverser.traverse(`do`)
-    case `for`: For => ForTraverser.traverse(`for`)
-    case forYield: ForYield => ForYieldTraverser.traverse(forYield)
-    case `new`: New => NewTraverser.traverse(`new`)
-    case newAnonymous: NewAnonymous => NewAnonymousTraverser.traverse(newAnonymous)
-    case termPlaceholder: Term.Placeholder => TermPlaceholderTraverser.traverse(termPlaceholder)
-    case eta: Eta => EtaTraverser.traverse(eta)
-    case termRepeated: Term.Repeated => TermRepeatedTraverser.traverse(termRepeated)
-    case interpolate: Term.Interpolate => TermInterpolateTraverser.traverse(interpolate)
-    case xml: Term.Xml => TermXmlTraverser.traverse(xml)
-    case literal: Lit => LitTraverser.traverse(literal)
+    case termRef: Term.Ref => termRefTraverser.traverse(termRef)
+    case apply: Term.Apply => termApplyTraverser.traverse(apply)
+    case applyType: ApplyType => applyTypeTraverser.traverse(applyType)
+    case applyInfix: Term.ApplyInfix => termApplyInfixTraverser.traverse(applyInfix)
+    case assign: Assign => assignTraverser.traverse(assign)
+    case `return`: Return => returnTraverser.traverse(`return`)
+    case `throw`: Throw => throwTraverser.traverse(`throw`)
+    case ascribe: Ascribe => ascribeTraverser.traverse(ascribe)
+    case annotate: Term.Annotate => termAnnotateTraverser.traverse(annotate)
+    case tuple: Term.Tuple => termTupleTraverser.traverse(tuple)
+    case block: Block => blockTraverser.traverse(block)
+    case `if`: If => ifTraverser.traverse(`if`)
+    case `match`: Term.Match => termMatchTraverser.traverse(`match`)
+    case `try`: Try => tryTraverser.traverse(`try`)
+    case tryWithHandler: TryWithHandler => tryWithHandlerTraverser.traverse(tryWithHandler)
+    case `function`: Term.Function => termFunctionTraverser.traverse(`function`)
+    case partialFunction: Term.PartialFunction => partialFunctionTraverser.traverse(partialFunction)
+    case anonFunction: AnonymousFunction => anonymousFunctionTraverser.traverse(anonFunction)
+    case `while`: While => whileTraverser.traverse(`while`)
+    case `do`: Do => doTraverser.traverse(`do`)
+    case `for`: For => forTraverser.traverse(`for`)
+    case forYield: ForYield => forYieldTraverser.traverse(forYield)
+    case `new`: New => newTraverser.traverse(`new`)
+    case newAnonymous: NewAnonymous => newAnonymousTraverser.traverse(newAnonymous)
+    case termPlaceholder: Term.Placeholder => termPlaceholderTraverser.traverse(termPlaceholder)
+    case eta: Eta => etaTraverser.traverse(eta)
+    case termRepeated: Term.Repeated => termRepeatedTraverser.traverse(termRepeated)
+    case interpolate: Term.Interpolate => termInterpolateTraverser.traverse(interpolate)
+    case xml: Term.Xml => termXmlTraverser.traverse(xml)
+    case literal: Lit => litTraverser.traverse(literal)
     case _ => emitComment(s"UNSUPPORTED: $term")
   }
 }
+
+object TermTraverser extends TermTraverserImpl(
+  TermRefTraverser,
+  TermApplyTraverser,
+  ApplyTypeTraverser,
+  TermApplyInfixTraverser,
+  AssignTraverser,
+  ReturnTraverser,
+  ThrowTraverser,
+  AscribeTraverser,
+  TermAnnotateTraverser,
+  TermTupleTraverser,
+  BlockTraverser,
+  IfTraverser,
+  TermMatchTraverser,
+  TryTraverser,
+  TryWithHandlerTraverser,
+  TermFunctionTraverser,
+  PartialFunctionTraverser,
+  AnonymousFunctionTraverser,
+  WhileTraverser,
+  DoTraverser,
+  ForTraverser,
+  ForYieldTraverser,
+  NewTraverser,
+  NewAnonymousTraverser,
+  TermPlaceholderTraverser,
+  EtaTraverser,
+  TermRepeatedTraverser,
+  TermInterpolateTraverser,
+  TermXmlTraverser,
+  LitTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/TermTupleTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TermTupleTraverser.scala
@@ -4,10 +4,12 @@ import scala.meta.Term
 
 trait TermTupleTraverser extends ScalaTreeTraverser[Term.Tuple]
 
-object TermTupleTraverser extends TermTupleTraverser {
+private[scala2java] class TermTupleTraverserImpl(termListTraverser: => TermListTraverser) extends TermTupleTraverser {
 
   // Java supports tuples only in lambdas AFAIK, but the replacement is not obvious - so rendering it always
   override def traverse(termTuple: Term.Tuple): Unit = {
-    TermListTraverser.traverse(termTuple.args, maybeDelimiterType = Some(Parentheses), onSameLine = true)
+    termListTraverser.traverse(termTuple.args, maybeDelimiterType = Some(Parentheses), onSameLine = true)
   }
 }
+
+object TermTupleTraverser extends TermTupleTraverserImpl(TermListTraverser)

--- a/src/main/scala/com/effiban/scala2java/ThisTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ThisTraverser.scala
@@ -7,12 +7,14 @@ import scala.meta.Term.This
 
 trait ThisTraverser extends ScalaTreeTraverser[This]
 
-object ThisTraverser extends ThisTraverser {
+private[scala2java] class ThisTraverserImpl(nameTraverser: => NameTraverser) extends ThisTraverser {
 
   override def traverse(`this`: This): Unit = {
     `this`.qual match {
       case Name.Anonymous() => emit("this")
-      case name => NameTraverser.traverse(name)
+      case name => nameTraverser.traverse(name)
     }
   }
 }
+
+object ThisTraverser extends ThisTraverserImpl(NameTraverser)

--- a/src/main/scala/com/effiban/scala2java/ThrowTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/ThrowTraverser.scala
@@ -6,11 +6,13 @@ import scala.meta.Term.Throw
 
 trait ThrowTraverser extends ScalaTreeTraverser[Throw]
 
-object ThrowTraverser extends ThrowTraverser {
+private[scala2java] class ThrowTraverserImpl(termTraverser: => TermTraverser) extends ThrowTraverser {
 
   override def traverse(`throw`: Throw): Unit = {
     emit("throw ")
-    TermTraverser.traverse(`throw`.expr)
+    termTraverser.traverse(`throw`.expr)
     emitStatementEnd()
   }
 }
+
+object ThrowTraverser extends ThrowTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/TraitTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TraitTraverser.scala
@@ -7,16 +7,20 @@ import scala.meta.Defn.Trait
 
 trait TraitTraverser extends ScalaTreeTraverser[Trait]
 
-object TraitTraverser extends TraitTraverser {
+private[scala2java] class TraitTraverserImpl(typeParamListTraverser: => TypeParamListTraverser,
+                                             templateTraverser: => TemplateTraverser,
+                                             javaModifiersResolver: JavaModifiersResolver) extends TraitTraverser {
 
   override def traverse(traitDef: Trait): Unit = {
-    emitTypeDeclaration(modifiers = JavaModifiersResolver.resolveForInterface(traitDef.mods),
+    emitTypeDeclaration(modifiers = javaModifiersResolver.resolveForInterface(traitDef.mods),
       typeKeyword = "interface",
       name = traitDef.name.toString)
-    TypeParamListTraverser.traverse(traitDef.tparams)
+    typeParamListTraverser.traverse(traitDef.tparams)
     val outerJavaOwnerContext = javaOwnerContext
     javaOwnerContext = Interface
-    TemplateTraverser.traverse(traitDef.templ)
+    templateTraverser.traverse(traitDef.templ)
     javaOwnerContext = outerJavaOwnerContext
   }
 }
+
+object TraitTraverser extends TraitTraverserImpl(TypeParamListTraverser, TemplateTraverser, JavaModifiersResolver)

--- a/src/main/scala/com/effiban/scala2java/TryTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TryTraverser.scala
@@ -6,31 +6,34 @@ import scala.meta.{Case, Term}
 
 trait TryTraverser extends ScalaTreeTraverser[Term.Try]
 
-object TryTraverser extends TryTraverser {
+private[scala2java] class TryTraverserImpl(termTraverser: => TermTraverser,
+                                           patTraverser: => PatTraverser) extends TryTraverser {
 
   override def traverse(`try`: Term.Try): Unit = {
     emit("try ")
-    TermTraverser.traverse(`try`.expr)
+    termTraverser.traverse(`try`.expr)
     `try`.catchp.foreach(traverseCatchClause)
     `try`.finallyp.foreach(finallyp => {
       emit("finally")
       emitBlockStart()
-      TermTraverser.traverse(finallyp)
+      termTraverser.traverse(finallyp)
       emitBlockEnd()
     })
   }
 
   private def traverseCatchClause(`case`: Case): Unit = {
     emit("catch (")
-    PatTraverser.traverse(`case`.pat)
+    patTraverser.traverse(`case`.pat)
     `case`.cond.foreach(cond => {
       emit(" && (")
-      TermTraverser.traverse(cond)
+      termTraverser.traverse(cond)
       emit(")")
     })
     emit(")")
     emitBlockStart()
-    TermTraverser.traverse(`case`.body)
+    termTraverser.traverse(`case`.body)
     emitBlockEnd()
   }
 }
+
+object TryTraverser extends TryTraverserImpl(TermTraverser, PatTraverser)

--- a/src/main/scala/com/effiban/scala2java/TryWithHandlerTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TryWithHandlerTraverser.scala
@@ -7,23 +7,25 @@ import scala.meta.Term.TryWithHandler
 
 trait TryWithHandlerTraverser extends ScalaTreeTraverser[TryWithHandler]
 
-object TryWithHandlerTraverser extends TryWithHandlerTraverser {
+private[scala2java] class TryWithHandlerTraverserImpl(termTraverser: => TermTraverser) extends TryWithHandlerTraverser {
 
   override def traverse(tryWithHandler: TryWithHandler): Unit = {
     emit("try ")
-    TermTraverser.traverse(tryWithHandler.expr)
+    termTraverser.traverse(tryWithHandler.expr)
     traverseCatchClause(tryWithHandler.catchp)
     tryWithHandler.finallyp.foreach(finallyp => {
       emit("finally")
       emitBlockStart()
-      TermTraverser.traverse(finallyp)
+      termTraverser.traverse(finallyp)
       emitBlockEnd()
     })
   }
 
   private def traverseCatchClause(handler: Term): Unit = {
     emit("catch (")
-    TermTraverser.traverse(handler)
+    termTraverser.traverse(handler)
     emit(")")
   }
 }
+
+object TryWithHandlerTraverser extends TryWithHandlerTraverserImpl(TermTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeAnnotateTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeAnnotateTraverser.scala
@@ -6,12 +6,15 @@ import scala.meta.Type
 
 trait TypeAnnotateTraverser extends ScalaTreeTraverser[Type.Annotate]
 
-object TypeAnnotateTraverser extends TypeAnnotateTraverser {
+private[scala2java] class TypeAnnotateTraverserImpl(annotListTraverser: => AnnotListTraverser,
+                                                    typeTraverser: => TypeTraverser) extends TypeAnnotateTraverser {
 
   // type with annotation, e.g.: T @annot
   override def traverse(annotatedType: Type.Annotate): Unit = {
-    AnnotListTraverser.traverseAnnotations(annotatedType.annots)
+    annotListTraverser.traverseAnnotations(annotatedType.annots)
     emit(" ")
-    TypeTraverser.traverse(annotatedType.tpe)
+    typeTraverser.traverse(annotatedType.tpe)
   }
 }
+
+object TypeAnnotateTraverser extends TypeAnnotateTraverserImpl(AnnotListTraverser, TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeApplyTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeApplyTraverser.scala
@@ -4,11 +4,14 @@ import scala.meta.Type
 
 trait TypeApplyTraverser extends ScalaTreeTraverser[Type.Apply]
 
-object TypeApplyTraverser extends TypeApplyTraverser {
+private[scala2java] class TypeApplyTraverserImpl(typeTraverser: => TypeTraverser,
+                                                 typeListTraverser: => TypeListTraverser) extends TypeApplyTraverser {
 
   // type definition with generic args, e.g. F[T]
   override def traverse(typeApply: Type.Apply): Unit = {
-    TypeTraverser.traverse(typeApply.tpe)
-    TypeListTraverser.traverse(typeApply.args)
+    typeTraverser.traverse(typeApply.tpe)
+    typeListTraverser.traverse(typeApply.args)
   }
 }
+
+object TypeApplyTraverser extends TypeApplyTraverserImpl(TypeTraverser, TypeListTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeBoundsTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeBoundsTraverser.scala
@@ -6,7 +6,7 @@ import scala.meta.Type
 
 trait TypeBoundsTraverser extends ScalaTreeTraverser[Type.Bounds]
 
-object TypeBoundsTraverser extends TypeBoundsTraverser {
+private[scala2java] class TypeBoundsTraverserImpl(typeTraverser: => TypeTraverser) extends TypeBoundsTraverser {
 
   // Scala type bounds e.g. X <: Y
   override def traverse(typeBounds: Type.Bounds): Unit = {
@@ -15,10 +15,10 @@ object TypeBoundsTraverser extends TypeBoundsTraverser {
     (typeBounds.lo, typeBounds.hi) match {
       case (Some(lo), None) =>
         emit(" super ")
-        TypeTraverser.traverse(lo)
+        typeTraverser.traverse(lo)
       case (None, Some(hi)) =>
         emit(" extends ")
-        TypeTraverser.traverse(hi)
+        typeTraverser.traverse(hi)
       case (None, None) =>
       case _ =>
         // Both bounds provided - we can only emit a comment
@@ -26,3 +26,5 @@ object TypeBoundsTraverser extends TypeBoundsTraverser {
     }
   }
 }
+
+object TypeBoundsTraverser extends TypeBoundsTraverserImpl(TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeByNameTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeByNameTraverser.scala
@@ -4,11 +4,13 @@ import scala.meta.Type
 
 trait TypeByNameTraverser extends ScalaTreeTraverser[Type.ByName]
 
-object TypeByNameTraverser extends TypeByNameTraverser {
+private[scala2java] class TypeByNameTraverserImpl(typeApplyTraverser: => TypeApplyTraverser) extends TypeByNameTraverser {
 
   // Type by name, e.g.: =>T in f(x: => T)
   override def traverse(typeByName: Type.ByName): Unit = {
     // The closest analogue in Java is Supplier
-    TypeApplyTraverser.traverse(Type.Apply(Type.Name("Supplier"), List(typeByName.tpe)))
+    typeApplyTraverser.traverse(Type.Apply(Type.Name("Supplier"), List(typeByName.tpe)))
   }
 }
+
+object TypeByNameTraverser extends TypeByNameTraverserImpl(TypeApplyTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeExistentialTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeExistentialTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Type
 
 trait TypeExistentialTraverser extends ScalaTreeTraverser[Type.Existential]
 
-object TypeExistentialTraverser extends TypeExistentialTraverser {
+private[scala2java] class TypeExistentialTraverserImpl(typeTraverser: => TypeTraverser) extends TypeExistentialTraverser {
 
   // type with existential constraint e.g.:  A[B] forSome {B <: Number with Serializable}
   override def traverse(existentialType: Type.Existential): Unit = {
-    TypeTraverser.traverse(existentialType.tpe)
+    typeTraverser.traverse(existentialType.tpe)
     // TODO - convert to Java for simple cases
     emitComment(existentialType.stats.toString())
   }
 }
+
+object TypeExistentialTraverser extends TypeExistentialTraverserImpl(TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeFunctionTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeFunctionTraverser.scala
@@ -4,11 +4,13 @@ import scala.meta.Type
 
 trait TypeFunctionTraverser extends ScalaTreeTraverser[Type.Function]
 
-object TypeFunctionTraverser extends TypeFunctionTraverser {
+private[scala2java] class TypeFunctionTraverserImpl(typeApplyTraverser: => TypeApplyTraverser) extends TypeFunctionTraverser {
 
   // function type, e.g.: Int => String
   override def traverse(functionType: Type.Function): Unit = {
     // TODO - handle more than one input param (in Java we can use BiFunction for 2, but more than that will have to be a comment)
-    TypeApplyTraverser.traverse(Type.Apply(Type.Name("Function"), functionType.params :+ functionType.res))
+    typeApplyTraverser.traverse(Type.Apply(Type.Name("Function"), functionType.params :+ functionType.res))
   }
 }
+
+object TypeFunctionTraverser extends TypeFunctionTraverserImpl(TypeApplyTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeListTraverser.scala
@@ -6,14 +6,17 @@ trait TypeListTraverser {
   def traverse(types: List[Type]): Unit
 }
 
-object TypeListTraverser extends TypeListTraverser {
+private[scala2java] class TypeListTraverserImpl(argumentListTraverser: => ArgumentListTraverser,
+                                                typeTraverser: => TypeTraverser) extends TypeListTraverser {
 
   override def traverse(types: List[Type]): Unit = {
     if (types.nonEmpty) {
-      ArgumentListTraverser.traverse(args = types,
-        argTraverser = TypeTraverser,
+      argumentListTraverser.traverse(args = types,
+        argTraverser = typeTraverser,
         maybeDelimiterType = Some(AngleBracket),
         onSameLine = true)
     }
   }
 }
+
+object TypeListTraverser extends TypeListTraverserImpl(ArgumentListTraverser, TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeParamListTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeParamListTraverser.scala
@@ -6,14 +6,17 @@ trait TypeParamListTraverser {
   def traverse(typeParams: List[Type.Param]): Unit
 }
 
-object TypeParamListTraverser extends TypeParamListTraverser {
+private[scala2java] class TypeParamListTraverserImpl(argumentListTraverser: => ArgumentListTraverser,
+                                                     typeParamTraverser: => TypeParamTraverser) extends TypeParamListTraverser {
 
   override def traverse(typeParams: List[Type.Param]): Unit = {
     if (typeParams.nonEmpty) {
-      ArgumentListTraverser.traverse(args = typeParams,
-        argTraverser = TypeParamTraverser,
+      argumentListTraverser.traverse(args = typeParams,
+        argTraverser = typeParamTraverser,
         maybeDelimiterType = Some(AngleBracket),
         onSameLine = true)
     }
   }
 }
+
+object TypeParamListTraverser extends TypeParamListTraverserImpl(ArgumentListTraverser, TypeParamTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeParamTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeParamTraverser.scala
@@ -4,14 +4,18 @@ import scala.meta.Type
 
 trait TypeParamTraverser extends ScalaTreeTraverser[Type.Param]
 
-object TypeParamTraverser extends TypeParamTraverser {
+private[scala2java] class TypeParamTraverserImpl(nameTraverser: => NameTraverser,
+                                                 typeParamListTraverser: => TypeParamListTraverser,
+                                                 typeBoundsTraverser: => TypeBoundsTraverser) extends TypeParamTraverser {
 
   // Type param declaration, e.g.: `T` in trait MyTrait[T]
   override def traverse(typeParam: Type.Param): Unit = {
     // TODO handle mods
-    NameTraverser.traverse(typeParam.name)
-    TypeParamListTraverser.traverse(typeParam.tparams)
-    TypeBoundsTraverser.traverse(typeParam.tbounds)
+    nameTraverser.traverse(typeParam.name)
+    typeParamListTraverser.traverse(typeParam.tparams)
+    typeBoundsTraverser.traverse(typeParam.tbounds)
     // TODO handle vbounds and cbounds (which aren't supported in Java, maybe partially ?)
   }
 }
+
+object TypeParamTraverser extends TypeParamTraverserImpl(NameTraverser, TypeParamListTraverser, TypeBoundsTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypePlaceholderTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypePlaceholderTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Type
 
 trait TypePlaceholderTraverser extends ScalaTreeTraverser[Type.Placeholder]
 
-object TypePlaceholderTraverser extends TypePlaceholderTraverser {
+private[scala2java] class TypePlaceholderTraverserImpl(typeBoundsTraverser: => TypeBoundsTraverser) extends TypePlaceholderTraverser {
 
   // Underscore in type param, e.g. T[_]
   override def traverse(placeholderType: Type.Placeholder): Unit = {
     emit("? ")
-    TypeBoundsTraverser.traverse(placeholderType.bounds)
+    typeBoundsTraverser.traverse(placeholderType.bounds)
   }
 
 }
+
+object TypePlaceholderTraverser extends TypePlaceholderTraverserImpl(TypeBoundsTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeProjectTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeProjectTraverser.scala
@@ -6,12 +6,15 @@ import scala.meta.Type
 
 trait TypeProjectTraverser extends ScalaTreeTraverser[Type.Project]
 
-object TypeProjectTraverser extends TypeProjectTraverser {
+private[scala2java] class TypeProjectTraverserImpl(typeTraverser: => TypeTraverser,
+                                                   typeNameTraverser: => TypeNameTraverser) extends TypeProjectTraverser {
 
   // A scala type projecting expression like: a#B
   override def traverse(typeProject: Type.Project): Unit = {
-    TypeTraverser.traverse(typeProject.qual)
+    typeTraverser.traverse(typeProject.qual)
     emit(".")
-    TypeNameTraverser.traverse(typeProject.name)
+    typeNameTraverser.traverse(typeProject.name)
   }
 }
+
+object TypeProjectTraverser extends TypeProjectTraverserImpl(TypeTraverser, TypeNameTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeRefTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeRefTraverser.scala
@@ -6,13 +6,23 @@ import scala.meta.Type
 
 trait TypeRefTraverser extends ScalaTreeTraverser[Type.Ref]
 
-object TypeRefTraverser extends TypeRefTraverser {
+private[scala2java] class TypeRefTraverserImpl(typeNameTraverser: => TypeNameTraverser,
+                                               typeSelectTraverser: => TypeSelectTraverser,
+                                               typeProjectTraverser: => TypeProjectTraverser,
+                                               typeSingletonTraverser: => TypeSingletonTraverser) extends TypeRefTraverser {
 
   override def traverse(typeRef: Type.Ref): Unit = typeRef match {
-    case typeName: Type.Name => TypeNameTraverser.traverse(typeName)
-    case typeSelect: Type.Select => TypeSelectTraverser.traverse(typeSelect)
-    case typeProject: Type.Project => TypeProjectTraverser.traverse(typeProject)
-    case typeSingleton: Type.Singleton => TypeSingletonTraverser.traverse(typeSingleton)
+    case typeName: Type.Name => typeNameTraverser.traverse(typeName)
+    case typeSelect: Type.Select => typeSelectTraverser.traverse(typeSelect)
+    case typeProject: Type.Project => typeProjectTraverser.traverse(typeProject)
+    case typeSingleton: Type.Singleton => typeSingletonTraverser.traverse(typeSingleton)
     case _ => emitComment(s"UNSUPPORTED: $typeRef")
   }
 }
+
+object TypeRefTraverser extends TypeRefTraverserImpl(
+  TypeNameTraverser,
+  TypeSelectTraverser,
+  TypeProjectTraverser,
+  TypeSingletonTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/TypeRefineTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeRefineTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Type
 
 trait TypeRefineTraverser extends ScalaTreeTraverser[Type.Refine]
 
-object TypeRefineTraverser extends TypeRefineTraverser {
+private[scala2java] class TypeRefineTraverserImpl(typeTraverser: => TypeTraverser) extends TypeRefineTraverser {
 
   // A {def f: Int }
   override def traverse(refinedType: Type.Refine): Unit = {
-    refinedType.tpe.foreach(TypeTraverser.traverse)
+    refinedType.tpe.foreach(typeTraverser.traverse)
     // TODO maybe convert to Java type with inheritance
     emitComment(s" ${refinedType.stats.toString()}")
   }
 }
+
+object TypeRefineTraverser extends TypeRefineTraverserImpl(TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeRepeatedTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeRepeatedTraverser.scala
@@ -6,11 +6,13 @@ import scala.meta.Type
 
 trait TypeRepeatedTraverser extends ScalaTreeTraverser[Type.Repeated]
 
-object TypeRepeatedTraverser extends TypeRepeatedTraverser {
+private[scala2java] class TypeRepeatedTraverserImpl(typeTraverser: => TypeTraverser) extends TypeRepeatedTraverser {
 
   // Vararg type,e.g.: T*
   override def traverse(repeatedType: Type.Repeated): Unit = {
-    TypeTraverser.traverse(repeatedType.tpe)
+    typeTraverser.traverse(repeatedType.tpe)
     emitEllipsis()
   }
 }
+
+object TypeRepeatedTraverser extends TypeRepeatedTraverserImpl(TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeSelectTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeSelectTraverser.scala
@@ -6,12 +6,15 @@ import scala.meta.Type
 
 trait TypeSelectTraverser extends ScalaTreeTraverser[Type.Select]
 
-object TypeSelectTraverser extends TypeSelectTraverser {
+private[scala2java] class TypeSelectTraverserImpl(termRefTraverser: => TermRefTraverser,
+                                                  typeNameTraverser: => TypeNameTraverser) extends TypeSelectTraverser {
 
   // A scala type selecting expression like: a.B
   override def traverse(typeSelect: Type.Select): Unit = {
-    TermRefTraverser.traverse(typeSelect.qual)
+    termRefTraverser.traverse(typeSelect.qual)
     emit(".")
-    TypeNameTraverser.traverse(typeSelect.name)
+    typeNameTraverser.traverse(typeSelect.name)
   }
 }
+
+object TypeSelectTraverser extends TypeSelectTraverserImpl(TermRefTraverser, TypeNameTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeSingletonTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeSingletonTraverser.scala
@@ -4,11 +4,13 @@ import scala.meta.Type
 
 trait TypeSingletonTraverser extends ScalaTreeTraverser[Type.Singleton]
 
-object TypeSingletonTraverser extends TypeSingletonTraverser {
+private[scala2java] class TypeSingletonTraverserImpl(termRefTraverser: => TermRefTraverser) extends TypeSingletonTraverser {
 
   // A scala expression representing a singleton type like: A.type
   override def traverse(singletonType: Type.Singleton): Unit = {
-    TermRefTraverser.traverse(singletonType.ref)
+    termRefTraverser.traverse(singletonType.ref)
     // TODO not sure if something else is needed in Java...
   }
 }
+
+object TypeSingletonTraverser extends TypeSingletonTraverserImpl(TermRefTraverser)

--- a/src/main/scala/com/effiban/scala2java/TypeTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeTraverser.scala
@@ -6,23 +6,53 @@ import scala.meta.Type
 
 trait TypeTraverser extends ScalaTreeTraverser[Type]
 
-object TypeTraverser extends TypeTraverser {
+private[scala2java] class TypeTraverserImpl(typeRefTraverser: => TypeRefTraverser,
+                                            typeApplyTraverser: => TypeApplyTraverser,
+                                            typeApplyInfixTraverser: => TypeApplyInfixTraverser,
+                                            typeFunctionTraverser: => TypeFunctionTraverser,
+                                            typeTupleTraverser: => TypeTupleTraverser,
+                                            typeWithTraverser: => TypeWithTraverser,
+                                            typeRefineTraverser: => TypeRefineTraverser,
+                                            typeExistentialTraverser: => TypeExistentialTraverser,
+                                            typeAnnotateTraverser: => TypeAnnotateTraverser,
+                                            typeLambdaTraverser: => TypeLambdaTraverser,
+                                            typePlaceholderTraverser: => TypePlaceholderTraverser,
+                                            typeByNameTraverser: => TypeByNameTraverser,
+                                            typeRepeatedTraverser: => TypeRepeatedTraverser,
+                                            typeVarTraverser: => TypeVarTraverser) extends TypeTraverser {
 
   override def traverse(`type`: Type): Unit = `type` match {
-    case typeRef: Type.Ref => TypeRefTraverser.traverse(typeRef)
-    case typeApply: Type.Apply => TypeApplyTraverser.traverse(typeApply)
-    case typeApplyInfix: Type.ApplyInfix => TypeApplyInfixTraverser.traverse(typeApplyInfix)
-    case functionType: Type.Function => TypeFunctionTraverser.traverse(functionType)
-    case tupleType: Type.Tuple => TypeTupleTraverser.traverse(tupleType)
-    case withType: Type.With => TypeWithTraverser.traverse(withType)
-    case typeRefine: Type.Refine => TypeRefineTraverser.traverse(typeRefine)
-    case existentialType: Type.Existential => TypeExistentialTraverser.traverse(existentialType)
-    case typeAnnotation: Type.Annotate => TypeAnnotateTraverser.traverse(typeAnnotation)
-    case lambdaType: Type.Lambda => TypeLambdaTraverser.traverse(lambdaType)
-    case placeholderType: Type.Placeholder => TypePlaceholderTraverser.traverse(placeholderType)
-    case byNameType: Type.ByName => TypeByNameTraverser.traverse(byNameType)
-    case repeatedType: Type.Repeated => TypeRepeatedTraverser.traverse(repeatedType)
-    case typeVar: Type.Var => TypeVarTraverser.traverse(typeVar)
+    case typeRef: Type.Ref => typeRefTraverser.traverse(typeRef)
+    case typeApply: Type.Apply => typeApplyTraverser.traverse(typeApply)
+    case typeApplyInfix: Type.ApplyInfix => typeApplyInfixTraverser.traverse(typeApplyInfix)
+    case functionType: Type.Function => typeFunctionTraverser.traverse(functionType)
+    case tupleType: Type.Tuple => typeTupleTraverser.traverse(tupleType)
+    case withType: Type.With => typeWithTraverser.traverse(withType)
+    case typeRefine: Type.Refine => typeRefineTraverser.traverse(typeRefine)
+    case existentialType: Type.Existential => typeExistentialTraverser.traverse(existentialType)
+    case typeAnnotation: Type.Annotate => typeAnnotateTraverser.traverse(typeAnnotation)
+    case lambdaType: Type.Lambda => typeLambdaTraverser.traverse(lambdaType)
+    case placeholderType: Type.Placeholder => typePlaceholderTraverser.traverse(placeholderType)
+    case byNameType: Type.ByName => typeByNameTraverser.traverse(byNameType)
+    case repeatedType: Type.Repeated => typeRepeatedTraverser.traverse(repeatedType)
+    case typeVar: Type.Var => typeVarTraverser.traverse(typeVar)
     case _ => emitComment(s"UNSUPPORTED: ${`type`}")
   }
 }
+
+object TypeTraverser extends TypeTraverserImpl(
+  TypeRefTraverser,
+  TypeApplyTraverser,
+  TypeApplyInfixTraverser,
+  TypeFunctionTraverser,
+  TypeTupleTraverser,
+  TypeWithTraverser,
+  TypeRefineTraverser,
+  TypeExistentialTraverser,
+  TypeAnnotateTraverser,
+  TypeLambdaTraverser,
+  TypePlaceholderTraverser,
+  TypeByNameTraverser,
+  TypeRepeatedTraverser,
+  TypeVarTraverser
+)

--- a/src/main/scala/com/effiban/scala2java/TypeWithTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/TypeWithTraverser.scala
@@ -6,13 +6,15 @@ import scala.meta.Type
 
 trait TypeWithTraverser extends ScalaTreeTraverser[Type.With]
 
-object TypeWithTraverser extends TypeWithTraverser {
+private[scala2java] class TypeWithTraverserImpl(typeTraverser: => TypeTraverser) extends TypeWithTraverser {
 
   // type with parent, e.g.  A with B
   // approximated by Java "extends" but might not compile
   override def traverse(typeWith: Type.With): Unit = {
-    TypeTraverser.traverse(typeWith.lhs)
+    typeTraverser.traverse(typeWith.lhs)
     emit(" extends ")
-    TypeTraverser.traverse(typeWith.rhs)
+    typeTraverser.traverse(typeWith.rhs)
   }
 }
+
+object TypeWithTraverser extends TypeWithTraverserImpl(TypeTraverser)

--- a/src/main/scala/com/effiban/scala2java/WhileTraverser.scala
+++ b/src/main/scala/com/effiban/scala2java/WhileTraverser.scala
@@ -6,12 +6,14 @@ import scala.meta.Term.While
 
 trait WhileTraverser extends ScalaTreeTraverser[While]
 
-object WhileTraverser extends WhileTraverser {
+private[scala2java] class WhileTraverserImpl(termTraverser: => TermTraverser) extends WhileTraverser {
 
   override def traverse(`while`: While): Unit = {
     emit("while (")
-    TermTraverser.traverse(`while`.expr)
+    termTraverser.traverse(`while`.expr)
     emit(") ")
-    TermTraverser.traverse(`while`.body)
+    termTraverser.traverse(`while`.body)
   }
 }
+
+object WhileTraverser extends WhileTraverserImpl(TermTraverser)


### PR DESCRIPTION
NOTE: Due to the circular dependencies between traversers, they must all be passed "by-name" to the constructors