### PR TITLE
Improve integration test error message

### DIFF
--- a/src/integrationTest/scala/effiban/scala2java/integrationtest/IntegrationTestRunner.scala
+++ b/src/integrationTest/scala/effiban/scala2java/integrationtest/IntegrationTestRunner.scala
@@ -1,12 +1,12 @@
 package effiban.scala2java.integrationtest
 
 import effiban.scala2java.Scala2JavaTranslator.translate
+import effiban.scala2java.integrationtest.matchers.FileMatchers.equalContentsOf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 
 import java.nio.file.{Files, Path, Paths}
-import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters._
 import scala.util.Using
 
@@ -54,24 +54,9 @@ class IntegrationTestRunner extends AnyFunSuite
       withClue(s"Output java file not found at $outputJavaPath") {
         outputJavaPath.toFile.exists() shouldBe true
       }
-      verifyJavaFileContents(outputJavaPath, expectedJavaPath)
+      outputJavaPath should equalContentsOf(expectedJavaPath)
     }
   }
 
   private def pathOf(basePath: Path, relativePath: Path, fileName: String) = Paths.get(basePath.toString, relativePath.toString, fileName)
-
-  private def verifyJavaFileContents(outputJavaPath: Path, expectedJavaPath: Path): Unit = {
-    val actualLines = Files.readAllLines(outputJavaPath).asScala
-    val expectedLines = Files.readAllLines(expectedJavaPath).asScala
-
-    withClue("Generated Java file has incorrect number of lines: ") {
-      actualLines.size shouldBe expectedLines.size
-    }
-
-    actualLines.indices.foreach(lineNum => {
-      withClue(s"Generated Java code doesn't match expected at line ${lineNum + 1}: ") {
-        actualLines(lineNum) shouldBe expectedLines(lineNum)
-      }
-    })
-  }
 }

--- a/src/integrationTest/scala/effiban/scala2java/integrationtest/matchers/FileMatchers.scala
+++ b/src/integrationTest/scala/effiban/scala2java/integrationtest/matchers/FileMatchers.scala
@@ -1,0 +1,26 @@
+package effiban.scala2java.integrationtest.matchers
+
+import effiban.scala2java.integrationtest.matchers.FileMatchers.SameFileContentsMessage
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import java.nio.file.Path
+
+trait FileMatchers {
+
+  class FileContentsEqualMatcher(expectedPath: Path) extends Matcher[Path] {
+
+    override def apply(actualPath: Path): MatchResult = {
+      val maybeFileMismatchMessage = FileMismatchMessageGenerator.generate(actualPath, expectedPath)
+
+      MatchResult(matches = maybeFileMismatchMessage.isEmpty,
+        rawFailureMessage = maybeFileMismatchMessage.getOrElse(""),
+        rawNegatedFailureMessage = SameFileContentsMessage)
+    }
+  }
+}
+
+object FileMatchers extends FileMatchers {
+  final val SameFileContentsMessage = "Actual and expected files have the same contents"
+
+  def equalContentsOf(actualPath: Path): Matcher[Path] = new FileContentsEqualMatcher(actualPath)
+}

--- a/src/integrationTest/scala/effiban/scala2java/integrationtest/matchers/FileMismatchMessageGenerator.scala
+++ b/src/integrationTest/scala/effiban/scala2java/integrationtest/matchers/FileMismatchMessageGenerator.scala
@@ -1,0 +1,95 @@
+package effiban.scala2java.integrationtest.matchers
+
+import java.nio.file.{Files, Path}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+import scala.math.{floor, log10, max, min}
+
+private[matchers] object FileMismatchMessageGenerator {
+
+  final val Divider = " |"
+  final val Highlight = "~"
+  final val Missing = "<MISSING>"
+  final val Actual = "ACTUAL"
+  final val Expected = "EXPECTED"
+
+  def generate(actualPath: Path, expectedPath: Path): Option[String] = {
+    val actualLines = Files.readAllLines(actualPath).asScala.toSeq
+    val expectedLines = Files.readAllLines(expectedPath).asScala.toSeq
+
+    findMismatchingLineNum(actualLines, expectedLines)
+      .map(mismatchingLineNum => generate(actualLines, expectedLines, mismatchingLineNum))
+  }
+
+  private def generate(actualLines: Seq[String], expectedLines: Seq[String], mismatchingLineNum: Int) = {
+    val maxNumLines = max(actualLines.size, expectedLines.size)
+    val maxLineNumDigits = numDigitsOf(maxNumLines)
+    val maxActualLineLength = actualLines.map(_.length).max
+    val maxExpectedLineLength = expectedLines.map(_.length).max
+    val maxRowLength = maxLineNumDigits + maxActualLineLength + maxExpectedLineLength + (2 * Divider.length)
+
+    val diffBuilder = new mutable.StringBuilder(500)
+    diffBuilder ++= "\n"
+    diffBuilder ++= s"Actual file did not match expected file at line ${mismatchingLineNum + 1}:\n"
+    diffBuilder ++= "\n"
+    diffBuilder ++= generateHeader(maxLineNumDigits, maxActualLineLength)
+
+    (0 until maxNumLines).foreach(lineNum => {
+      if (mismatchingLineNum == lineNum - 1 || mismatchingLineNum == lineNum) {
+        diffBuilder ++= generateHighlightedRow(maxRowLength)
+      }
+      diffBuilder ++= generateLineNumber(lineNum = lineNum, maxLineNumDigits = maxLineNumDigits)
+      diffBuilder ++= Divider
+      diffBuilder ++= generateActualLinePart(actualLines, lineNum = lineNum, maxActualLineLength = maxActualLineLength)
+      diffBuilder ++= Divider
+      diffBuilder ++= generateExpectedLinePart(expectedLines, lineNum)
+      diffBuilder ++= "\n"
+    })
+    if (mismatchingLineNum == maxNumLines - 1) {
+      diffBuilder ++= generateHighlightedRow(maxRowLength)
+    }
+    diffBuilder.toString()
+  }
+
+  private def generateHeader(maxLineNumDigits: Int, maxActualLineLength: Int) = {
+    (" " * maxLineNumDigits) + Divider + Actual + (" " * (maxActualLineLength - Actual.length)) + Divider + Expected + "\n"
+  }
+
+  private def generateHighlightedRow(maxRowLength: Int) = (Highlight * maxRowLength) + "\n"
+
+  private def generateLineNumber(lineNum: Int, maxLineNumDigits: Int) = {
+    (" " * (maxLineNumDigits - numDigitsOf(lineNum + 1))) + (lineNum + 1)
+  }
+
+  private def generateActualLinePart(actualLines: Seq[String], lineNum: Int, maxActualLineLength: Int) = {
+    if (lineNum < actualLines.size) {
+      actualLines(lineNum) + (" " * (maxActualLineLength - actualLines(lineNum).length))
+    } else {
+      Missing + (" " * (maxActualLineLength - Missing.length))
+    }
+  }
+
+  private def generateExpectedLinePart(expectedLines: Seq[String], lineNum: Int) = {
+    if (lineNum < expectedLines.size) {
+      expectedLines(lineNum)
+    } else {
+      Missing
+    }
+  }
+
+  private def findMismatchingLineNum(actualLines: Seq[String], expectedLines: Seq[String]): Option[Int] = {
+    val minNumLines = min(actualLines.size, expectedLines.size)
+
+    val maybeMismatchingLineNum = (0 until minNumLines)
+      .find(lineNum => actualLines(lineNum) != expectedLines(lineNum))
+
+    maybeMismatchingLineNum match {
+      case Some(mismatchingLineNum) => Some(mismatchingLineNum)
+      case None if actualLines.size != expectedLines.size => Some(minNumLines)
+      case _ => None
+    }
+  }
+
+  private def numDigitsOf(num: Int) = floor(log10(num)).toInt + 1
+}
+


### PR DESCRIPTION
Improve the error message for integration tests in case files don't match - now the files are displayed side-by-side with the mismatching row highlighted