### PR TITLE
Improve Java inheritance keyword resolution

### DIFF
--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithInits/OneWithSingleParamList/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithInits/OneWithSingleParamList/Sample.java
@@ -1,7 +1,7 @@
 package dummy;
 
 
-public class Sample implements Parent {
+public class Sample extends Parent {
 
     public Sample() {
         super("name", 3);

--- a/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithInits/OneWithTwoParamLists/Sample.java
+++ b/src/integrationTest/resources/testfiles/Classes/Regular/TopLevel/WithInits/OneWithTwoParamLists/Sample.java
@@ -1,7 +1,7 @@
 package dummy;
 
 
-public class Sample implements Parent {
+public class Sample extends Parent {
 
     public Sample() {
         super("name1",

--- a/src/integrationTest/resources/testfiles/Traits/TopLevel/WithInits/One/Sample.java
+++ b/src/integrationTest/resources/testfiles/Traits/TopLevel/WithInits/One/Sample.java
@@ -1,5 +1,5 @@
 package dummy;
 
 
-public interface Sample implements Parent {
+public interface Sample extends Parent {
 }

--- a/src/integrationTest/resources/testfiles/Traits/TopLevel/WithInits/Two/Sample.java
+++ b/src/integrationTest/resources/testfiles/Traits/TopLevel/WithInits/Two/Sample.java
@@ -1,5 +1,5 @@
 package dummy;
 
 
-public interface Sample implements Parent1, Parent2 {
+public interface Sample extends Parent1, Parent2 {
 }

--- a/src/main/scala/effiban/scala2java/entities/JavaKeyword.scala
+++ b/src/main/scala/effiban/scala2java/entities/JavaKeyword.scala
@@ -1,0 +1,8 @@
+package effiban.scala2java.entities
+
+sealed abstract class JavaKeyword(val name: String)
+
+object JavaKeyword {
+  case object Extends extends JavaKeyword("extends")
+  case object Implements extends JavaKeyword("implements")
+}

--- a/src/main/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolver.scala
+++ b/src/main/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolver.scala
@@ -1,0 +1,30 @@
+package effiban.scala2java.resolvers
+
+import effiban.scala2java.entities.JavaScope.JavaScope
+import effiban.scala2java.entities.{JavaKeyword, JavaScope}
+
+import scala.meta.Init
+
+trait JavaInheritanceKeywordResolver {
+
+  def resolve(scope: JavaScope, inits: List[Init]): JavaKeyword
+}
+
+object JavaInheritanceKeywordResolver extends JavaInheritanceKeywordResolver {
+
+  override def resolve(scope: JavaScope, inits: List[Init]): JavaKeyword = {
+    val haveArgs = doInitsHaveArgs(inits)
+    // The wildcard covers scenarios of both explicit and anonymous classes
+    (scope, haveArgs) match {
+      case (JavaScope.Interface, _) => JavaKeyword.Extends
+      case (_, true) => JavaKeyword.Extends
+      case (_, false) => JavaKeyword.Implements
+      // TODO handle scenario of class having parent class + parent interface
+    }
+  }
+
+  private def doInitsHaveArgs(inits: List[Init]) = {
+    inits.flatMap(_.argss).flatten.nonEmpty
+  }
+
+}

--- a/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
@@ -2,7 +2,7 @@ package effiban.scala2java.traversers
 
 import effiban.scala2java.classifiers.TermApplyInfixClassifier
 import effiban.scala2java.orderings.JavaTemplateChildOrdering
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaInheritanceKeywordResolver, JavaModifiersResolver}
 import effiban.scala2java.transformers._
 import effiban.scala2java.writers.JavaWriter
 
@@ -236,7 +236,8 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
     statTraverser,
     ctorPrimaryTraverser,
     ctorSecondaryTraverser,
-    JavaTemplateChildOrdering
+    JavaTemplateChildOrdering,
+    JavaInheritanceKeywordResolver
   )
 
   private lazy val termAnnotateTraverser: TermAnnotateTraverser = new TermAnnotateTraverserImpl(annotListTraverser, termTraverser)

--- a/src/main/scala/effiban/scala2java/traversers/TemplateTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TemplateTraverser.scala
@@ -1,7 +1,9 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.entities.ClassInfo
+import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.orderings.JavaTemplateChildOrdering
+import effiban.scala2java.resolvers.JavaInheritanceKeywordResolver
 import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.{Ctor, Defn, Init, Name, Stat, Template, Term, Tree, Type}
@@ -17,7 +19,8 @@ private[traversers] class TemplateTraverserImpl(initListTraverser: => InitListTr
                                                 statTraverser: => StatTraverser,
                                                 ctorPrimaryTraverser: => CtorPrimaryTraverser,
                                                 ctorSecondaryTraverser: => CtorSecondaryTraverser,
-                                                javaTemplateChildOrdering: JavaTemplateChildOrdering)
+                                                javaTemplateChildOrdering: JavaTemplateChildOrdering,
+                                                javaInheritanceKeywordResolver: JavaInheritanceKeywordResolver)
                                                (implicit javaWriter: JavaWriter) extends TemplateTraverser {
 
   import javaWriter._
@@ -39,10 +42,13 @@ private[traversers] class TemplateTraverserImpl(initListTraverser: => InitListTr
       maybeClassInfo = maybeClassInfo)
   }
 
-  private def traverseTemplateInits(relevantInits: List[Init]): Unit = {
-    if (relevantInits.nonEmpty) {
-      writeInheritanceKeyword()
-      initListTraverser.traverse(relevantInits, ignoreArgs = true)
+  private def traverseTemplateInits(inits: List[Init]): Unit = {
+    if (inits.nonEmpty) {
+      val inheritanceKeyword = javaInheritanceKeywordResolver.resolve(javaScope, inits)
+      write(" ")
+      writeKeyword(inheritanceKeyword)
+      write(" ")
+      initListTraverser.traverse(inits, ignoreArgs = true)
     }
   }
 

--- a/src/main/scala/effiban/scala2java/writers/JavaWriter.scala
+++ b/src/main/scala/effiban/scala2java/writers/JavaWriter.scala
@@ -1,6 +1,7 @@
 package effiban.scala2java.writers
 
 import effiban.scala2java.entities.EnclosingDelimiter.{EnclosingDelimiter, _}
+import effiban.scala2java.entities.JavaKeyword
 
 import java.io.Writer
 
@@ -10,7 +11,7 @@ trait JavaWriter {
 
   def writeModifiers(modifiers: List[String]): Unit
 
-  def writeInheritanceKeyword(): Unit
+  def writeKeyword(keyword: JavaKeyword): Unit
 
   def writeStatementEnd(): Unit
 
@@ -58,9 +59,8 @@ class JavaWriterImpl(writer: Writer) extends JavaWriter {
     }
   }
 
-  override def writeInheritanceKeyword(): Unit = {
-    //TODO - fix, handle class vs. interface
-    write(s" implements ")
+  override def writeKeyword(keyword: JavaKeyword): Unit = {
+    write(keyword.name)
   }
 
   override def writeStatementEnd(): Unit = {

--- a/src/test/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolverTest.scala
+++ b/src/test/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolverTest.scala
@@ -1,0 +1,44 @@
+package effiban.scala2java.resolvers
+
+import effiban.scala2java.entities.{JavaKeyword, JavaScope}
+import effiban.scala2java.testsuites.UnitTestSuite
+
+import scala.meta.{Init, Lit, Name, Type}
+
+class JavaInheritanceKeywordResolverTest extends UnitTestSuite {
+
+  test("resolve for class with parent args should return 'extends'") {
+    val inits = List(
+      Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = List(List(Lit.Int(3))))
+    )
+    JavaInheritanceKeywordResolver.resolve(JavaScope.Class, inits) shouldBe JavaKeyword.Extends
+  }
+
+  test("resolve for class without parent args should return 'implements'") {
+    val inits = List(
+      Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = Nil)
+    )
+    JavaInheritanceKeywordResolver.resolve(JavaScope.Class, inits) shouldBe JavaKeyword.Implements
+  }
+
+  test("resolve for interface should return 'extends'") {
+    val inits = List(
+      Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = Nil)
+    )
+    JavaInheritanceKeywordResolver.resolve(JavaScope.Interface, inits) shouldBe JavaKeyword.Extends
+  }
+
+  test("resolve for unknown with parent args should return 'extends'") {
+    val inits = List(
+      Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = List(List(Lit.Int(3))))
+    )
+    JavaInheritanceKeywordResolver.resolve(JavaScope.NoScope, inits) shouldBe JavaKeyword.Extends
+  }
+
+  test("resolve for unknown without parent args should return 'implements'") {
+    val inits = List(
+      Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = Nil)
+    )
+    JavaInheritanceKeywordResolver.resolve(JavaScope.NoScope, inits) shouldBe JavaKeyword.Implements
+  }
+}

--- a/src/test/scala/effiban/scala2java/testwriters/TestJavaWriter.scala
+++ b/src/test/scala/effiban/scala2java/testwriters/TestJavaWriter.scala
@@ -1,6 +1,7 @@
 package effiban.scala2java.testwriters
 
 import effiban.scala2java.entities.EnclosingDelimiter._
+import effiban.scala2java.entities.JavaKeyword
 import effiban.scala2java.writers.JavaWriter
 
 import java.io.StringWriter
@@ -18,8 +19,8 @@ class TestJavaWriter(sw: StringWriter) extends JavaWriter {
     }
   }
 
-  override def writeInheritanceKeyword(): Unit = {
-    write(s" extends/implements ")
+  override def writeKeyword(keyword: JavaKeyword): Unit = {
+    write(keyword.name)
   }
 
   override def writeStatementEnd(): Unit = {


### PR DESCRIPTION
- An interface should always `extend`
- A class with a parent having args should `extend`
- A class with a parent without args should `implements` (this is a best-guess since we can't tell if the parent is a class or interface, but interface is more common)
- An anonymous class should follow the same rules as a class

Still not handled: the scenario of a class which has a parent class **and** a parent interface