### PR TITLE
Add first integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs: # a collection of steps
           key: v1-gradle-cache-{{ checksum "build.gradle" }}
       - run:
           name: Run tests
-          command: ./gradlew test
+          command: ./gradlew check
       - save_cache:
           paths:
             - ~/.gradle/wrapper

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ java {
     }
 }
 
-group 'com.effiban'
+group 'effiban'
 version '1.0'
 
 repositories {
@@ -19,14 +19,48 @@ repositories {
 
 dependencies {
     implementation 'org.scalameta:scalameta_2.13:4.5.4'
-
-    testImplementation 'org.scalatest:scalatest_2.13:3.2.12'
-    testImplementation 'org.mockito:mockito-scala_2.13:1.17.5'
-
-    testRuntimeOnly 'com.vladsch.flexmark:flexmark-all:0.64.0'
 }
 
-test {
-    useJUnitPlatform()
-    maxParallelForks = 1
+testing {
+    suites {
+        test {
+            dependencies {
+                implementation 'org.scalatest:scalatest_2.13:3.2.12'
+                implementation 'org.mockito:mockito-scala_2.13:1.17.5'
+                runtimeOnly 'com.vladsch.flexmark:flexmark-all:0.64.0'
+            }
+            targets {
+                all {
+                    testTask.configure {
+                        maxParallelForks = 1
+                    }
+                }
+            }
+        }
+        integrationTest(JvmTestSuite) {
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
+}
+
+sourceSets {
+    integrationTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+tasks.named('check') {
+    dependsOn(testing.suites.integrationTest)
 }

--- a/src/integrationTest/resources/effiban/scala2java/integrationtest/expectedjava/EmptyTopLevelDefinitions/EmptyTrait.java
+++ b/src/integrationTest/resources/effiban/scala2java/integrationtest/expectedjava/EmptyTopLevelDefinitions/EmptyTrait.java
@@ -1,0 +1,5 @@
+package dummy;
+
+
+public interface EmptyTrait {
+}

--- a/src/integrationTest/resources/effiban/scala2java/integrationtest/scala/EmptyTopLevelDefinitions/EmptyTrait.scala
+++ b/src/integrationTest/resources/effiban/scala2java/integrationtest/scala/EmptyTopLevelDefinitions/EmptyTrait.scala
@@ -1,0 +1,3 @@
+package dummy
+
+trait EmptyTrait

--- a/src/integrationTest/scala/effiban/scala2java/integrationtest/IntegrationTestRunner.scala
+++ b/src/integrationTest/scala/effiban/scala2java/integrationtest/IntegrationTestRunner.scala
@@ -1,0 +1,77 @@
+package effiban.scala2java.integrationtest
+
+import effiban.scala2java.Scala2JavaTranslator.translate
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
+
+import java.nio.file.{Files, Path, Paths}
+import scala.jdk.CollectionConverters._
+import scala.jdk.StreamConverters._
+import scala.util.Using
+
+class IntegrationTestRunner extends AnyFunSuite
+  with Matchers
+  with OptionValues
+  with BeforeAndAfterAll {
+
+  private val basePathStr = "effiban/scala2java/integrationtest"
+  private val scalaBasePath = pathOfResource(s"$basePathStr/scala")
+  private val expectedJavaBasePath = pathOfResource(s"$basePathStr/expectedjava")
+  private var outputJavaBasePath: Path = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    outputJavaBasePath = Files.createTempDirectory("outputjava")
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+
+    val outputJavaBaseDir = outputJavaBasePath.toFile
+    outputJavaBaseDir.listFiles().foreach(_.delete())
+    outputJavaBaseDir.delete()
+  }
+
+  Using(Files.walk(scalaBasePath)) { stream =>
+    stream.toScala(LazyList)
+      .filterNot(Files.isDirectory(_))
+      .foreach(test)
+  }
+
+  private def test(scalaPath: Path): Unit = {
+    val scalaFileName = scalaPath.getFileName.toString
+    test(s"translate $scalaFileName to Java") {
+      val relativePath = scalaBasePath.relativize(scalaPath.getParent)
+      val javaFileName = scalaFileName.replace("scala", "java")
+      val expectedJavaPath = pathOf(expectedJavaBasePath, relativePath, javaFileName)
+      val outputJavaPath = pathOf(outputJavaBasePath, relativePath, javaFileName)
+
+      translate(scalaPath, Some(outputJavaPath.getParent))
+
+      withClue(s"Output java file not found at $outputJavaPath") {
+        outputJavaPath.toFile.exists() shouldBe true
+      }
+      verifyJavaFileContents(outputJavaPath, expectedJavaPath)
+    }
+  }
+
+  private def pathOfResource(resourceName: String) = Paths.get(getClass.getClassLoader.getResource(resourceName).toURI)
+  private def pathOf(basePath: Path, relativePath: Path, fileName: String) = Paths.get(basePath.toString, relativePath.toString, fileName)
+
+  private def verifyJavaFileContents(outputJavaPath: Path, expectedJavaPath: Path): Unit = {
+    val actualLines = Files.readAllLines(outputJavaPath).asScala
+    val expectedLines = Files.readAllLines(expectedJavaPath).asScala
+
+    withClue("Generated Java file has incorrect number of lines: ") {
+      actualLines.size shouldBe expectedLines.size
+    }
+
+    actualLines.indices.foreach(lineNum => {
+      withClue(s"Generated Java code doesn't match expected at line ${lineNum + 1}: ") {
+        actualLines(lineNum) shouldBe expectedLines(lineNum)
+      }
+    })
+  }
+}

--- a/src/main/scala/effiban/scala2java/Scala2JavaRunner.scala
+++ b/src/main/scala/effiban/scala2java/Scala2JavaRunner.scala
@@ -1,6 +1,7 @@
 package effiban.scala2java
 
-import java.io.File
+import effiban.scala2java.Scala2JavaTranslator.translate
+
 import java.nio.file.Paths
 import scala.Console.err
 import scala.sys.exit
@@ -16,8 +17,8 @@ object Scala2JavaRunner {
       case javaOutputDir :: scalaFilePaths => (Some(javaOutputDir), scalaFilePaths)
     }
 
-    val scalaFiles = scalaFilePaths.map(pathStr => Paths.get(pathStr).toFile)
-    scalaFiles.foreach(scalaFile => Scala2JavaTranslator.translate(scalaFile, maybeJavaOutputDir.map(new File(_))))
+    val scalaFiles = scalaFilePaths.map(Paths.get(_))
+    scalaFiles.foreach(scalaFile => translate(scalaFile, maybeJavaOutputDir.map(Paths.get(_))))
   }
 }
 

--- a/src/main/scala/effiban/scala2java/Scala2JavaTranslator.scala
+++ b/src/main/scala/effiban/scala2java/Scala2JavaTranslator.scala
@@ -3,20 +3,21 @@ package effiban.scala2java
 import effiban.scala2java.traversers.ScalaTreeTraversers
 import effiban.scala2java.writers.{ConsoleJavaWriter, JavaWriter, JavaWriterImpl}
 
-import java.io.{File, FileWriter}
-import java.nio.file.{Files, Paths}
+import java.io.FileWriter
+import java.nio.file.{Files, Path, Paths}
 import scala.meta.Source
 import scala.meta.inputs.Input
 
 object Scala2JavaTranslator {
 
-  def translate(scalaFile: File, maybeOutputDir: Option[File] = None): Unit = {
-    val text = Files.readString(scalaFile.toPath)
-    val input = Input.VirtualFile(scalaFile.getAbsolutePath, text)
+  def translate(scalaPath: Path, maybeOutputJavaBasePath: Option[Path] = None): Unit = {
+    val scalaText = Files.readString(scalaPath)
+    val scalaFileName = scalaPath.getFileName.toString
+    val input = Input.VirtualFile(scalaFileName, scalaText)
     val sourceTree = input.parse[Source].get
 
-    implicit val javaWriter: JavaWriter = maybeOutputDir match {
-      case Some(outputDir) => createFileJavaWriter(scalaFile, outputDir)
+    implicit val javaWriter: JavaWriter = maybeOutputJavaBasePath match {
+      case Some(outputJavaBasePath) => createFileJavaWriter(scalaFileName, outputJavaBasePath)
       case None => ConsoleJavaWriter
     }
     try {
@@ -26,10 +27,10 @@ object Scala2JavaTranslator {
     }
   }
 
-  private def createFileJavaWriter(scalaFile: File, outputDir: File) = {
-    outputDir.mkdirs()
-    val javaFileName = scalaFile.getName.replace("scala", "java")
-    val javaFile = Paths.get(outputDir.getAbsolutePath, javaFileName).toFile
+  private def createFileJavaWriter(scalaFileName: String, outputJavaBasePath: Path) = {
+    outputJavaBasePath.toFile.mkdirs()
+    val javaFileName = scalaFileName.replace("scala", "java")
+    val javaFile = Paths.get(outputJavaBasePath.toString, javaFileName).toFile
     new JavaWriterImpl(new FileWriter(javaFile))
   }
 }


### PR DESCRIPTION
- Added a generic framework for integration tests that will automatically pick up pairs of matching scala and java files under the test resources folder, and verify the translation.
- Added the first test for an empty `Trait`