### PR TITLE
Set anonymous type in secondary ctor. transformer

### DIFF
--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/PrimaryAndSecondary/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/PrimaryAndSecondary/Sample.java
@@ -10,7 +10,7 @@ public class Sample {
         this.param2 = param2;
     }
 
-    public /* UnknownType */ Sample(final String param1,
+    public Sample(final String param1,
         final int param2,
         final String param3,
         final int param4) {

--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithSingleParamList/Basic/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithSingleParamList/Basic/Sample.java
@@ -6,7 +6,7 @@ public class Sample {
     public Sample() {
     }
 
-    public /* UnknownType */ Sample(final String param1, final int param2) {
+    public Sample(final String param1, final int param2) {
         this;
     }
 }

--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithSingleParamList/WithVisibilityModifiers/Private/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithSingleParamList/WithVisibilityModifiers/Private/Sample.java
@@ -6,7 +6,7 @@ public class Sample {
     public Sample() {
     }
 
-    private /* UnknownType */ Sample(final String param1, final int param2) {
+    private Sample(final String param1, final int param2) {
         this;
     }
 }

--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithSingleParamList/WithVisibilityModifiers/Protected/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithSingleParamList/WithVisibilityModifiers/Protected/Sample.java
@@ -6,7 +6,7 @@ public class Sample {
     public Sample() {
     }
 
-    protected /* UnknownType */ Sample(final String param1, final int param2) {
+    protected Sample(final String param1, final int param2) {
         this;
     }
 }

--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithTwoParamLists/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithConstructors/Secondary/WithTwoParamLists/Sample.java
@@ -6,7 +6,7 @@ public class Sample {
     public Sample() {
     }
 
-    public /* UnknownType */ Sample(final String param1,
+    public Sample(final String param1,
         final int param2,
         final String param3,
         final int param4) {

--- a/src/main/scala/effiban/scala2java/transformers/CtorSecondaryTransformer.scala
+++ b/src/main/scala/effiban/scala2java/transformers/CtorSecondaryTransformer.scala
@@ -17,7 +17,7 @@ object CtorSecondaryTransformer extends CtorSecondaryTransformer {
       name = Term.Name(className.value),
       tparams = Nil,
       paramss = secondaryCtor.paramss,
-      decltpe = None,
+      decltpe = Some(Type.AnonymousName()),
       body = Block(secondaryCtor.stats)
     )
   }

--- a/src/test/scala/effiban/scala2java/transformers/CtorSecondaryTransformerTest.scala
+++ b/src/test/scala/effiban/scala2java/transformers/CtorSecondaryTransformerTest.scala
@@ -49,7 +49,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
       name = Term.Name(ClassName),
       tparams = Nil,
       paramss = List(Nil),
-      decltpe = None,
+      decltpe = Some(Type.AnonymousName()),
       body = Block(Nil)
     )
 
@@ -74,7 +74,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
       name = Term.Name(ClassName),
       tparams = Nil,
       paramss = List(CtorParams),
-      decltpe = None,
+      decltpe = Some(Type.AnonymousName()),
       body = Block(Nil)
     )
 
@@ -104,7 +104,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
       name = Term.Name(ClassName),
       tparams = Nil,
       paramss = List(Nil),
-      decltpe = None,
+      decltpe = Some(Type.AnonymousName()),
       body = Block(stats)
     )
 
@@ -134,7 +134,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
       name = Term.Name(ClassName),
       tparams = Nil,
       paramss = List(CtorParams),
-      decltpe = None,
+      decltpe = Some(Type.AnonymousName()),
       body = Block(stats)
     )
 


### PR DESCRIPTION
The constructors must have an anonymous return type instead of no type at all - because the latter is interpreted by the type traverser as a missing type which needs to be inferred