### PR TITLE
Rename `JavaScope` to `JavaTreeType`

### DIFF
--- a/src/main/scala/effiban/scala2java/entities/JavaScope.scala
+++ b/src/main/scala/effiban/scala2java/entities/JavaScope.scala
@@ -1,6 +1,0 @@
-package effiban.scala2java.entities
-
-object JavaScope extends Enumeration {
-  type JavaScope = Value
-  val Class, Interface, Method, Lambda, NoScope = Value
-}

--- a/src/main/scala/effiban/scala2java/entities/JavaTreeType.scala
+++ b/src/main/scala/effiban/scala2java/entities/JavaTreeType.scala
@@ -1,0 +1,6 @@
+package effiban.scala2java.entities
+
+object JavaTreeType extends Enumeration {
+  type JavaTreeType = Value
+  val Class, Interface, Method, Lambda, Unknown = Value
+}

--- a/src/main/scala/effiban/scala2java/entities/TraversalContext.scala
+++ b/src/main/scala/effiban/scala2java/entities/TraversalContext.scala
@@ -1,9 +1,9 @@
 package effiban.scala2java.entities
 
-import effiban.scala2java.entities.JavaScope._
+import effiban.scala2java.entities.JavaTreeType._
 
 object TraversalContext {
 
-  var javaScope: JavaScope = NoScope
+  var javaScope: JavaTreeType = Unknown
 
 }

--- a/src/main/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolver.scala
+++ b/src/main/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolver.scala
@@ -1,22 +1,22 @@
 package effiban.scala2java.resolvers
 
-import effiban.scala2java.entities.JavaScope.JavaScope
-import effiban.scala2java.entities.{JavaKeyword, JavaScope}
+import effiban.scala2java.entities.JavaTreeType.JavaTreeType
+import effiban.scala2java.entities.{JavaKeyword, JavaTreeType}
 
 import scala.meta.Init
 
 trait JavaInheritanceKeywordResolver {
 
-  def resolve(scope: JavaScope, inits: List[Init]): JavaKeyword
+  def resolve(scope: JavaTreeType, inits: List[Init]): JavaKeyword
 }
 
 object JavaInheritanceKeywordResolver extends JavaInheritanceKeywordResolver {
 
-  override def resolve(scope: JavaScope, inits: List[Init]): JavaKeyword = {
+  override def resolve(scope: JavaTreeType, inits: List[Init]): JavaKeyword = {
     val haveArgs = doInitsHaveArgs(inits)
     // The wildcard covers scenarios of both explicit and anonymous classes
     (scope, haveArgs) match {
-      case (JavaScope.Interface, _) => JavaKeyword.Extends
+      case (JavaTreeType.Interface, _) => JavaKeyword.Extends
       case (_, true) => JavaKeyword.Extends
       case (_, false) => JavaKeyword.Implements
       // TODO handle scenario of class having parent class + parent interface

--- a/src/main/scala/effiban/scala2java/traversers/CaseClassTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/CaseClassTraverser.scala
@@ -1,7 +1,7 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{ClassInfo, JavaScope}
+import effiban.scala2java.entities.{ClassInfo, JavaTreeType}
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
 
@@ -27,7 +27,7 @@ private[traversers] class CaseClassTraverserImpl(annotListTraverser: => AnnotLis
     typeParamListTraverser.traverse(classDef.tparams)
     termParamListTraverser.traverse(classDef.ctor.paramss.flatten)
     val outerJavaScope = javaScope
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
     // Even though the Java type is a Record, the constructor must still be explicitly declared if it has modifiers (annotations, visibility, etc.)
     val maybePrimaryCtor = if (classDef.ctor.mods.nonEmpty) Some(classDef.ctor) else None
     val classInfo = ClassInfo(className = classDef.name, maybePrimaryCtor = maybePrimaryCtor)

--- a/src/main/scala/effiban/scala2java/traversers/DeclDefTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclDefTraverser.scala
@@ -1,7 +1,7 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
@@ -25,7 +25,7 @@ private[traversers] class DeclDefTraverserImpl(annotListTraverser: => AnnotListT
     annotListTraverser.traverseMods(defDecl.mods)
     val resolvedModifierNames = javaScope match {
       case Interface => javaModifiersResolver.resolveForInterfaceMethod(defDecl.mods, hasBody = false)
-      case JavaScope.Class => javaModifiersResolver.resolveForClassMethod(defDecl.mods)
+      case JavaTreeType.Class => javaModifiersResolver.resolveForClassMethod(defDecl.mods)
       case _ => Nil
     }
     writeModifiers(resolvedModifierNames)

--- a/src/main/scala/effiban/scala2java/traversers/DeclValTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclValTraverser.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
 
@@ -24,7 +24,7 @@ private[traversers] class DeclValTraverserImpl(annotListTraverser: => AnnotListT
     annotListTraverser.traverseMods(valDecl.mods)
     val mods = valDecl.mods :+ Final()
     val modifierNames = javaScope match {
-      case JavaScope.Class => javaModifiersResolver.resolveForClassDataMember(mods)
+      case JavaTreeType.Class => javaModifiersResolver.resolveForClassDataMember(mods)
       //TODO replace interface data member (invalid in Java) with method
       case _ if javaScope == Interface => Nil
       // The only possible Java modifier for a local var is 'final'

--- a/src/main/scala/effiban/scala2java/traversers/DeclVarTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclVarTraverser.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
@@ -21,7 +21,7 @@ private[traversers] class DeclVarTraverserImpl(annotListTraverser: => AnnotListT
   override def traverse(varDecl: Decl.Var): Unit = {
     annotListTraverser.traverseMods(varDecl.mods)
     val modifierNames = javaScope match {
-      case JavaScope.Class => javaModifiersResolver.resolveForClassDataMember(varDecl.mods)
+      case JavaTreeType.Class => javaModifiersResolver.resolveForClassDataMember(varDecl.mods)
       case _ => Nil
     }
     writeModifiers(modifierNames)

--- a/src/main/scala/effiban/scala2java/traversers/DefnDefTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnDefTraverser.scala
@@ -1,7 +1,7 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalConstants.UnknownType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.resolvers.JavaModifiersResolver
@@ -32,7 +32,7 @@ private[traversers] class DefnDefTraverserImpl(annotListTraverser: => AnnotListT
     annotListTraverser.traverseMods(defnDef.mods)
     val resolvedModifierNames = javaScope match {
       case Interface => javaModifiersResolver.resolveForInterfaceMethod(defnDef.mods, hasBody = true)
-      case JavaScope.Class => javaModifiersResolver.resolveForClassMethod(defnDef.mods)
+      case JavaTreeType.Class => javaModifiersResolver.resolveForClassMethod(defnDef.mods)
       case _ => Nil
     }
     writeModifiers(resolvedModifierNames)

--- a/src/main/scala/effiban/scala2java/traversers/DefnValOrVarTypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnValOrVarTypeTraverser.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.Method
+import effiban.scala2java.entities.JavaTreeType.Method
 import effiban.scala2java.entities.TraversalConstants.UnknownType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.typeinference.TermTypeInferrer

--- a/src/main/scala/effiban/scala2java/traversers/DefnValTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnValTraverser.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
 
@@ -25,7 +25,7 @@ private[traversers] class DefnValTraverserImpl(annotListTraverser: => AnnotListT
     annotListTraverser.traverseMods(valDef.mods)
     val mods = valDef.mods :+ Final()
     val modifierNames = mods match {
-      case modifiers if javaScope == JavaScope.Class => javaModifiersResolver.resolveForClassDataMember(modifiers)
+      case modifiers if javaScope == JavaTreeType.Class => javaModifiersResolver.resolveForClassDataMember(modifiers)
       case _ if javaScope == Interface => Nil
       // The only possible Java modifier for a local var is 'final'
       case modifiers if javaScope == Method => List(JavaModifier.Final)

--- a/src/main/scala/effiban/scala2java/traversers/DefnVarTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnVarTraverser.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
@@ -22,7 +22,7 @@ private[traversers] class DefnVarTraverserImpl(annotListTraverser: => AnnotListT
   override def traverse(varDef: Defn.Var): Unit = {
     annotListTraverser.traverseMods(varDef.mods)
     val modifierNames = varDef.mods match {
-      case modifiers if javaScope == JavaScope.Class => javaModifiersResolver.resolveForClassDataMember(modifiers)
+      case modifiers if javaScope == JavaTreeType.Class => javaModifiersResolver.resolveForClassDataMember(modifiers)
       case _ => Nil
     }
     writeModifiers(modifierNames)

--- a/src/main/scala/effiban/scala2java/traversers/ObjectTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ObjectTraverser.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter
@@ -25,7 +25,7 @@ private[traversers] class ObjectTraverserImpl(annotListTraverser: => AnnotListTr
       typeKeyword = "class",
       name = s"${objectDef.name.toString}")
     val outerJavaScope = javaScope
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
     templateTraverser.traverse(objectDef.templ)
     javaScope = outerJavaScope
   }

--- a/src/main/scala/effiban/scala2java/traversers/RegularClassTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/RegularClassTraverser.scala
@@ -1,7 +1,7 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{ClassInfo, JavaScope}
+import effiban.scala2java.entities.{ClassInfo, JavaTreeType}
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.transformers.ParamToDeclValTransformer
 import effiban.scala2java.writers.JavaWriter
@@ -27,7 +27,7 @@ private[traversers] class RegularClassTraverserImpl(annotListTraverser: => Annot
       name = classDef.name.value)
     typeParamListTraverser.traverse(classDef.tparams)
     val outerJavaScope = javaScope
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
     val explicitMemberDecls = classDef.ctor.paramss.flatten.map(x =>
       paramToDeclValTransformer.transform(x)
     )

--- a/src/main/scala/effiban/scala2java/traversers/TermFunctionTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermFunctionTraverser.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.Lambda
+import effiban.scala2java.entities.JavaTreeType.Lambda
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.writers.JavaWriter
 

--- a/src/main/scala/effiban/scala2java/traversers/TermParamTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermParamTraverser.scala
@@ -1,7 +1,7 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.entities.JavaModifier
-import effiban.scala2java.entities.JavaScope.Lambda
+import effiban.scala2java.entities.JavaTreeType.Lambda
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.writers.JavaWriter
 

--- a/src/main/scala/effiban/scala2java/traversers/TraitTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TraitTraverser.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.Interface
+import effiban.scala2java.entities.JavaTreeType.Interface
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.resolvers.JavaModifiersResolver
 import effiban.scala2java.writers.JavaWriter

--- a/src/test/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolverTest.scala
+++ b/src/test/scala/effiban/scala2java/resolvers/JavaInheritanceKeywordResolverTest.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.resolvers
 
-import effiban.scala2java.entities.{JavaKeyword, JavaScope}
+import effiban.scala2java.entities.{JavaKeyword, JavaTreeType}
 import effiban.scala2java.testsuites.UnitTestSuite
 
 import scala.meta.{Init, Lit, Name, Type}
@@ -11,34 +11,34 @@ class JavaInheritanceKeywordResolverTest extends UnitTestSuite {
     val inits = List(
       Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = List(List(Lit.Int(3))))
     )
-    JavaInheritanceKeywordResolver.resolve(JavaScope.Class, inits) shouldBe JavaKeyword.Extends
+    JavaInheritanceKeywordResolver.resolve(JavaTreeType.Class, inits) shouldBe JavaKeyword.Extends
   }
 
   test("resolve for class without parent args should return 'implements'") {
     val inits = List(
       Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = Nil)
     )
-    JavaInheritanceKeywordResolver.resolve(JavaScope.Class, inits) shouldBe JavaKeyword.Implements
+    JavaInheritanceKeywordResolver.resolve(JavaTreeType.Class, inits) shouldBe JavaKeyword.Implements
   }
 
   test("resolve for interface should return 'extends'") {
     val inits = List(
       Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = Nil)
     )
-    JavaInheritanceKeywordResolver.resolve(JavaScope.Interface, inits) shouldBe JavaKeyword.Extends
+    JavaInheritanceKeywordResolver.resolve(JavaTreeType.Interface, inits) shouldBe JavaKeyword.Extends
   }
 
   test("resolve for unknown with parent args should return 'extends'") {
     val inits = List(
       Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = List(List(Lit.Int(3))))
     )
-    JavaInheritanceKeywordResolver.resolve(JavaScope.NoScope, inits) shouldBe JavaKeyword.Extends
+    JavaInheritanceKeywordResolver.resolve(JavaTreeType.Unknown, inits) shouldBe JavaKeyword.Extends
   }
 
   test("resolve for unknown without parent args should return 'implements'") {
     val inits = List(
       Init(tpe = Type.Name("Parent"), name = Name.Anonymous(), argss = Nil)
     )
-    JavaInheritanceKeywordResolver.resolve(JavaScope.NoScope, inits) shouldBe JavaKeyword.Implements
+    JavaInheritanceKeywordResolver.resolve(JavaTreeType.Unknown, inits) shouldBe JavaKeyword.Implements
   }
 }

--- a/src/test/scala/effiban/scala2java/testsuites/UnitTestSuite.scala
+++ b/src/test/scala/effiban/scala2java/testsuites/UnitTestSuite.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.testsuites
 
-import effiban.scala2java.entities.JavaScope.NoScope
+import effiban.scala2java.entities.JavaTreeType.Unknown
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.testwriters.TestJavaWriter
 import effiban.scala2java.writers.JavaWriter
@@ -25,6 +25,6 @@ class UnitTestSuite extends AnyFunSuite
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    javaScope = NoScope
+    javaScope = Unknown
   }
 }

--- a/src/test/scala/effiban/scala2java/transformers/CtorPrimaryTransformerImplTest.scala
+++ b/src/test/scala/effiban/scala2java/transformers/CtorPrimaryTransformerImplTest.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.transformers
 
-import effiban.scala2java.entities.JavaScope
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -31,7 +31,7 @@ class CtorPrimaryTransformerImplTest extends UnitTestSuite {
   private val ctorPrimaryTransformer = new CtorPrimaryTransformerImpl(ctorInitsToSuperCallTransformer)
 
   test("traverse() when has no params and no super call") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val primaryCtor = Ctor.Primary(
       mods = Modifiers,
@@ -56,7 +56,7 @@ class CtorPrimaryTransformerImplTest extends UnitTestSuite {
   }
 
   test("traverse() when has no params and has super call") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val primaryCtor = Ctor.Primary(
       mods = Modifiers,
@@ -93,7 +93,7 @@ class CtorPrimaryTransformerImplTest extends UnitTestSuite {
 
 
   test("traverse() when has params and no super call") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val primaryCtor = Ctor.Primary(
       mods = Modifiers,
@@ -123,7 +123,7 @@ class CtorPrimaryTransformerImplTest extends UnitTestSuite {
   }
 
   test("traverse() when has params and super call") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val primaryCtor = Ctor.Primary(
       mods = Modifiers,

--- a/src/test/scala/effiban/scala2java/transformers/CtorSecondaryTransformerTest.scala
+++ b/src/test/scala/effiban/scala2java/transformers/CtorSecondaryTransformerTest.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.transformers
 
-import effiban.scala2java.entities.JavaScope
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -34,7 +34,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
 
 
   test("traverse() when has no params and no body") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val secondaryCtor = Ctor.Secondary(
       mods = Modifiers,
@@ -59,7 +59,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
   }
 
   test("traverse() when has params and no body") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val secondaryCtor = Ctor.Secondary(
       mods = Modifiers,
@@ -84,7 +84,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
   }
 
   test("traverse() when has no params and has body") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val stats = List(
       Term.Apply(Term.Name("doSomething"), List(Lit.String("param5"), Lit.String("param6"))),
@@ -114,7 +114,7 @@ class CtorSecondaryTransformerTest extends UnitTestSuite {
   }
 
   test("traverse() when has params and body") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val stats = List(
       Term.Apply(Term.Name("doSomething"), List(Lit.String("param5"), Lit.String("param6"))),

--- a/src/test/scala/effiban/scala2java/traversers/DeclDefTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DeclDefTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.Interface
+import effiban.scala2java.entities.JavaTreeType.Interface
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.resolvers.JavaModifiersResolver
@@ -62,7 +62,7 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
 
 
   test("traverse() for class method when has one list of params") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val declDef = Decl.Def(
       mods = Modifiers,
@@ -93,7 +93,7 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for class method when has type params") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val declDef = Decl.Def(
       mods = Modifiers,

--- a/src/test/scala/effiban/scala2java/traversers/DeclValTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DeclValTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.resolvers.JavaModifiersResolver
@@ -37,7 +37,7 @@ class DeclValTraverserImplTest extends UnitTestSuite {
 
 
   test("traverse() when it is a class member") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val initialModifiers: List[Mod] = List(TheAnnot)
     val adjustedModifiers = initialModifiers :+ Final()

--- a/src/test/scala/effiban/scala2java/traversers/DeclVarTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DeclVarTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.resolvers.JavaModifiersResolver
@@ -35,7 +35,7 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
 
 
   test("traverse() when it is a class member") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val modifiers = List(TheAnnot)
 

--- a/src/test/scala/effiban/scala2java/traversers/DefnDefTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnDefTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.Interface
+import effiban.scala2java.entities.JavaTreeType.Interface
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import effiban.scala2java.matchers.SomeMatcher.eqSome
 import effiban.scala2java.matchers.TreeMatcher
@@ -71,7 +71,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
     javaModifiersResolver)
 
   test("traverse() for class method with one statement returning int") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnDef = Defn.Def(
       mods = Modifiers,
@@ -114,7 +114,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for class method with one statement returning Unit") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnDef = Defn.Def(
       mods = Modifiers,
@@ -157,7 +157,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for class method with type params") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnDef = Defn.Def(
       mods = Modifiers,
@@ -201,7 +201,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for constructor") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnDef = Defn.Def(
       mods = Modifiers,
@@ -250,7 +250,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for class method with one statement missing return type when not inferrable") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnDef = Defn.Def(
       mods = Modifiers,
@@ -293,7 +293,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for class method with one statement missing return type when inferrable") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnDef = Defn.Def(
       mods = Modifiers,
@@ -337,7 +337,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() for class method with block") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val body = Block(stats = List(Statement1, Statement2))
 

--- a/src/test/scala/effiban/scala2java/traversers/DefnValOrVarTypeTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnValOrVarTypeTraverserImplTest.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
@@ -52,7 +52,7 @@ class DefnValOrVarTypeTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse when has no declared type and JavaScope is Method - should write 'var'") {
-    javaScope = JavaScope.Method
+    javaScope = JavaTreeType.Method
 
     defnValOrVarTypeTraverser.traverse(maybeDeclType = None, maybeRhs = None)
 

--- a/src/test/scala/effiban/scala2java/traversers/DefnValTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnValTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.resolvers.JavaModifiersResolver
@@ -40,7 +40,7 @@ class DefnValTraverserImplTest extends UnitTestSuite {
 
 
   test("traverse() when it is a class member - typed") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val initialModifiers: List[Mod] = List(TheAnnot)
     val adjustedModifiers = initialModifiers :+ Final()
@@ -69,7 +69,7 @@ class DefnValTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() when it is a class member - untyped") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val initialModifiers: List[Mod] = List(TheAnnot)
     val adjustedModifiers = initialModifiers :+ Final()

--- a/src/test/scala/effiban/scala2java/traversers/DefnVarTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnVarTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaScope}
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.resolvers.JavaModifiersResolver
@@ -40,7 +40,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
 
 
   test("traverse() when it is a class member - typed with value") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnVar = Defn.Var(
       mods = Modifiers,
@@ -66,7 +66,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() when it is a class member - typed without value") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnVar = Defn.Var(
       mods = Modifiers,
@@ -91,7 +91,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
   }
 
   test("traverse() when it is a class member - untyped with value") {
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     val defnVar = Defn.Var(
       mods = Modifiers,

--- a/src/test/scala/effiban/scala2java/traversers/TemplateTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/TemplateTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.entities
-import effiban.scala2java.entities.JavaScope.JavaScope
+import effiban.scala2java.entities.JavaTreeType.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaKeyword, JavaScope}
+import effiban.scala2java.entities.{JavaKeyword, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import effiban.scala2java.matchers.TreeMatcher.eqTree
 import effiban.scala2java.orderings.JavaTemplateChildOrdering
@@ -137,9 +137,9 @@ class TemplateTraverserImplTest extends UnitTestSuite {
       stats = Nil
     )
 
-    expectWriteInits(JavaScope.Class)
+    expectWriteInits(JavaTreeType.Class)
 
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     templateTraverser.traverse(template)
 
@@ -176,11 +176,11 @@ class TemplateTraverserImplTest extends UnitTestSuite {
       stats = Nil
     )
 
-    expectWriteInits(JavaScope.Class)
+    expectWriteInits(JavaTreeType.Class)
     expectWritePrimaryCtor(TheInits)
     expectChildOrdering()
 
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     templateTraverser.traverse(
       template = template,
@@ -252,7 +252,7 @@ class TemplateTraverserImplTest extends UnitTestSuite {
       stats = stats
     )
 
-    expectWriteInits(JavaScope.Class)
+    expectWriteInits(JavaTreeType.Class)
     expectWriteSelf()
     expectWriteDataMemberDecl()
     expectWriteDataMemberDefn()
@@ -262,7 +262,7 @@ class TemplateTraverserImplTest extends UnitTestSuite {
 
     expectChildOrdering()
 
-    javaScope = JavaScope.Class
+    javaScope = JavaTreeType.Class
 
     templateTraverser.traverse(
       template = template,
@@ -290,7 +290,7 @@ class TemplateTraverserImplTest extends UnitTestSuite {
     Term.Param(mods = List(), name = Term.Name(name), decltpe = Some(Type.Name(typeName)), default = None)
   }
 
-  private def expectWriteInits(javaScope: JavaScope): Unit = {
+  private def expectWriteInits(javaScope: JavaTreeType): Unit = {
     when(javaInheritanceKeywordResolver.resolve(ArgumentMatchers.eq(javaScope), eqTreeList(TheInits))).thenReturn(JavaKeyword.Implements)
     doWrite("Parent1, Parent2").when(initListTraverser).traverse(eqTreeList(TheInits), ArgumentMatchers.eq(true))
   }

--- a/src/test/scala/effiban/scala2java/traversers/TermParamTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/TermParamTraverserImplTest.scala
@@ -1,6 +1,6 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaScope.{Lambda, Method}
+import effiban.scala2java.entities.JavaTreeType.{Lambda, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import effiban.scala2java.matchers.TreeMatcher.eqTree


### PR DESCRIPTION
This is done because we will need to use the same enum to indicate a Java tree type directly, and not just the scope it is in