### PR TITLE
Fix traverser args not passed by-name

### DIFF
--- a/src/main/scala/effiban/scala2java/traversers/ArgumentListTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ArgumentListTraverser.scala
@@ -7,7 +7,7 @@ import scala.meta.Tree
 
 trait ArgumentListTraverser {
   def traverse[T <: Tree](args: List[T],
-                          argTraverser: ScalaTreeTraverser[T],
+                          argTraverser: => ScalaTreeTraverser[T],
                           onSameLine: Boolean = false,
                           maybeEnclosingDelimiter: Option[EnclosingDelimiter] = None): Unit
 }
@@ -17,7 +17,7 @@ class ArgumentListTraverserImpl(implicit javaWriter: JavaWriter) extends Argumen
   import javaWriter._
 
   override def traverse[T <: Tree](args: List[T],
-                                   argTraverser: ScalaTreeTraverser[T],
+                                   argTraverser: => ScalaTreeTraverser[T],
                                    onSameLine: Boolean = false,
                                    maybeEnclosingDelimiter: Option[EnclosingDelimiter] = None): Unit = {
     maybeEnclosingDelimiter.foreach(writeArgumentsStart)

--- a/src/main/scala/effiban/scala2java/traversers/BlockTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/BlockTraverser.scala
@@ -11,8 +11,8 @@ trait BlockTraverser {
 
 private[traversers] class BlockTraverserImpl(initTraverser: => InitTraverser,
                                              ifTraverser: => IfTraverser,
-                                             whileTraverser: WhileTraverser,
-                                             returnTraverser: ReturnTraverser,
+                                             whileTraverser: => WhileTraverser,
+                                             returnTraverser: => ReturnTraverser,
                                              statTraverser: => StatTraverser)
                                             (implicit javaWriter: JavaWriter) extends BlockTraverser {
 

--- a/src/main/scala/effiban/scala2java/traversers/CtorPrimaryTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CtorPrimaryTraverser.scala
@@ -9,7 +9,7 @@ trait CtorPrimaryTraverser {
 }
 
 private[traversers] class CtorPrimaryTraverserImpl(ctorPrimaryTransformer: CtorPrimaryTransformer,
-                                                   defnDefTraverser: DefnDefTraverser) extends CtorPrimaryTraverser {
+                                                   defnDefTraverser: => DefnDefTraverser) extends CtorPrimaryTraverser {
 
   override def traverse(primaryCtor: Ctor.Primary, className: Type.Name, inits: List[Init]): Unit = {
     val defnDef = ctorPrimaryTransformer.transform(primaryCtor, className, inits)

--- a/src/main/scala/effiban/scala2java/traversers/CtorSecondaryTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CtorSecondaryTraverser.scala
@@ -9,7 +9,7 @@ trait CtorSecondaryTraverser {
 }
 
 private[traversers] class CtorSecondaryTraverserImpl(ctorSecondaryTransformer: CtorSecondaryTransformer,
-                                                     defnDefTraverser: DefnDefTraverser) extends CtorSecondaryTraverser {
+                                                     defnDefTraverser: => DefnDefTraverser) extends CtorSecondaryTraverser {
 
   override def traverse(secondaryCtor: Ctor.Secondary, className: Type.Name): Unit = {
     val defnDef = ctorSecondaryTransformer.transform(secondaryCtor, className)

--- a/src/main/scala/effiban/scala2java/traversers/DoTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DoTraverser.scala
@@ -7,7 +7,7 @@ import scala.meta.Term.{Block, Do}
 trait DoTraverser extends ScalaTreeTraverser[Do]
 
 private[traversers] class DoTraverserImpl(termTraverser: => TermTraverser,
-                                          blockTraverser: BlockTraverser)
+                                          blockTraverser: => BlockTraverser)
                                          (implicit javaWriter: JavaWriter) extends DoTraverser {
 
   import javaWriter._

--- a/src/main/scala/effiban/scala2java/traversers/PatExtractInfixTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PatExtractInfixTraverser.scala
@@ -4,7 +4,7 @@ import scala.meta.Pat
 
 trait PatExtractInfixTraverser extends ScalaTreeTraverser[Pat.ExtractInfix]
 
-class PatExtractInfixTraverserImpl(patExtractTraverser: PatExtractTraverser) extends PatExtractInfixTraverser {
+class PatExtractInfixTraverserImpl(patExtractTraverser: => PatExtractTraverser) extends PatExtractInfixTraverser {
 
   /**
    * Pattern match extractor in infix notation, e.g. {{{a MyRecord b}}}

--- a/src/main/scala/effiban/scala2java/traversers/WhileTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/WhileTraverser.scala
@@ -7,7 +7,7 @@ import scala.meta.Term.{Block, While}
 trait WhileTraverser extends ScalaTreeTraverser[While]
 
 private[traversers] class WhileTraverserImpl(termTraverser: => TermTraverser,
-                                             blockTraverser: BlockTraverser)
+                                             blockTraverser: => BlockTraverser)
                                             (implicit javaWriter: JavaWriter) extends WhileTraverser {
 
   import javaWriter._


### PR DESCRIPTION
They must be passed by-name to avoid circular references