### PR TITLE
Remove incorrectly implemented type inferrers for `Term.Function` and `Term.PartialFunction`

### DIFF
--- a/src/main/scala/effiban/scala2java/typeinference/TermTypeInferrer.scala
+++ b/src/main/scala/effiban/scala2java/typeinference/TermTypeInferrer.scala
@@ -20,12 +20,10 @@ private[typeinference] class TermTypeInferrerImpl(ifTypeInferrer: => IfTypeInfer
       case `try`: Try => tryTypeInferrer.infer(`try`)
       case tryWithHandler: TryWithHandler => tryWithHandlerTypeInferrer.infer(tryWithHandler)
       case termMatch: Term.Match => caseListTypeInferrer.infer(termMatch.cases)
-      case partialFunction: Term.PartialFunction => caseListTypeInferrer.infer(partialFunction.cases)
       case repeated: Term.Repeated => inferRepeated(repeated)
       case forYield: ForYield => infer(forYield.body)
       case `return`: Return => infer(`return`.expr)
       case assign: Assign => infer(assign.rhs)
-      case function: Term.Function => infer(function.body)
       case ascribe: Ascribe => Some(ascribe.tpe)
       case `new`: New => Some(`new`.init.tpe)
       case _: Term.Interpolate => Some(Type.Name("String"))
@@ -34,7 +32,7 @@ private[typeinference] class TermTypeInferrerImpl(ifTypeInferrer: => IfTypeInfer
       case _: Do => Some(Type.AnonymousName())
       case _: While => Some(Type.AnonymousName())
       case _: Throw => Some(Type.AnonymousName())
-      // TODO - support Tuple, NewAnonymous
+      // TODO - support Tuple, NewAnonymous, Function, PartialFunction
       case _ => None
     }
   }


### PR DESCRIPTION
The types of these `Term`-s should be function types, and not the return types of these functions as I accidentally implemented.
Since the function types can have more than 2 input args there is no straightforward conversion to Java without using a library such as JOOL, so they fall into the same category as `Tuple` which will not be handled at this time.