### PR TITLE
Extract traverser objects to inner objects of a new class

### DIFF
--- a/src/main/scala/effiban/scala2java/Scala2JavaRunner.scala
+++ b/src/main/scala/effiban/scala2java/Scala2JavaRunner.scala
@@ -1,6 +1,7 @@
 package effiban.scala2java
 
-import effiban.scala2java.traversers.SourceTraverser
+import effiban.scala2java.traversers.ScalaTreeTraversers
+import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Source
 import scala.meta.inputs.Input
@@ -19,7 +20,10 @@ object Scala2JavaRunner {
       input.parse[Source].get
     })
 
-    sourceTrees.foreach(SourceTraverser.traverse)
+    implicit val javaWriter: JavaWriter = JavaWriter
+    val traversers = new ScalaTreeTraversers
+
+    sourceTrees.foreach(traversers.SourceTraverser.traverse)
   }
 }
 

--- a/src/main/scala/effiban/scala2java/traversers/AlternativeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/AlternativeTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class AlternativeTraverserImpl(patTraverser: => PatTraverser
     patTraverser.traverse(patternAlternative.rhs)
   }
 }
-
-object AlternativeTraverser extends AlternativeTraverserImpl(PatTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/AnnotListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/AnnotListTraverser.scala
@@ -33,5 +33,3 @@ private[traversers] class AnnotListTraverserImpl(annotTraverser: => AnnotTravers
 
 }
 
-object AnnotListTraverser extends AnnotListTraverserImpl(AnnotTraverser)
-

--- a/src/main/scala/effiban/scala2java/traversers/AnnotTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/AnnotTraverser.scala
@@ -15,5 +15,3 @@ private[traversers] class AnnotTraverserImpl(initTraverser: => InitTraverser)
     initTraverser.traverse(annotation.init)
   }
 }
-
-object AnnotTraverser extends AnnotTraverserImpl(InitTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/AnonymousFunctionTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/AnonymousFunctionTraverser.scala
@@ -15,5 +15,3 @@ private[traversers] class AnonymousFunctionTraverserImpl(termFunctionTraverser: 
       body = anonymousFunction.body))
   }
 }
-
-object AnonymousFunctionTraverser extends AnonymousFunctionTraverserImpl(TermFunctionTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ApplyTypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ApplyTypeTraverser.scala
@@ -33,5 +33,3 @@ private[traversers] class ApplyTypeTraverserImpl(typeTraverser: => TypeTraverser
     }
   }
 }
-
-object ApplyTypeTraverser extends ApplyTypeTraverserImpl(TypeTraverser, TermTraverser, TypeListTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ApplyUnaryTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ApplyUnaryTraverser.scala
@@ -15,5 +15,3 @@ private[traversers] class ApplyUnaryTraverserImpl(termNameTraverser: => TermName
     termTraverser.traverse(applyUnary.arg)
   }
 }
-
-object ApplyUnaryTraverser extends ApplyUnaryTraverserImpl(TermNameTraverser, TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ArgumentListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ArgumentListTraverser.scala
@@ -40,5 +40,3 @@ class ArgumentListTraverserImpl(implicit javaWriter: JavaWriter) extends Argumen
     }
   }
 }
-
-object ArgumentListTraverser extends ArgumentListTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/AscribeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/AscribeTraverser.scala
@@ -22,5 +22,3 @@ private[traversers] class AscribeTraverserImpl(typeTraverser: => TypeTraverser,
     termTraverser.traverse(ascribe.expr)
   }
 }
-
-object AscribeTraverser extends AscribeTraverserImpl(TypeTraverser, TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/AssignTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/AssignTraverser.scala
@@ -18,5 +18,3 @@ private[traversers] class AssignTraverserImpl(termTraverser: => TermTraverser)
     termTraverser.traverse(assign.rhs)
   }
 }
-
-object AssignTraverser extends AssignTraverserImpl(TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/BindTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/BindTraverser.scala
@@ -18,5 +18,3 @@ private[traversers] class BindTraverserImpl(patTraverser: => PatTraverser)
     writeComment(patternBind.toString())
   }
 }
-
-object BindTraverser extends BindTraverserImpl(PatTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/BlockTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/BlockTraverser.scala
@@ -51,11 +51,3 @@ private[traversers] class BlockTraverserImpl(initTraverser: => InitTraverser,
     }
   }
 }
-
-object BlockTraverser extends BlockTraverserImpl(
-  InitTraverser,
-  IfTraverser,
-  WhileTraverser,
-  ReturnTraverser,
-  StatTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/CaseClassTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CaseClassTraverser.scala
@@ -32,11 +32,3 @@ private[traversers] class CaseClassTraverserImpl(annotListTraverser: => AnnotLis
     javaScope = outerJavaScope
   }
 }
-
-object CaseClassTraverser extends CaseClassTraverserImpl(
-  AnnotListTraverser,
-  TypeParamListTraverser,
-  TermParamListTraverser,
-  TemplateTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/CaseTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CaseTraverser.scala
@@ -27,5 +27,3 @@ private[traversers] class CaseTraverserImpl(patTraverser: => PatTraverser,
     writeStatementEnd()
   }
 }
-
-object CaseTraverser extends CaseTraverserImpl(PatTraverser, TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/CatchHandlerTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CatchHandlerTraverser.scala
@@ -25,5 +25,3 @@ private[traversers] class CatchHandlerTraverserImpl(termParamListTraverser: => T
     }
   }
 }
-
-object CatchHandlerTraverser extends CatchHandlerTraverserImpl(TermParamListTraverser, BlockTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ClassTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ClassTraverser.scala
@@ -15,5 +15,3 @@ private[traversers] class ClassTraverserImpl(caseClassTraverser: => CaseClassTra
     }
   }
 }
-
-object ClassTraverser extends ClassTraverserImpl(CaseClassTraverser, RegularClassTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/CtorPrimaryTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CtorPrimaryTraverser.scala
@@ -8,13 +8,11 @@ trait CtorPrimaryTraverser {
   def traverse(primaryCtor: Ctor.Primary, className: Type.Name, inits: List[Init]): Unit
 }
 
-private[traversers] class CtorPrimaryStatTraverserImpl(ctorPrimaryStatTransformer: CtorPrimaryTransformer,
-                                                       defnDefTraverser: DefnDefTraverser) extends CtorPrimaryTraverser {
+private[traversers] class CtorPrimaryTraverserImpl(ctorPrimaryTransformer: CtorPrimaryTransformer,
+                                                   defnDefTraverser: DefnDefTraverser) extends CtorPrimaryTraverser {
 
   override def traverse(primaryCtor: Ctor.Primary, className: Type.Name, inits: List[Init]): Unit = {
-    val defnDef = ctorPrimaryStatTransformer.transform(primaryCtor, className, inits)
+    val defnDef = ctorPrimaryTransformer.transform(primaryCtor, className, inits)
     defnDefTraverser.traverse(defnDef)
   }
 }
-
-object CtorPrimaryTraverser extends CtorPrimaryStatTraverserImpl(CtorPrimaryTransformer, DefnDefTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/CtorSecondaryTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CtorSecondaryTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class CtorSecondaryTraverserImpl(ctorSecondaryTransformer: C
     defnDefTraverser.traverse(defnDef, Some(secondaryCtor.init))
   }
 }
-
-object CtorSecondaryTraverser extends CtorSecondaryTraverserImpl(CtorSecondaryTransformer, DefnDefTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/DeclDefTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclDefTraverser.scala
@@ -39,11 +39,3 @@ private[traversers] class DeclDefTraverserImpl(annotListTraverser: => AnnotListT
     javaScope = outerJavaScope
   }
 }
-
-object DeclDefTraverser extends DeclDefTraverserImpl(
-  AnnotListTraverser,
-  TypeTraverser,
-  TermNameTraverser,
-  TermParamListTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/DeclTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclTraverser.scala
@@ -21,8 +21,3 @@ private[traversers] class DeclTraverserImpl(declValTraverser: => DeclValTraverse
     case _ => writeComment(s"UNSUPPORTED: $decl")
   }
 }
-
-object DeclTraverser extends DeclTraverserImpl(DeclValTraverser,
-  DeclVarTraverser,
-  DeclDefTraverser,
-  DeclTypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/DeclTypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclTypeTraverser.scala
@@ -26,5 +26,3 @@ private[traversers] class DeclTypeTraverserImpl(typeParamListTraverser: => TypeP
     writeBlockEnd()
   }
 }
-
-object DeclTypeTraverser extends DeclTypeTraverserImpl(TypeParamListTraverser, JavaModifiersResolver)

--- a/src/main/scala/effiban/scala2java/traversers/DeclValTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclValTraverser.scala
@@ -38,10 +38,3 @@ private[traversers] class DeclValTraverserImpl(annotListTraverser: => AnnotListT
     patListTraverser.traverse(valDecl.pats)
   }
 }
-
-object DeclValTraverser extends DeclValTraverserImpl(
-  AnnotListTraverser,
-  TypeTraverser,
-  PatListTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/DeclVarTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclVarTraverser.scala
@@ -31,10 +31,3 @@ private[traversers] class DeclVarTraverserImpl(annotListTraverser: => AnnotListT
     patListTraverser.traverse(varDecl.pats)
   }
 }
-
-object DeclVarTraverser extends DeclVarTraverserImpl(
-  AnnotListTraverser,
-  TypeTraverser,
-  PatListTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/DefnDefTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnDefTraverser.scala
@@ -70,12 +70,3 @@ private[traversers] class DefnDefTraverserImpl(annotListTraverser: => AnnotListT
         maybeInit = maybeInit)
   }
 }
-
-object DefnDefTraverser extends DefnDefTraverserImpl(
-  AnnotListTraverser,
-  TermNameTraverser,
-  TypeTraverser,
-  TermParamListTraverser,
-  BlockTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/DefnTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnTraverser.scala
@@ -28,13 +28,3 @@ private[traversers] class DefnTraverserImpl(defnValTraverser: => DefnValTraverse
     case _ => writeComment(s"UNSUPPORTED: $defn")
   }
 }
-
-object DefnTraverser extends DefnTraverserImpl(
-  DefnValTraverser,
-  DefnVarTraverser,
-  DefnDefTraverser,
-  DefnTypeTraverser,
-  ClassTraverser,
-  TraitTraverser,
-  ObjectTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/DefnTypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnTypeTraverser.scala
@@ -40,8 +40,3 @@ private[traversers] class DefnTypeTraverserImpl(typeParamListTraverser: => TypeP
     writeBlockEnd()
   }
 }
-
-object DefnTypeTraverser extends DefnTypeTraverserImpl(
-  TypeParamListTraverser,
-  TypeTraverser,
-  JavaModifiersResolver)

--- a/src/main/scala/effiban/scala2java/traversers/DefnValTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnValTraverser.scala
@@ -49,12 +49,3 @@ private[traversers] class DefnValTraverserImpl(annotListTraverser: => AnnotListT
     termTraverser.traverse(valDef.rhs)
   }
 }
-
-object DefnValTraverser extends DefnValTraverserImpl(
-  AnnotListTraverser,
-  TypeTraverser,
-  PatListTraverser,
-  TermTraverser,
-  JavaModifiersResolver
-)
-

--- a/src/main/scala/effiban/scala2java/traversers/DefnVarTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnVarTraverser.scala
@@ -46,10 +46,3 @@ private[traversers] class DefnVarTraverserImpl(annotListTraverser: => AnnotListT
     }
   }
 }
-
-object DefnVarTraverser extends DefnVarTraverserImpl(AnnotListTraverser,
-  TypeTraverser,
-  PatListTraverser,
-  TermTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/DoTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DoTraverser.scala
@@ -23,5 +23,3 @@ private[traversers] class DoTraverserImpl(termTraverser: => TermTraverser,
     write(")")
   }
 }
-
-object DoTraverser extends DoTraverserImpl(TermTraverser, BlockTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/EtaTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/EtaTraverser.scala
@@ -21,5 +21,3 @@ private[traversers] class EtaTraverserImpl(termTraverser: => TermTraverser)
     termTraverser.traverse(eta.expr)
   }
 }
-
-object EtaTraverser extends EtaTraverserImpl(TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/FinallyTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/FinallyTraverser.scala
@@ -21,5 +21,3 @@ private[traversers] class FinallyTraverserImpl(blockTraverser: => BlockTraverser
     }
   }
 }
-
-object FinallyTraverser extends FinallyTraverserImpl(BlockTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ForTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ForTraverser.scala
@@ -5,11 +5,9 @@ import scala.meta.Term.For
 
 trait ForTraverser extends ScalaTreeTraverser[For]
 
-private[traversers] class ForTraverserImpl(forVariantsTraverser: => ForVariantTraverser) extends ForTraverser {
+private[traversers] class ForTraverserImpl(forVariantTraverser: => ForVariantTraverser) extends ForTraverser {
 
   override def traverse(`for`: For): Unit = {
-    forVariantsTraverser.traverse(`for`.enums, `for`.body, Term.Name("forEach"))
+    forVariantTraverser.traverse(`for`.enums, `for`.body, Term.Name("forEach"))
   }
 }
-
-object ForTraverser extends ForTraverserImpl(ForVariantTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ForVariantTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ForVariantTraverser.scala
@@ -64,5 +64,3 @@ private[traversers] class ForVariantTraverserImpl(termTraverser: => TermTraverse
     Param(mods = List.empty, name = Term.Name(name), decltpe = None, default = None)
   }
 }
-
-object ForVariantTraverser extends ForVariantTraverserImpl(TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ForYieldTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ForYieldTraverser.scala
@@ -5,11 +5,9 @@ import scala.meta.Term.ForYield
 
 trait ForYieldTraverser extends ScalaTreeTraverser[ForYield]
 
-private[traversers] class ForYieldTraverserImpl(forVariantsTraverser: => ForVariantTraverser) extends ForYieldTraverser {
+private[traversers] class ForYieldTraverserImpl(forVariantTraverser: => ForVariantTraverser) extends ForYieldTraverser {
 
   override def traverse(forYield: ForYield): Unit = {
-    forVariantsTraverser.traverse(forYield.enums, forYield.body, Term.Name("map"))
+    forVariantTraverser.traverse(forYield.enums, forYield.body, Term.Name("map"))
   }
 }
-
-object ForYieldTraverser extends ForYieldTraverserImpl(ForVariantTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/IfTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/IfTraverser.scala
@@ -36,5 +36,3 @@ private[traversers] class IfTraverserImpl(termTraverser: => TermTraverser,
     }
   }
 }
-
-object IfTraverser extends IfTraverserImpl(TermTraverser, BlockTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ImportTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ImportTraverser.scala
@@ -18,5 +18,3 @@ private[traversers] class ImportTraverserImpl(importerTraverser: => ImporterTrav
     }
   }
 }
-
-object ImportTraverser extends ImportTraverserImpl(ImporterTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ImporteeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ImporteeTraverser.scala
@@ -27,5 +27,3 @@ private[traversers] class ImporteeTraverserImpl(nameTraverser: => NameTraverser)
     }
   }
 }
-
-object ImporteeTraverser extends ImporteeTraverserImpl(NameTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ImporterTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ImporterTraverser.scala
@@ -29,5 +29,3 @@ private[traversers] class ImporterTraverserImpl(termRefTraverser: => TermRefTrav
     }
   }
 }
-
-object ImporterTraverser extends ImporterTraverserImpl(TermRefTraverser, ImporteeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/InitListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/InitListTraverser.scala
@@ -15,5 +15,3 @@ private[traversers] class InitListTraverserImpl(argumentListTraverser: => Argume
     }
   }
 }
-
-object InitListTraverser extends InitListTraverserImpl(ArgumentListTraverser, InitTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/InitTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/InitTraverser.scala
@@ -23,5 +23,3 @@ private[traversers] class InitTraverserImpl(typeTraverser: => TypeTraverser,
     }
   }
 }
-
-object InitTraverser extends InitTraverserImpl(TypeTraverser, TermListTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/LitTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/LitTraverser.scala
@@ -34,5 +34,3 @@ class LitTraverserImpl(implicit javaWriter: JavaWriter) extends LitTraverser {
 
   private def quoteString(str: String) = s"\"$str\""
 }
-
-object LitTraverser extends LitTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/NameIndeterminateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/NameIndeterminateTraverser.scala
@@ -16,5 +16,3 @@ class NameIndeterminateTraverserImpl(implicit javaWriter: JavaWriter) extends Na
     write(indeterminateName.value)
   }
 }
-
-object NameIndeterminateTraverser extends NameIndeterminateTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/NameTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/NameTraverser.scala
@@ -22,10 +22,3 @@ private[traversers] class NameTraverserImpl(nameAnonymousTraverser: => NameAnony
   }
 
 }
-
-object NameTraverser extends NameTraverserImpl(
-  NameAnonymousTraverser,
-  NameIndeterminateTraverser,
-  TermNameTraverser,
-  TypeNameTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/NewAnonymousTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/NewAnonymousTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class NewAnonymousTraverserImpl(templateTraverser: => Templa
     templateTraverser.traverse(newAnonymous.templ)
   }
 }
-
-object NewAnonymousTraverser extends NewAnonymousTraverserImpl(TemplateTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/NewTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/NewTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class NewTraverserImpl(initTraverser: => InitTraverser)
     initTraverser.traverse(`new`.init)
   }
 }
-
-object NewTraverser extends NewTraverserImpl(InitTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ObjectTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ObjectTraverser.scala
@@ -31,8 +31,3 @@ private[traversers] class ObjectTraverserImpl(annotListTraverser: => AnnotListTr
   }
 }
 
-object ObjectTraverser extends ObjectTraverserImpl(
-  AnnotListTraverser,
-  TemplateTraverser,
-  JavaModifiersResolver)
-

--- a/src/main/scala/effiban/scala2java/traversers/PartialFunctionTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PartialFunctionTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class PartialFunctionTraverserImpl(termFunctionTraverser: =>
     termFunctionTraverser.traverse(termFunction)
   }
 }
-
-object PartialFunctionTraverser extends PartialFunctionTraverserImpl(TermFunctionTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/PatExtractInfixTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatExtractInfixTraverser.scala
@@ -17,5 +17,3 @@ class PatExtractInfixTraverserImpl(patExtractTraverser: PatExtractTraverser) ext
     patExtractTraverser.traverse(patExtract)
   }
 }
-
-object PatExtractInfixTraverser extends PatExtractInfixTraverserImpl(PatExtractTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/PatExtractTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatExtractTraverser.scala
@@ -18,5 +18,3 @@ class PatExtractTraverserImpl(implicit javaWriter: JavaWriter) extends PatExtrac
     writeComment(s"${patternExtractor.fun}(${patternExtractor.args.mkString(", ")})")
   }
 }
-
-object PatExtractTraverser extends PatExtractTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/PatInterpolateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatInterpolateTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class PatInterpolateTraverserImpl(implicit javaWriter: JavaW
     writeComment(patternInterpolation.toString())
   }
 }
-
-object PatInterpolateTraverser extends PatInterpolateTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/PatListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatListTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class PatListTraverserImpl(argumentListTraverser: => Argumen
     }
   }
 }
-
-object PatListTraverser extends PatListTraverserImpl(ArgumentListTraverser, PatTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/PatSeqWildcardTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatSeqWildcardTraverser.scala
@@ -16,5 +16,3 @@ class PatSeqWildcardTraverserImpl(implicit javaWriter: JavaWriter) extends PatSe
     writeComment("...")
   }
 }
-
-object PatSeqWildcardTraverser extends PatSeqWildcardTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/PatTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatTraverser.scala
@@ -7,7 +7,8 @@ import scala.meta.{Lit, Pat, Term}
 
 trait PatTraverser extends ScalaTreeTraverser[Pat]
 
-private[traversers] class PatTraverserImpl(termNameTraverser: => TermNameTraverser,
+private[traversers] class PatTraverserImpl(litTraverser: => LitTraverser,
+                                           termNameTraverser: => TermNameTraverser,
                                            patWildcardTraverser: => PatWildcardTraverser,
                                            patSeqWildcardTraverser: => PatSeqWildcardTraverser,
                                            patVarTraverser: => PatVarTraverser,
@@ -23,7 +24,7 @@ private[traversers] class PatTraverserImpl(termNameTraverser: => TermNameTravers
   import javaWriter._
 
   override def traverse(pat: Pat): Unit = pat match {
-    case lit: Lit => LitTraverser.traverse(lit)
+    case lit: Lit => litTraverser.traverse(lit)
     case termName: Term.Name => termNameTraverser.traverse(termName)
     case patternWildcard: Pat.Wildcard => patWildcardTraverser.traverse(patternWildcard)
     case patternSeqWildcard: Pat.SeqWildcard => patSeqWildcardTraverser.traverse(patternSeqWildcard)
@@ -38,17 +39,3 @@ private[traversers] class PatTraverserImpl(termNameTraverser: => TermNameTravers
     case _ => writeComment(s"UNSUPPORTED: $pat")
   }
 }
-
-object PatTraverser extends PatTraverserImpl(
-  TermNameTraverser,
-  PatWildcardTraverser,
-  PatSeqWildcardTraverser,
-  PatVarTraverser,
-  BindTraverser,
-  AlternativeTraverser,
-  PatTupleTraverser,
-  PatExtractTraverser,
-  PatExtractInfixTraverser,
-  PatInterpolateTraverser,
-  PatTypedTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/PatTupleTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatTupleTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class PatTupleTraverserImpl(implicit javaWriter: JavaWriter)
     writeComment(s"(${patternTuple.args.mkString(", ")})")
   }
 }
-
-object PatTupleTraverser extends PatTupleTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/PatTypedTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatTypedTraverser.scala
@@ -19,5 +19,3 @@ private[traversers] class PatTypedTraverserImpl(typeTraverser: => TypeTraverser,
     patTraverser.traverse(typedPattern.lhs)
   }
 }
-
-object PatTypedTraverser extends PatTypedTraverserImpl(TypeTraverser, PatTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/PatVarTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatVarTraverser.scala
@@ -11,5 +11,3 @@ private[traversers] class PatVarTraverserImpl(termNameTraverser: => TermNameTrav
     termNameTraverser.traverse(patternVar.name)
   }
 }
-
-object PatVarTraverser extends PatVarTraverserImpl(TermNameTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/PatWildcardTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatWildcardTraverser.scala
@@ -13,5 +13,3 @@ private[traversers] class PatWildcardTraverserImpl(implicit javaWriter: JavaWrit
   // Wildcard in pattern match expression - translates to Java "default" ?
   override def traverse(ignored: Pat.Wildcard): Unit = write("default")
 }
-
-object PatWildcardTraverser extends PatWildcardTraverserImpl()

--- a/src/main/scala/effiban/scala2java/traversers/PkgTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PkgTraverser.scala
@@ -20,5 +20,3 @@ private[traversers] class PkgTraverserImpl(termRefTraverser: => TermRefTraverser
     pkg.stats.foreach(statTraverser.traverse)
   }
 }
-
-object PkgTraverser extends PkgTraverserImpl(TermRefTraverser, StatTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/RegularClassTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/RegularClassTraverser.scala
@@ -38,11 +38,3 @@ private[traversers] class RegularClassTraverserImpl(annotListTraverser: => Annot
     javaScope = outerJavaScope
   }
 }
-
-object RegularClassTraverser extends RegularClassTraverserImpl(
-  AnnotListTraverser,
-  TypeParamListTraverser,
-  TemplateTraverser,
-  ParamToDeclValTransformer,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/ReturnTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ReturnTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class ReturnTraverserImpl(termTraverser: => TermTraverser)
     termTraverser.traverse(`return`.expr)
   }
 }
-
-object ReturnTraverser extends ReturnTraverserImpl(TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
@@ -1,0 +1,417 @@
+package effiban.scala2java.traversers
+
+import effiban.scala2java.orderings.JavaTemplateChildOrdering
+import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.transformers._
+import effiban.scala2java.writers.JavaWriter
+
+class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
+
+  object AlternativeTraverser extends AlternativeTraverserImpl(PatTraverser)
+
+  object AnnotListTraverser extends AnnotListTraverserImpl(AnnotTraverser)
+
+  object AnnotTraverser extends AnnotTraverserImpl(InitTraverser)
+
+  object AnonymousFunctionTraverser extends AnonymousFunctionTraverserImpl(TermFunctionTraverser)
+
+  object ApplyTypeTraverser extends ApplyTypeTraverserImpl(TypeTraverser, TermTraverser, TypeListTraverser)
+
+  object ApplyUnaryTraverser extends ApplyUnaryTraverserImpl(TermNameTraverser, TermTraverser)
+
+  object ArgumentListTraverser extends ArgumentListTraverserImpl
+
+  object AscribeTraverser extends AscribeTraverserImpl(TypeTraverser, TermTraverser)
+
+  object AssignTraverser extends AssignTraverserImpl(TermTraverser)
+
+  object BindTraverser extends BindTraverserImpl(PatTraverser)
+
+  object BlockTraverser extends BlockTraverserImpl(
+    InitTraverser,
+    IfTraverser,
+    WhileTraverser,
+    ReturnTraverser,
+    StatTraverser
+  )
+
+  object CaseClassTraverser extends CaseClassTraverserImpl(
+    AnnotListTraverser,
+    TypeParamListTraverser,
+    TermParamListTraverser,
+    TemplateTraverser,
+    JavaModifiersResolver
+  )
+
+  object CaseTraverser extends CaseTraverserImpl(PatTraverser, TermTraverser)
+
+  object CatchHandlerTraverser extends CatchHandlerTraverserImpl(TermParamListTraverser, BlockTraverser)
+
+  object ClassTraverser extends ClassTraverserImpl(CaseClassTraverser, RegularClassTraverser)
+
+  object CtorPrimaryTraverser extends CtorPrimaryTraverserImpl(CtorPrimaryTransformer, DefnDefTraverser)
+
+  object CtorSecondaryTraverser extends CtorSecondaryTraverserImpl(CtorSecondaryTransformer, DefnDefTraverser)
+
+  object DeclDefTraverser extends DeclDefTraverserImpl(
+    AnnotListTraverser,
+    TypeTraverser,
+    TermNameTraverser,
+    TermParamListTraverser,
+    JavaModifiersResolver
+  )
+
+  object DeclTraverser extends DeclTraverserImpl(
+    DeclValTraverser,
+    DeclVarTraverser,
+    DeclDefTraverser,
+    DeclTypeTraverser)
+
+  object DeclTypeTraverser extends DeclTypeTraverserImpl(TypeParamListTraverser, JavaModifiersResolver)
+
+  object DeclValTraverser extends DeclValTraverserImpl(
+    AnnotListTraverser,
+    TypeTraverser,
+    PatListTraverser,
+    JavaModifiersResolver
+  )
+
+  object DeclVarTraverser extends DeclVarTraverserImpl(
+    AnnotListTraverser,
+    TypeTraverser,
+    PatListTraverser,
+    JavaModifiersResolver
+  )
+
+  object DefnDefTraverser extends DefnDefTraverserImpl(
+    AnnotListTraverser,
+    TermNameTraverser,
+    TypeTraverser,
+    TermParamListTraverser,
+    BlockTraverser,
+    JavaModifiersResolver
+  )
+
+  object DefnTraverser extends DefnTraverserImpl(
+    DefnValTraverser,
+    DefnVarTraverser,
+    DefnDefTraverser,
+    DefnTypeTraverser,
+    ClassTraverser,
+    TraitTraverser,
+    ObjectTraverser
+  )
+
+  object DefnTypeTraverser extends DefnTypeTraverserImpl(
+    TypeParamListTraverser,
+    TypeTraverser,
+    JavaModifiersResolver
+  )
+
+  object DefnValTraverser extends DefnValTraverserImpl(
+    AnnotListTraverser,
+    TypeTraverser,
+    PatListTraverser,
+    TermTraverser,
+    JavaModifiersResolver
+  )
+
+  object DefnVarTraverser extends DefnVarTraverserImpl(
+    AnnotListTraverser,
+    TypeTraverser,
+    PatListTraverser,
+    TermTraverser,
+    JavaModifiersResolver
+  )
+
+  object DoTraverser extends DoTraverserImpl(TermTraverser, BlockTraverser)
+
+  object EtaTraverser extends EtaTraverserImpl(TermTraverser)
+
+  object FinallyTraverser extends FinallyTraverserImpl(BlockTraverser)
+
+  object ForTraverser extends ForTraverserImpl(ForVariantTraverser)
+
+  object ForVariantTraverser extends ForVariantTraverserImpl(TermTraverser)
+
+  object ForYieldTraverser extends ForYieldTraverserImpl(ForVariantTraverser)
+
+  object IfTraverser extends IfTraverserImpl(TermTraverser, BlockTraverser)
+
+  object ImporteeTraverser extends ImporteeTraverserImpl(NameTraverser)
+
+  object ImporterTraverser extends ImporterTraverserImpl(TermRefTraverser, ImporteeTraverser)
+
+  object ImportTraverser extends ImportTraverserImpl(ImporterTraverser)
+
+  object InitListTraverser extends InitListTraverserImpl(ArgumentListTraverser, InitTraverser)
+
+  object InitTraverser extends InitTraverserImpl(TypeTraverser, TermListTraverser)
+
+  object LitTraverser extends LitTraverserImpl()
+
+  object NameIndeterminateTraverser extends NameIndeterminateTraverserImpl()
+
+  object NameTraverser extends NameTraverserImpl(
+    NameAnonymousTraverser,
+    NameIndeterminateTraverser,
+    TermNameTraverser,
+    TypeNameTraverser
+  )
+
+  object NewAnonymousTraverser extends NewAnonymousTraverserImpl(TemplateTraverser)
+
+  object NewTraverser extends NewTraverserImpl(InitTraverser)
+
+  object ObjectTraverser extends ObjectTraverserImpl(
+    AnnotListTraverser,
+    TemplateTraverser,
+    JavaModifiersResolver)
+
+  object PartialFunctionTraverser extends PartialFunctionTraverserImpl(TermFunctionTraverser)
+
+  object PatExtractInfixTraverser extends PatExtractInfixTraverserImpl(PatExtractTraverser)
+
+  object PatExtractTraverser extends PatExtractTraverserImpl()
+
+  object PatInterpolateTraverser extends PatInterpolateTraverserImpl()
+
+  object PatListTraverser extends PatListTraverserImpl(ArgumentListTraverser, PatTraverser)
+
+  object PatSeqWildcardTraverser extends PatSeqWildcardTraverserImpl()
+
+  object PatTraverser extends PatTraverserImpl(
+    LitTraverser,
+    TermNameTraverser,
+    PatWildcardTraverser,
+    PatSeqWildcardTraverser,
+    PatVarTraverser,
+    BindTraverser,
+    AlternativeTraverser,
+    PatTupleTraverser,
+    PatExtractTraverser,
+    PatExtractInfixTraverser,
+    PatInterpolateTraverser,
+    PatTypedTraverser
+  )
+
+  object PatTupleTraverser extends PatTupleTraverserImpl()
+
+  object PatTypedTraverser extends PatTypedTraverserImpl(TypeTraverser, PatTraverser)
+
+  object PatVarTraverser extends PatVarTraverserImpl(TermNameTraverser)
+
+  object PatWildcardTraverser extends PatWildcardTraverserImpl()
+
+  object PkgTraverser extends PkgTraverserImpl(TermRefTraverser, StatTraverser)
+
+  object RegularClassTraverser extends RegularClassTraverserImpl(
+    AnnotListTraverser,
+    TypeParamListTraverser,
+    TemplateTraverser,
+    ParamToDeclValTransformer,
+    JavaModifiersResolver
+  )
+
+  object ReturnTraverser extends ReturnTraverserImpl(TermTraverser)
+
+  object SelfTraverser extends SelfTraverserImpl
+
+  object SourceTraverser extends SourceTraverserImpl(StatTraverser)
+
+  object StatTraverser extends StatTraverserImpl(
+    TermTraverser,
+    ImportTraverser,
+    PkgTraverser,
+    DefnTraverser,
+    DeclTraverser
+  )
+
+  object SuperTraverser extends SuperTraverserImpl(NameTraverser)
+
+  object TemplateTraverser extends TemplateTraverserImpl(
+    InitListTraverser,
+    SelfTraverser,
+    StatTraverser,
+    CtorPrimaryTraverser,
+    CtorSecondaryTraverser,
+    JavaTemplateChildOrdering
+  )
+
+  object TermAnnotateTraverser extends TermAnnotateTraverserImpl(AnnotListTraverser, TermTraverser)
+
+  object TermApplyInfixTraverser extends TermApplyInfixTraverserImpl(
+    TermTraverser,
+    TermNameTraverser,
+    TermListTraverser
+  )
+
+  object TermApplyTraverser extends TermApplyTraverserImpl(TermTraverser, TermListTraverser)
+
+  object TermFunctionTraverser extends TermFunctionTraverserImpl(
+    TermParamTraverser,
+    TermParamListTraverser,
+    TermTraverser
+  )
+
+  object TermInterpolateTraverser extends TermInterpolateTraverserImpl(TermInterpolateTransformer, TermApplyTraverser)
+
+  object TermListTraverser extends TermListTraverserImpl(ArgumentListTraverser, TermTraverser)
+
+  object TermMatchTraverser extends TermMatchTraverserImpl(TermTraverser, CaseTraverser)
+
+  object TermNameTraverser extends TermNameTraverserImpl
+
+  object TermParamListTraverser extends TermParamListTraverserImpl(ArgumentListTraverser, TermParamTraverser)
+
+  object TermParamTraverser extends TermParamTraverserImpl(
+    AnnotListTraverser,
+    TypeTraverser,
+    NameTraverser,
+    JavaModifiersResolver
+  )
+
+  object TermPlaceholderTraverser extends TermPlaceholderTraverserImpl
+
+  object TermRefTraverser extends TermRefTraverserImpl(
+    ThisTraverser,
+    SuperTraverser,
+    TermNameTraverser,
+    TermSelectTraverser,
+    ApplyUnaryTraverser
+  )
+
+  object TermRepeatedTraverser extends TermRepeatedTraverserImpl(TermTraverser)
+
+  object TermSelectTraverser extends TermSelectTraverserImpl(TermTraverser, TermNameTraverser)
+
+  object TermTraverser extends TermTraverserImpl(
+    TermRefTraverser,
+    TermApplyTraverser,
+    ApplyTypeTraverser,
+    TermApplyInfixTraverser,
+    AssignTraverser,
+    ReturnTraverser,
+    ThrowTraverser,
+    AscribeTraverser,
+    TermAnnotateTraverser,
+    TermTupleTraverser,
+    BlockTraverser,
+    IfTraverser,
+    TermMatchTraverser,
+    TryTraverser,
+    TryWithHandlerTraverser,
+    TermFunctionTraverser,
+    PartialFunctionTraverser,
+    AnonymousFunctionTraverser,
+    WhileTraverser,
+    DoTraverser,
+    ForTraverser,
+    ForYieldTraverser,
+    NewTraverser,
+    NewAnonymousTraverser,
+    TermPlaceholderTraverser,
+    EtaTraverser,
+    TermRepeatedTraverser,
+    TermInterpolateTraverser,
+    LitTraverser
+  )
+
+  object TermTupleTraverser extends TermTupleTraverserImpl(TermListTraverser)
+
+  object ThisTraverser extends ThisTraverserImpl(NameTraverser)
+
+  object ThrowTraverser extends ThrowTraverserImpl(TermTraverser)
+
+  object TraitTraverser extends TraitTraverserImpl(
+    AnnotListTraverser,
+    TypeParamListTraverser,
+    TemplateTraverser,
+    JavaModifiersResolver
+  )
+
+  object TryTraverser extends TryTraverserImpl(
+    BlockTraverser,
+    CatchHandlerTraverser,
+    FinallyTraverser,
+    PatToTermParamTransformer
+  )
+
+  object TryWithHandlerTraverser extends TryWithHandlerTraverserImpl(
+    BlockTraverser,
+    CatchHandlerTraverser,
+    FinallyTraverser
+  )
+
+  object TypeAnnotateTraverser extends TypeAnnotateTraverserImpl(AnnotListTraverser, TypeTraverser)
+
+  object TypeApplyInfixTraverser extends TypeApplyInfixTraverserImpl
+
+  object TypeApplyTraverser extends TypeApplyTraverserImpl(TypeTraverser, TypeListTraverser)
+
+  object TypeBoundsTraverser extends TypeBoundsTraverserImpl(TypeTraverser)
+
+  object TypeByNameTraverser extends TypeByNameTraverserImpl(TypeApplyTraverser, TypeByNameToSupplierTypeTransformer)
+
+  object TypeExistentialTraverser extends TypeExistentialTraverserImpl(TypeTraverser)
+
+  object TypeFunctionTraverser extends TypeFunctionTraverserImpl(TypeApplyTraverser, ScalaToJavaFunctionTypeTransformer)
+
+  object TypeLambdaTraverser extends TypeLambdaTraverserImpl
+
+  object TypeListTraverser extends TypeListTraverserImpl(ArgumentListTraverser, TypeTraverser)
+
+  object TypeNameTraverser extends TypeNameTraverserImpl(ScalaToJavaTypeNameTransformer)
+
+  object TypeParamListTraverser extends TypeParamListTraverserImpl(ArgumentListTraverser, TypeParamTraverser)
+
+  object TypeParamTraverser extends TypeParamTraverserImpl(
+    NameTraverser,
+    TypeParamListTraverser,
+    TypeBoundsTraverser
+  )
+
+  object TypePlaceholderTraverser extends TypePlaceholderTraverserImpl(TypeBoundsTraverser)
+
+  object TypeProjectTraverser extends TypeProjectTraverserImpl(TypeTraverser, TypeNameTraverser)
+
+  object TypeRefineTraverser extends TypeRefineTraverserImpl(TypeTraverser)
+
+  object TypeRefTraverser extends TypeRefTraverserImpl(
+    TypeNameTraverser,
+    TypeSelectTraverser,
+    TypeProjectTraverser,
+    TypeSingletonTraverser
+  )
+
+  object TypeRepeatedTraverser extends TypeRepeatedTraverserImpl(TypeTraverser)
+
+  object TypeSelectTraverser extends TypeSelectTraverserImpl(TermRefTraverser, TypeNameTraverser)
+
+  object TypeSingletonTraverser extends TypeSingletonTraverserImpl(TermTraverser, TypeSingletonToTermTransformer)
+
+  object TypeTraverser extends TypeTraverserImpl(
+    TypeRefTraverser,
+    TypeApplyTraverser,
+    TypeApplyInfixTraverser,
+    TypeFunctionTraverser,
+    TypeTupleTraverser,
+    TypeWithTraverser,
+    TypeRefineTraverser,
+    TypeExistentialTraverser,
+    TypeAnnotateTraverser,
+    TypeLambdaTraverser,
+    TypePlaceholderTraverser,
+    TypeByNameTraverser,
+    TypeRepeatedTraverser,
+    TypeVarTraverser
+  )
+
+  object TypeTupleTraverser extends TypeTupleTraverserImpl
+
+  object TypeVarTraverser extends TypeVarTraverserImpl
+
+  object TypeWithTraverser extends TypeWithTraverserImpl(TypeTraverser)
+
+  object WhileTraverser extends WhileTraverserImpl(TermTraverser, BlockTraverser)
+}

--- a/src/main/scala/effiban/scala2java/traversers/SelfTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/SelfTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class SelfTraverserImpl(implicit javaWriter: JavaWriter) ext
     })
   }
 }
-
-object SelfTraverser extends SelfTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/SourceTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/SourceTraverser.scala
@@ -11,5 +11,3 @@ private[traversers] class SourceTraverserImpl(statTraverser: => StatTraverser) e
     source.stats.foreach(statTraverser.traverse)
   }
 }
-
-object SourceTraverser extends SourceTraverserImpl(StatTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/StatTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/StatTraverser.scala
@@ -25,11 +25,3 @@ private[traversers] class StatTraverserImpl(termTraverser: => TermTraverser,
   }
 
 }
-
-object StatTraverser extends StatTraverserImpl(
-  TermTraverser,
-  ImportTraverser,
-  PkgTraverser,
-  DefnTraverser,
-  DeclTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/SuperTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/SuperTraverser.scala
@@ -26,5 +26,3 @@ private[traversers] class SuperTraverserImpl(nameTraverser: => NameTraverser)
     }
   }
 }
-
-object SuperTraverser extends SuperTraverserImpl(NameTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TemplateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TemplateTraverser.scala
@@ -69,9 +69,9 @@ private[traversers] class TemplateTraverserImpl(initListTraverser: => InitListTr
     writeBlockEnd()
   }
 
-  def traversePrimaryCtor(primaryCtor: Ctor.Primary,
-                          maybeClassName: Option[Type.Name],
-                          inits: List[Init]): Unit = {
+  private def traversePrimaryCtor(primaryCtor: Ctor.Primary,
+                                  maybeClassName: Option[Type.Name],
+                                  inits: List[Init]): Unit = {
     maybeClassName match {
       case Some(className) => ctorPrimaryTraverser.traverse(primaryCtor, className, inits)
       case None => throw new IllegalStateException("Primary Ctor. exists but class name was not passed to the TemplateTraverser")
@@ -85,12 +85,3 @@ private[traversers] class TemplateTraverserImpl(initListTraverser: => InitListTr
     }
   }
 }
-
-object TemplateTraverser extends TemplateTraverserImpl(
-  InitListTraverser,
-  SelfTraverser,
-  StatTraverser,
-  CtorPrimaryTraverser,
-  CtorSecondaryTraverser,
-  JavaTemplateChildOrdering
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermAnnotateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermAnnotateTraverser.scala
@@ -21,5 +21,3 @@ private[traversers] class TermAnnotateTraverserImpl(annotListTraverser: => Annot
     write(")")
   }
 }
-
-object TermAnnotateTraverser extends TermAnnotateTraverserImpl(AnnotListTraverser, TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermApplyInfixTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermApplyInfixTraverser.scala
@@ -25,5 +25,3 @@ private[traversers] class TermApplyInfixTraverserImpl(termTraverser: => TermTrav
     termListTraverser.traverse(termApplyInfix.args, onSameLine = true)
   }
 }
-
-object TermApplyInfixTraverser extends TermApplyInfixTraverserImpl(TermTraverser, TermNameTraverser, TermListTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermApplyTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermApplyTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class TermApplyTraverserImpl(termTraverser: => TermTraverser
     termListTraverser.traverse(termApply.args, maybeEnclosingDelimiter = Some(Parentheses))
   }
 }
-
-object TermApplyTraverser extends TermApplyTraverserImpl(TermTraverser, TermListTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermFunctionTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermFunctionTraverser.scala
@@ -28,9 +28,3 @@ private[traversers] class TermFunctionTraverserImpl(termParamTraverser: => TermP
     javaScope = outerJavaScope
   }
 }
-
-object TermFunctionTraverser extends TermFunctionTraverserImpl(
-  TermParamTraverser,
-  TermParamListTraverser,
-  TermTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermInterpolateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermInterpolateTraverser.scala
@@ -20,8 +20,3 @@ private[traversers] class TermInterpolateTraverserImpl(termInterpolateTransforme
     }
   }
 }
-
-object TermInterpolateTraverser extends TermInterpolateTraverserImpl(
-  TermInterpolateTransformer,
-  TermApplyTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermListTraverser.scala
@@ -25,5 +25,3 @@ private[traversers] class TermListTraverserImpl(argumentListTraverser: => Argume
     }
   }
 }
-
-object TermListTraverser extends TermListTraverserImpl(ArgumentListTraverser, TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermMatchTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermMatchTraverser.scala
@@ -23,5 +23,3 @@ private[traversers] class TermMatchTraverserImpl(termTraverser: => TermTraverser
     writeBlockEnd()
   }
 }
-
-object TermMatchTraverser extends TermMatchTraverserImpl(TermTraverser, CaseTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermNameTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermNameTraverser.scala
@@ -19,5 +19,3 @@ private[traversers] class TermNameTraverserImpl(implicit javaWriter: JavaWriter)
     termName.value
   }
 }
-
-object TermNameTraverser extends TermNameTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/TermParamListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermParamListTraverser.scala
@@ -18,5 +18,3 @@ private[traversers] class TermParamListTraverserImpl(argumentListTraverser: => A
       maybeEnclosingDelimiter = Some(Parentheses))
   }
 }
-
-object TermParamListTraverser extends TermParamListTraverserImpl(ArgumentListTraverser, TermParamTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermParamTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermParamTraverser.scala
@@ -35,10 +35,3 @@ private[traversers] class TermParamTraverserImpl(annotListTraverser: => AnnotLis
     // TODO handle 'default'
   }
 }
-
-object TermParamTraverser extends TermParamTraverserImpl(
-  AnnotListTraverser,
-  TypeTraverser,
-  NameTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermPlaceholderTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermPlaceholderTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class TermPlaceholderTraverserImpl(implicit javaWriter: Java
     write(JavaPlaceholder)
   }
 }
-
-object TermPlaceholderTraverser extends TermPlaceholderTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/TermRefTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermRefTraverser.scala
@@ -25,11 +25,3 @@ private[traversers] class TermRefTraverserImpl(thisTraverser: => ThisTraverser,
     case _ => writeComment(s"UNSUPPORTED: $termRef")
   }
 }
-
-object TermRefTraverser extends TermRefTraverserImpl(
-  ThisTraverser,
-  SuperTraverser,
-  TermNameTraverser,
-  TermSelectTraverser,
-  ApplyUnaryTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermRepeatedTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermRepeatedTraverser.scala
@@ -12,5 +12,3 @@ private[traversers] class TermRepeatedTraverserImpl(termTraverser: => TermTraver
     termTraverser.traverse(termRepeated.expr)
   }
 }
-
-object TermRepeatedTraverser extends TermRepeatedTraverserImpl(TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TermSelectTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermSelectTraverser.scala
@@ -25,8 +25,3 @@ private[traversers] class TermSelectTraverserImpl(termTraverser: => TermTraverse
   }
 
 }
-
-object TermSelectTraverser extends TermSelectTraverserImpl(
-  TermTraverser,
-  TermNameTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermTraverser.scala
@@ -73,35 +73,3 @@ private[traversers] class TermTraverserImpl(termRefTraverser: => TermRefTraverse
     case _ => writeComment(s"UNSUPPORTED: $term")
   }
 }
-
-object TermTraverser extends TermTraverserImpl(
-  TermRefTraverser,
-  TermApplyTraverser,
-  ApplyTypeTraverser,
-  TermApplyInfixTraverser,
-  AssignTraverser,
-  ReturnTraverser,
-  ThrowTraverser,
-  AscribeTraverser,
-  TermAnnotateTraverser,
-  TermTupleTraverser,
-  BlockTraverser,
-  IfTraverser,
-  TermMatchTraverser,
-  TryTraverser,
-  TryWithHandlerTraverser,
-  TermFunctionTraverser,
-  PartialFunctionTraverser,
-  AnonymousFunctionTraverser,
-  WhileTraverser,
-  DoTraverser,
-  ForTraverser,
-  ForYieldTraverser,
-  NewTraverser,
-  NewAnonymousTraverser,
-  TermPlaceholderTraverser,
-  EtaTraverser,
-  TermRepeatedTraverser,
-  TermInterpolateTraverser,
-  LitTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TermTupleTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermTupleTraverser.scala
@@ -13,5 +13,3 @@ private[traversers] class TermTupleTraverserImpl(termListTraverser: => TermListT
     termListTraverser.traverse(termTuple.args, maybeEnclosingDelimiter = Some(Parentheses), onSameLine = true)
   }
 }
-
-object TermTupleTraverser extends TermTupleTraverserImpl(TermListTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ThisTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ThisTraverser.scala
@@ -22,5 +22,3 @@ private[traversers] class ThisTraverserImpl(nameTraverser: => NameTraverser)
     write("this")
   }
 }
-
-object ThisTraverser extends ThisTraverserImpl(NameTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/ThrowTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ThrowTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class ThrowTraverserImpl(termTraverser: => TermTraverser)
     termTraverser.traverse(`throw`.expr)
   }
 }
-
-object ThrowTraverser extends ThrowTraverserImpl(TermTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TraitTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TraitTraverser.scala
@@ -30,10 +30,3 @@ private[traversers] class TraitTraverserImpl(annotListTraverser: => AnnotListTra
     javaScope = outerJavaScope
   }
 }
-
-object TraitTraverser extends TraitTraverserImpl(
-  AnnotListTraverser,
-  TypeParamListTraverser,
-  TemplateTraverser,
-  JavaModifiersResolver
-)

--- a/src/main/scala/effiban/scala2java/traversers/TryTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TryTraverser.scala
@@ -33,10 +33,3 @@ private[traversers] class TryTraverserImpl(blockTraverser: => BlockTraverser,
     `try`.finallyp.foreach(finallyTraverser.traverse)
   }
 }
-
-object TryTraverser extends TryTraverserImpl(
-  BlockTraverser,
-  CatchHandlerTraverser,
-  FinallyTraverser,
-  PatToTermParamTransformer
-)

--- a/src/main/scala/effiban/scala2java/traversers/TryWithHandlerTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TryWithHandlerTraverser.scala
@@ -30,9 +30,3 @@ private[traversers] class TryWithHandlerTraverserImpl(blockTraverser: => BlockTr
     tryWithHandler.finallyp.foreach(finallyTraverser.traverse)
   }
 }
-
-object TryWithHandlerTraverser extends TryWithHandlerTraverserImpl(
-  BlockTraverser,
-  CatchHandlerTraverser,
-  FinallyTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TypeAnnotateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeAnnotateTraverser.scala
@@ -19,5 +19,3 @@ private[traversers] class TypeAnnotateTraverserImpl(annotListTraverser: => Annot
     typeTraverser.traverse(annotatedType.tpe)
   }
 }
-
-object TypeAnnotateTraverser extends TypeAnnotateTraverserImpl(AnnotListTraverser, TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeApplyInfixTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeApplyInfixTraverser.scala
@@ -1,13 +1,14 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.writers.JavaWriter
-import effiban.scala2java.writers.JavaWriter.writeComment
 
 import scala.meta.Type
 
 trait TypeApplyInfixTraverser extends ScalaTreeTraverser[Type.ApplyInfix]
 
-private[traversers] class TypeApplyInfixTraverserImpl(javaWriter: JavaWriter) extends TypeApplyInfixTraverser {
+private[traversers] class TypeApplyInfixTraverserImpl(implicit javaWriter: JavaWriter) extends TypeApplyInfixTraverser {
+
+  import javaWriter._
 
   // type with generic args in infix notation, e.g. K Map V
   override def traverse(typeApplyInfix: Type.ApplyInfix): Unit = {
@@ -15,5 +16,3 @@ private[traversers] class TypeApplyInfixTraverserImpl(javaWriter: JavaWriter) ex
     writeComment(typeApplyInfix.toString())
   }
 }
-
-object TypeApplyInfixTraverser extends TypeApplyInfixTraverserImpl(JavaWriter)

--- a/src/main/scala/effiban/scala2java/traversers/TypeApplyTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeApplyTraverser.scala
@@ -13,5 +13,3 @@ private[traversers] class TypeApplyTraverserImpl(typeTraverser: => TypeTraverser
     typeListTraverser.traverse(typeApply.args)
   }
 }
-
-object TypeApplyTraverser extends TypeApplyTraverserImpl(TypeTraverser, TypeListTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeBoundsTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeBoundsTraverser.scala
@@ -29,5 +29,3 @@ private[traversers] class TypeBoundsTraverserImpl(typeTraverser: => TypeTraverse
     }
   }
 }
-
-object TypeBoundsTraverser extends TypeBoundsTraverserImpl(TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeByNameTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeByNameTraverser.scala
@@ -15,5 +15,3 @@ private[traversers] class TypeByNameTraverserImpl(typeApplyTraverser: => TypeApp
     typeApplyTraverser.traverse(typeByNameToSupplierTypeTransformer.transform(typeByName))
   }
 }
-
-object TypeByNameTraverser extends TypeByNameTraverserImpl(TypeApplyTraverser, TypeByNameToSupplierTypeTransformer)

--- a/src/main/scala/effiban/scala2java/traversers/TypeExistentialTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeExistentialTraverser.scala
@@ -18,5 +18,3 @@ private[traversers] class TypeExistentialTraverserImpl(typeTraverser: => TypeTra
     writeComment(s"forSome ${existentialType.stats.toString()}")
   }
 }
-
-object TypeExistentialTraverser extends TypeExistentialTraverserImpl(TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeFunctionTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeFunctionTraverser.scala
@@ -22,5 +22,3 @@ private[traversers] class TypeFunctionTraverserImpl(typeApplyTraverser: => TypeA
     }
   }
 }
-
-object TypeFunctionTraverser extends TypeFunctionTraverserImpl(TypeApplyTraverser, ScalaToJavaFunctionTypeTransformer)

--- a/src/main/scala/effiban/scala2java/traversers/TypeLambdaTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeLambdaTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class TypeLambdaTraverserImpl(implicit javaWriter: JavaWrite
     writeComment(lambdaType.toString())
   }
 }
-
-object TypeLambdaTraverser extends TypeLambdaTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/TypeListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeListTraverser.scala
@@ -20,5 +20,3 @@ private[traversers] class TypeListTraverserImpl(argumentListTraverser: => Argume
     }
   }
 }
-
-object TypeListTraverser extends TypeListTraverserImpl(ArgumentListTraverser, TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeNameTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeNameTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class TypeNameTraverserImpl(scalaToJavaTypeNameTransformer: 
     write(scalaToJavaTypeNameTransformer.transform(name))
   }
 }
-
-object TypeNameTraverser extends TypeNameTraverserImpl(ScalaToJavaTypeNameTransformer)

--- a/src/main/scala/effiban/scala2java/traversers/TypeParamListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeParamListTraverser.scala
@@ -20,5 +20,3 @@ private[traversers] class TypeParamListTraverserImpl(argumentListTraverser: => A
     }
   }
 }
-
-object TypeParamListTraverser extends TypeParamListTraverserImpl(ArgumentListTraverser, TypeParamTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeParamTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeParamTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class TypeParamTraverserImpl(nameTraverser: => NameTraverser
     //TODO handle vbounds and cbounds (which aren't supported in Java, maybe partially ?)
   }
 }
-
-object TypeParamTraverser extends TypeParamTraverserImpl(NameTraverser, TypeParamListTraverser, TypeBoundsTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypePlaceholderTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypePlaceholderTraverser.scala
@@ -16,7 +16,4 @@ private[traversers] class TypePlaceholderTraverserImpl(typeBoundsTraverser: => T
     write("?")
     typeBoundsTraverser.traverse(placeholderType.bounds)
   }
-
 }
-
-object TypePlaceholderTraverser extends TypePlaceholderTraverserImpl(TypeBoundsTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeProjectTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeProjectTraverser.scala
@@ -20,5 +20,3 @@ private[traversers] class TypeProjectTraverserImpl(typeTraverser: => TypeTravers
     typeNameTraverser.traverse(typeProject.name)
   }
 }
-
-object TypeProjectTraverser extends TypeProjectTraverserImpl(TypeTraverser, TypeNameTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeRefTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeRefTraverser.scala
@@ -21,10 +21,3 @@ private[traversers] class TypeRefTraverserImpl(typeNameTraverser: => TypeNameTra
     case _ => writeComment(s"UNSUPPORTED: $typeRef")
   }
 }
-
-object TypeRefTraverser extends TypeRefTraverserImpl(
-  TypeNameTraverser,
-  TypeSelectTraverser,
-  TypeProjectTraverser,
-  TypeSingletonTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TypeRefineTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeRefineTraverser.scala
@@ -19,5 +19,3 @@ private[traversers] class TypeRefineTraverserImpl(typeTraverser: => TypeTraverse
     writeComment(s"${refinedType.stats.toString()}")
   }
 }
-
-object TypeRefineTraverser extends TypeRefineTraverserImpl(TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeRepeatedTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeRepeatedTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class TypeRepeatedTraverserImpl(typeTraverser: => TypeTraver
     writeEllipsis()
   }
 }
-
-object TypeRepeatedTraverser extends TypeRepeatedTraverserImpl(TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeSelectTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeSelectTraverser.scala
@@ -12,12 +12,11 @@ private[traversers] class TypeSelectTraverserImpl(termRefTraverser: => TermRefTr
 
   import javaWriter._
 
-  // A scala type selecting expression like: a.B
+  // A scala type selecting a type from a term, e.g.: a.B where 'a' is of some class 'A' that has a 'B' type inside.
+  // I think it's supported in Java, but will produce a warning that a 'static member is being accessed from a non-static context'.
   override def traverse(typeSelect: Type.Select): Unit = {
     termRefTraverser.traverse(typeSelect.qual)
     write(".")
     typeNameTraverser.traverse(typeSelect.name)
   }
 }
-
-object TypeSelectTraverser extends TypeSelectTraverserImpl(TermRefTraverser, TypeNameTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TypeSingletonTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeSingletonTraverser.scala
@@ -14,5 +14,3 @@ private[traversers] class TypeSingletonTraverserImpl(termTraverser: => TermTrave
     termTraverser.traverse(typeSingletonToTermTransformer.transform(singletonType))
   }
 }
-
-object TypeSingletonTraverser extends TypeSingletonTraverserImpl(TermTraverser, TypeSingletonToTermTransformer)

--- a/src/main/scala/effiban/scala2java/traversers/TypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeTraverser.scala
@@ -42,20 +42,3 @@ private[traversers] class TypeTraverserImpl(typeRefTraverser: => TypeRefTraverse
     case _ => writeComment(s"UNSUPPORTED: ${`type`}")
   }
 }
-
-object TypeTraverser extends TypeTraverserImpl(
-  TypeRefTraverser,
-  TypeApplyTraverser,
-  TypeApplyInfixTraverser,
-  TypeFunctionTraverser,
-  TypeTupleTraverser,
-  TypeWithTraverser,
-  TypeRefineTraverser,
-  TypeExistentialTraverser,
-  TypeAnnotateTraverser,
-  TypeLambdaTraverser,
-  TypePlaceholderTraverser,
-  TypeByNameTraverser,
-  TypeRepeatedTraverser,
-  TypeVarTraverser
-)

--- a/src/main/scala/effiban/scala2java/traversers/TypeTupleTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeTupleTraverser.scala
@@ -17,5 +17,3 @@ private[traversers] class TypeTupleTraverserImpl(implicit javaWriter: JavaWriter
     writeComment(tupleType.toString())
   }
 }
-
-object TypeTupleTraverser extends TypeTupleTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/TypeVarTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeVarTraverser.scala
@@ -16,5 +16,3 @@ private[traversers] class TypeVarTraverserImpl(implicit javaWriter: JavaWriter) 
     writeComment(typeVar.toString())
   }
 }
-
-object TypeVarTraverser extends TypeVarTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/TypeWithTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TypeWithTraverser.scala
@@ -19,5 +19,3 @@ private[traversers] class TypeWithTraverserImpl(typeTraverser: => TypeTraverser)
     typeTraverser.traverse(typeWith.rhs)
   }
 }
-
-object TypeWithTraverser extends TypeWithTraverserImpl(TypeTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/WhileTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/WhileTraverser.scala
@@ -22,5 +22,3 @@ private[traversers] class WhileTraverserImpl(termTraverser: => TermTraverser,
     }
   }
 }
-
-object WhileTraverser extends WhileTraverserImpl(TermTraverser, BlockTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/package.scala
+++ b/src/main/scala/effiban/scala2java/traversers/package.scala
@@ -1,8 +1,0 @@
-package effiban.scala2java
-
-import effiban.scala2java.writers.JavaWriter
-
-package object traversers {
-
-  implicit val javaWriter: JavaWriter = JavaWriter
-}

--- a/src/test/scala/effiban/scala2java/traversers/PatTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/PatTraverserImplTest.scala
@@ -10,6 +10,7 @@ class PatTraverserImplTest extends UnitTestSuite {
 
   private val TermName: Term.Name = Term.Name("x")
 
+  private val litTraverser = mock[LitTraverser]
   private val termNameTraverser = mock[TermNameTraverser]
   private val patWildcardTraverser = mock[PatWildcardTraverser]
   private val patSeqWildcardTraverser = mock[PatSeqWildcardTraverser]
@@ -23,6 +24,7 @@ class PatTraverserImplTest extends UnitTestSuite {
   private val patTypedTraverser = mock[PatTypedTraverser]
 
   val patTraverser = new PatTraverserImpl(
+    litTraverser,
     termNameTraverser,
     patWildcardTraverser,
     patSeqWildcardTraverser,
@@ -35,6 +37,12 @@ class PatTraverserImplTest extends UnitTestSuite {
     patInterpolateTraverser,
     patTypedTraverser)
 
+
+  test("traverse Lit.Int") {
+    val litInt = Lit.Int(3)
+    patTraverser.traverse(litInt)
+    verify(litTraverser).traverse(eqTree(litInt))
+  }
 
   test("traverse Term.Name") {
     patTraverser.traverse(TermName)


### PR DESCRIPTION
Extracting the traverser objects which were pure singletons, into a new class that will be constructed dynamically.
The motivation for this is to allow for a dynamic `JavaWriter` that will write the output to a file according to user input.