### PR TITLE
Fix tests using property check feature

### DIFF
--- a/src/test/scala/effiban/scala2java/orderings/JavaTemplateChildOrderingTest.scala
+++ b/src/test/scala/effiban/scala2java/orderings/JavaTemplateChildOrderingTest.scala
@@ -82,7 +82,9 @@ class JavaTemplateChildOrderingTest extends UnitTestSuite {
     (declDef, declType)
   )
 
-  forAll(ChildTypeComparisons) { case (child1: Tree, child2: Tree) =>
-    JavaTemplateChildOrdering.compare(child1, child2) should be < 0
+  test("compare all types") {
+    forAll(ChildTypeComparisons) { case (child1: Tree, child2: Tree) =>
+      JavaTemplateChildOrdering.compare(child1, child2) should be < 0
+    }
   }
 }

--- a/src/test/scala/effiban/scala2java/transformers/ScalaToJavaTypeNameTransformerTest.scala
+++ b/src/test/scala/effiban/scala2java/transformers/ScalaToJavaTypeNameTransformerTest.scala
@@ -23,7 +23,9 @@ class ScalaToJavaTypeNameTransformerTest extends UnitTestSuite {
     ("Option", "Optional")
   )
 
-  forAll (TypeMappings) { (scalaType: String, expectedJavaType: String) =>
-    ScalaToJavaTypeNameTransformer.transform(Type.Name(scalaType)) shouldBe expectedJavaType
+  test ("transform all mappings") {
+    forAll(TypeMappings) { (scalaType: String, expectedJavaType: String) =>
+      ScalaToJavaTypeNameTransformer.transform(Type.Name(scalaType)) shouldBe expectedJavaType
+    }
   }
 }


### PR DESCRIPTION
The tests should be encapsulated in a `test` method like others, so that the before/after methods of the suite can run