### PR TITLE
`for` comprehensions: Bug fix and integration tests

### DIFF
--- a/src/integrationTest/resources/testfiles/ForComprehensions/For/OneEnumerator/Sample.java
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/For/OneEnumerator/Sample.java
@@ -1,0 +1,15 @@
+package dummy;
+
+
+public class Sample {
+
+    public Sample() {
+    }
+
+    public void foo() {
+        xs.forEach(x ->  {
+            doSomething(x);
+        }
+        );
+    }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/For/OneEnumerator/Sample.scala
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/For/OneEnumerator/Sample.scala
@@ -1,0 +1,10 @@
+package dummy
+
+class Sample {
+
+  def foo(): Unit = {
+    for (x <- xs) {
+      doSomething(x)
+    }
+  }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/For/TwoEnumerators/Sample.java
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/For/TwoEnumerators/Sample.java
@@ -1,0 +1,15 @@
+package dummy;
+
+
+public class Sample {
+
+    public Sample() {
+    }
+
+    public void foo() {
+        xs.forEach(x -> ys.forEach(y ->  {
+                doSomething(x, y);
+            }
+            ));
+    }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/For/TwoEnumerators/Sample.scala
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/For/TwoEnumerators/Sample.scala
@@ -1,0 +1,11 @@
+package dummy
+
+class Sample {
+
+  def foo(): Unit = {
+    for (x <- xs;
+         y <- ys) {
+      doSomething(x, y)
+    }
+  }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/OneEnumerator/Sample.java
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/OneEnumerator/Sample.java
@@ -1,0 +1,12 @@
+package dummy;
+
+
+public class Sample {
+
+    public Sample() {
+    }
+
+    public void foo() {
+        xs.map(x -> doSomething(x));
+    }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/OneEnumerator/Sample.scala
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/OneEnumerator/Sample.scala
@@ -1,0 +1,10 @@
+package dummy
+
+class Sample {
+
+  def foo(): Unit = {
+    for {
+      x <- xs
+    } yield doSomething(x)
+  }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/ThreeEnumerators/Sample.java
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/ThreeEnumerators/Sample.java
@@ -1,0 +1,14 @@
+package dummy;
+
+
+public class Sample {
+
+    public Sample() {
+    }
+
+    public void foo() {
+        xs.flatMap(x -> ys.flatMap(y -> zs.map(z -> doSomething(x,
+            y,
+            z))));
+    }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/ThreeEnumerators/Sample.scala
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/ThreeEnumerators/Sample.scala
@@ -1,0 +1,12 @@
+package dummy
+
+class Sample {
+
+  def foo(): Unit = {
+    for {
+      x <- xs
+      y <- ys
+      z <- zs
+    } yield doSomething(x, y, z)
+  }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/TwoEnumerators/Sample.java
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/TwoEnumerators/Sample.java
@@ -1,0 +1,12 @@
+package dummy;
+
+
+public class Sample {
+
+    public Sample() {
+    }
+
+    public void foo() {
+        xs.flatMap(x -> ys.map(y -> doSomething(x, y)));
+    }
+}

--- a/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/TwoEnumerators/Sample.scala
+++ b/src/integrationTest/resources/testfiles/ForComprehensions/ForYield/TwoEnumerators/Sample.scala
@@ -1,0 +1,11 @@
+package dummy
+
+class Sample {
+
+  def foo(): Unit = {
+    for {
+      x <- xs
+      y <- ys
+    } yield doSomething(x, y)
+  }
+}

--- a/src/main/scala/effiban/scala2java/traversers/ForTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ForTraverser.scala
@@ -1,13 +1,25 @@
 package effiban.scala2java.traversers
 
+import effiban.scala2java.traversers.ForTraverser.ForEachFunctionName
+import effiban.scala2java.writers.JavaWriter
+
 import scala.meta.Term
 import scala.meta.Term.For
 
-trait ForTraverser extends ScalaTreeTraverser[For]
+trait ForTraverser extends ScalaTreeTraverser[For] with ForVariantTraverser {
+  override val intermediateFunctionName: Term.Name = ForEachFunctionName
+  override val finalFunctionName: Term.Name = ForEachFunctionName
+}
 
-private[traversers] class ForTraverserImpl(forVariantTraverser: => ForVariantTraverser) extends ForTraverser {
+private[traversers] class ForTraverserImpl(theTermTraverser: => TermTraverser)
+                                          (implicit override val javaWriter: JavaWriter) extends ForTraverser {
+  override def termTraverser: TermTraverser = theTermTraverser
 
   override def traverse(`for`: For): Unit = {
-    forVariantTraverser.traverse(`for`.enums, `for`.body, Term.Name("forEach"))
+    traverse(`for`.enums, `for`.body)
   }
+}
+
+private[traversers] object ForTraverser {
+  final val ForEachFunctionName: Term.Name = Term.Name("forEach")
 }

--- a/src/main/scala/effiban/scala2java/traversers/ForYieldTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ForYieldTraverser.scala
@@ -1,13 +1,20 @@
 package effiban.scala2java.traversers
 
+import effiban.scala2java.writers.JavaWriter
+
 import scala.meta.Term
 import scala.meta.Term.ForYield
 
-trait ForYieldTraverser extends ScalaTreeTraverser[ForYield]
+trait ForYieldTraverser extends ScalaTreeTraverser[ForYield] with ForVariantTraverser {
+  override val intermediateFunctionName: Term.Name = Term.Name("flatMap")
+  override val finalFunctionName: Term.Name = Term.Name("map")
+}
 
-private[traversers] class ForYieldTraverserImpl(forVariantTraverser: => ForVariantTraverser) extends ForYieldTraverser {
+private[traversers] class ForYieldTraverserImpl(theTermTraverser: => TermTraverser)
+                                          (implicit override val javaWriter: JavaWriter) extends ForYieldTraverser {
+  override def termTraverser: TermTraverser = theTermTraverser
 
   override def traverse(forYield: ForYield): Unit = {
-    forVariantTraverser.traverse(forYield.enums, forYield.body, Term.Name("map"))
+    traverse(forYield.enums, forYield.body)
   }
 }

--- a/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
@@ -130,11 +130,9 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
 
   private lazy val finallyTraverser: FinallyTraverser = new FinallyTraverserImpl(blockTraverser)
 
-  private lazy val forTraverser: ForTraverser = new ForTraverserImpl(forVariantTraverser)
+  private lazy val forTraverser: ForTraverser = new ForTraverserImpl(termTraverser)
 
-  private lazy val forVariantTraverser: ForVariantTraverser = new ForVariantTraverserImpl(termTraverser)
-
-  private lazy val forYieldTraverser: ForYieldTraverser = new ForYieldTraverserImpl(forVariantTraverser)
+  private lazy val forYieldTraverser: ForYieldTraverser = new ForYieldTraverserImpl(termTraverser)
 
   private lazy val ifTraverser: IfTraverser = new IfTraverserImpl(termTraverser, blockTraverser)
 

--- a/src/test/scala/effiban/scala2java/traversers/ForTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/ForTraverserImplTest.scala
@@ -10,9 +10,9 @@ import scala.meta.{Pat, Term}
 
 class ForTraverserImplTest extends UnitTestSuite {
 
-  private val forVariantTraverser = mock[ForVariantTraverser]
+  private val termTraverser = mock[TermTraverser]
 
-  private val forTraverser = new ForTraverserImpl(forVariantTraverser)
+  private val forTraverser = spy(new ForTraverserImpl(termTraverser))
 
 
   test("traverse") {
@@ -27,9 +27,8 @@ class ForTraverserImplTest extends UnitTestSuite {
 
     forTraverser.traverse(`for`)
 
-    verify(forVariantTraverser).traverse(
+    verify(forTraverser).traverse(
       enumerators = eqTreeList(enumerators),
-      body = eqTree(body),
-      finalFunctionName = eqTree(Term.Name("forEach")))
+      body = eqTree(body))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/ForVariantTraverserTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/ForVariantTraverserTest.scala
@@ -3,12 +3,13 @@ package effiban.scala2java.traversers
 import effiban.scala2java.entities.TraversalConstants.JavaPlaceholder
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.testsuites.UnitTestSuite
+import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Enumerator.{CaseGenerator, Generator}
 import scala.meta.Term.Select
 import scala.meta.{Enumerator, Pat, Term}
 
-class ForVariantTraverserImplTest extends UnitTestSuite {
+class ForVariantTraverserTest extends UnitTestSuite {
 
   private val X = Term.Name("x")
   private val Y = Term.Name("y")
@@ -33,7 +34,15 @@ class ForVariantTraverserImplTest extends UnitTestSuite {
   private val termTraverser = mock[TermTraverser]
 
 
-  private val forVariantTraverser = new ForVariantTraverserImpl(termTraverser)
+  private val forVariantTraverser = new ForVariantTraverser {
+    override val intermediateFunctionName: Term.Name = FlatMapFunctionName
+    override val finalFunctionName: Term.Name = MapFunctionName
+
+    override def termTraverser: TermTraverser = ForVariantTraverserTest.this.termTraverser
+
+    override implicit val javaWriter: JavaWriter = ForVariantTraverserTest.this.javaWriter
+  }
+
   test("traverse() for one Generator with a variable in the LHS") {
     val enumerators = List(
       Generator(pat = PatX, rhs = Xs),
@@ -46,7 +55,7 @@ class ForVariantTraverserImplTest extends UnitTestSuite {
         args = List(Term.Function(params = List(ParamX), body = inputBody))
       )
 
-    forVariantTraverser.traverse(enumerators, inputBody, MapFunctionName)
+    forVariantTraverser.traverse(enumerators, inputBody)
 
     verify(termTraverser).traverse(eqTree(expectedTranslatedFor))
   }
@@ -63,7 +72,7 @@ class ForVariantTraverserImplTest extends UnitTestSuite {
         args = List(Term.Function(params = List(paramOf(Term.Name(JavaPlaceholder))), body = inputBody))
       )
 
-    forVariantTraverser.traverse(enumerators, inputBody, MapFunctionName)
+    forVariantTraverser.traverse(enumerators, inputBody)
 
     verify(termTraverser).traverse(eqTree(expectedTranslatedFor))
   }
@@ -80,7 +89,7 @@ class ForVariantTraverserImplTest extends UnitTestSuite {
         args = List(Term.Function(params = List(ParamX), body = inputBody))
       )
 
-    forVariantTraverser.traverse(enumerators, inputBody, MapFunctionName)
+    forVariantTraverser.traverse(enumerators, inputBody)
 
     verify(termTraverser).traverse(eqTree(expectedTranslatedFor))
   }
@@ -97,7 +106,7 @@ class ForVariantTraverserImplTest extends UnitTestSuite {
         args = List(Term.Function(params = List(ParamX), body = inputBody))
       )
 
-    forVariantTraverser.traverse(enumerators, inputBody, MapFunctionName)
+    forVariantTraverser.traverse(enumerators, inputBody)
 
     verify(termTraverser).traverse(eqTree(expectedTranslatedFor))
   }
@@ -132,7 +141,7 @@ class ForVariantTraverserImplTest extends UnitTestSuite {
         ))
       )
 
-    forVariantTraverser.traverse(enumerators, inputBody, MapFunctionName)
+    forVariantTraverser.traverse(enumerators, inputBody)
 
     verify(termTraverser).traverse(eqTree(expectedTranslatedFor))
   }

--- a/src/test/scala/effiban/scala2java/traversers/ForYieldTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/ForYieldTraverserImplTest.scala
@@ -10,9 +10,9 @@ import scala.meta.{Pat, Term}
 
 class ForYieldTraverserImplTest extends UnitTestSuite {
 
-  private val forVariantTraverser = mock[ForVariantTraverser]
+  private val termTraverser = mock[TermTraverser]
 
-  private val forYieldTraverser = new ForYieldTraverserImpl(forVariantTraverser)
+  private val forYieldTraverser = spy(new ForYieldTraverserImpl(termTraverser))
 
   test("traverse") {
     val enumerators = List(
@@ -28,9 +28,9 @@ class ForYieldTraverserImplTest extends UnitTestSuite {
     )
     forYieldTraverser.traverse(forYield)
 
-    verify(forVariantTraverser).traverse(
+    verify(forYieldTraverser).traverse(
       enumerators = eqTreeList(enumerators),
-      body = eqTree(body),
-      finalFunctionName = eqTree(Term.Name("map")))
+      body = eqTree(body)
+    )
   }
 }


### PR DESCRIPTION
1) Fixed a bug in `For` (without `yield`) - all translated method calls should be `forEach`. This led to a refactoring for code cleanup, making `ForVariantTraverser` a `trait`
2) Added integration tests for `For` and `ForYield` scenarios 