### PR TITLE
Refactor `JavaModifiersResolver`

### DIFF
--- a/src/integrationTest/resources/testfiles/Traits/Inner/Basic/Sample.java
+++ b/src/integrationTest/resources/testfiles/Traits/Inner/Basic/Sample.java
@@ -3,7 +3,7 @@ package dummy;
 
 public interface Sample {
 
-    public interface InnerSample {
+    interface InnerSample {
     }
     ;
 }

--- a/src/main/scala/effiban/scala2java/entities/JavaTreeType.scala
+++ b/src/main/scala/effiban/scala2java/entities/JavaTreeType.scala
@@ -8,6 +8,7 @@ object JavaTreeType extends Enumeration {
   Interface,
   Method,
   Lambda,
-  DataMember,
+  Variable,
+  Parameter,
   Unknown = Value
 }

--- a/src/main/scala/effiban/scala2java/resolvers/JavaAllowedModifiersResolver.scala
+++ b/src/main/scala/effiban/scala2java/resolvers/JavaAllowedModifiersResolver.scala
@@ -18,7 +18,7 @@ object JavaAllowedModifiersResolver extends JavaAllowedModifiersResolver {
     JavaModifier.Final
   )
 
-  private final val InnerClassAllowedModifiers = Set[JavaModifier](
+  private final val InnerClassOfClassAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
     JavaModifier.Protected,
     JavaModifier.Public,
@@ -28,14 +28,22 @@ object JavaAllowedModifiersResolver extends JavaAllowedModifiersResolver {
     JavaModifier.Final
   )
 
+  private final val InnerClassOfInterfaceAllowedModifiers = Set[JavaModifier](
+    JavaModifier.Sealed,
+    JavaModifier.Abstract,
+    JavaModifier.Final
+  )
+
   private final val OuterInterfaceAllowedModifiers = Set[JavaModifier](JavaModifier.Public, JavaModifier.Sealed)
 
-  private final val InnerInterfaceAllowedModifiers = Set[JavaModifier](
+  private final val InnerInterfaceOfClassAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
     JavaModifier.Protected,
     JavaModifier.Public,
     JavaModifier.Sealed
   )
+
+  private final val InnerInterfaceOfInterfaceAllowedModifiers = Set[JavaModifier](JavaModifier.Sealed)
 
   private final val ClassMethodAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
@@ -48,7 +56,7 @@ object JavaAllowedModifiersResolver extends JavaAllowedModifiersResolver {
 
   private final val InterfaceMethodAllowedModifiers = Set[JavaModifier](JavaModifier.Private, JavaModifier.Default)
 
-  private final val ClassDataMemberAllowedModifiers = Set[JavaModifier](
+  private final val ClassVariableAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
     JavaModifier.Protected,
     JavaModifier.Public,
@@ -56,17 +64,25 @@ object JavaAllowedModifiersResolver extends JavaAllowedModifiersResolver {
     JavaModifier.Final
   )
 
+  private final val LocalVariableAllowedModifiers = Set[JavaModifier](JavaModifier.Final)
+
+  private final val ParameterAllowedModifiers = Set[JavaModifier](JavaModifier.Final)
+
   override def resolve(treeType: JavaTreeType, scope: JavaTreeType): Set[JavaModifier] = {
 
     (treeType, scope) match {
-      case (JavaTreeType.Class, JavaTreeType.Package)     => OuterClassAllowedModifiers
-      case (JavaTreeType.Class, _)                        => InnerClassAllowedModifiers
+      case (JavaTreeType.Class, JavaTreeType.Package) => OuterClassAllowedModifiers
+      case (JavaTreeType.Class, JavaTreeType.Class) => InnerClassOfClassAllowedModifiers
+      case (JavaTreeType.Class, JavaTreeType.Interface) => InnerClassOfInterfaceAllowedModifiers
       case (JavaTreeType.Interface, JavaTreeType.Package) => OuterInterfaceAllowedModifiers
-      case (JavaTreeType.Interface, _)                    => InnerInterfaceAllowedModifiers
-      case (JavaTreeType.Method, JavaTreeType.Class)      => ClassMethodAllowedModifiers
-      case (JavaTreeType.Method, JavaTreeType.Interface)  => InterfaceMethodAllowedModifiers
-      case (JavaTreeType.DataMember, JavaTreeType.Class)  => ClassDataMemberAllowedModifiers
-      case _                                              => Set.empty
+      case (JavaTreeType.Interface, JavaTreeType.Class) => InnerInterfaceOfClassAllowedModifiers
+      case (JavaTreeType.Interface, JavaTreeType.Interface) => InnerInterfaceOfInterfaceAllowedModifiers
+      case (JavaTreeType.Method, JavaTreeType.Class) => ClassMethodAllowedModifiers
+      case (JavaTreeType.Method, JavaTreeType.Interface) => InterfaceMethodAllowedModifiers
+      case (JavaTreeType.Variable, JavaTreeType.Class) => ClassVariableAllowedModifiers
+      case (JavaTreeType.Variable, JavaTreeType.Method | JavaTreeType.Lambda) => LocalVariableAllowedModifiers
+      case (JavaTreeType.Parameter, _) => ParameterAllowedModifiers
+      case _ => Set.empty
     }
   }
 }

--- a/src/main/scala/effiban/scala2java/resolvers/JavaModifierImplyingPublicResolver.scala
+++ b/src/main/scala/effiban/scala2java/resolvers/JavaModifierImplyingPublicResolver.scala
@@ -3,19 +3,22 @@ package effiban.scala2java.resolvers
 import effiban.scala2java.entities.JavaTreeType.JavaTreeType
 import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 
+import scala.meta.{Defn, Tree}
+
 trait JavaModifierImplyingPublicResolver {
 
-  def resolve(javaTreeType: JavaTreeType, javaScope: JavaTreeType, hasBody: Boolean = false): Option[JavaModifier]
+  def resolve(scalaTree: Tree, javaTreeType: JavaTreeType, javaScope: JavaTreeType): Option[JavaModifier]
 }
 
 object JavaModifierImplyingPublicResolver extends JavaModifierImplyingPublicResolver {
 
-  override def resolve(javaTreeType: JavaTreeType, javaScope: JavaTreeType, hasBody: Boolean = false): Option[JavaModifier] = {
-    (javaTreeType, javaScope, hasBody) match {
-      case (JavaTreeType.Method, JavaTreeType.Interface, true) => Some(JavaModifier.Default)
-      case (JavaTreeType.Interface, _, _) => Some(JavaModifier.Public)
-      case (_, JavaTreeType.Interface, _) => None
-      case _ => Some(JavaModifier.Public)
+  override def resolve(scalaTree: Tree, javaTreeType: JavaTreeType, javaScope: JavaTreeType): Option[JavaModifier] = {
+    (scalaTree, javaTreeType, javaScope) match {
+      case (_: Defn.Def, JavaTreeType.Method, JavaTreeType.Interface) => Some(JavaModifier.Default)
+      // A class (ctor.) param is a member in Scala and can be 'public', but for Java we will transfer the 'public' to a generated member
+      case (_, JavaTreeType.Parameter, JavaTreeType.Class) => None
+      case (_, _, JavaTreeType.Package | JavaTreeType.Class) => Some(JavaModifier.Public)
+      case _ => None
     }
   }
 }

--- a/src/main/scala/effiban/scala2java/resolvers/JavaModifiersResolver.scala
+++ b/src/main/scala/effiban/scala2java/resolvers/JavaModifiersResolver.scala
@@ -1,8 +1,6 @@
 package effiban.scala2java.resolvers
 
-import effiban.scala2java.entities.JavaTreeType.JavaTreeType
-import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
+import effiban.scala2java.entities.JavaModifier
 import effiban.scala2java.orderings.JavaModifierOrdering
 import effiban.scala2java.transformers.ScalaToJavaModifierTransformer
 
@@ -10,47 +8,21 @@ import scala.meta.Mod
 
 trait JavaModifiersResolver {
 
-  def resolveForClass(mods: List[Mod]): List[JavaModifier]
-
-  def resolveForInterface(mods: List[Mod]): List[JavaModifier]
-
-  def resolveForClassMethod(mods: List[Mod]): List[JavaModifier]
-
-  def resolveForInterfaceMethod(mods: List[Mod], hasBody: Boolean): List[JavaModifier]
-
-  def resolveForClassDataMember(mods: List[Mod]): List[JavaModifier]
+  def resolve(params: JavaModifiersResolverParams): List[JavaModifier]
 }
 
 object JavaModifiersResolver extends JavaModifiersResolver {
 
-  override def resolveForClass(mods: List[Mod]): List[JavaModifier] = {
-    resolve(mods, JavaTreeType.Class, javaScope)
-  }
+  override def resolve(params: JavaModifiersResolverParams): List[JavaModifier] = {
+    import params._
 
-  override def resolveForInterface(mods: List[Mod]): List[JavaModifier] = {
-    resolve(mods, JavaTreeType.Interface, javaScope)
-  }
-
-  override def resolveForClassMethod(mods: List[Mod]): List[JavaModifier] = {
-    resolve(mods, JavaTreeType.Method, javaScope)
-  }
-
-  override def resolveForInterfaceMethod(mods: List[Mod], hasBody: Boolean): List[JavaModifier] = {
-    resolve(mods, JavaTreeType.Method, javaScope, hasBody)
-  }
-
-  override def resolveForClassDataMember(mods: List[Mod]): List[JavaModifier] = {
-    resolve(mods, JavaTreeType.DataMember, javaScope)
-  }
-
-  def resolve(mods: List[Mod], javaTreeType: JavaTreeType, javaScope: JavaTreeType, hasBody: Boolean = false): List[JavaModifier] = {
     val modifierNamesBuilder = Set.newBuilder[JavaModifier]
 
     val allowedJavaModifiers = JavaAllowedModifiersResolver.resolve(javaTreeType, javaScope)
-    modifierNamesBuilder ++= transform(mods, allowedJavaModifiers)
+    modifierNamesBuilder ++= transform(scalaMods, allowedJavaModifiers)
 
-    if (scalaModifiersImplyPublic(mods)) {
-      modifierNamesBuilder ++= JavaModifierImplyingPublicResolver.resolve(javaTreeType, javaScope, hasBody)
+    if (scalaModifiersImplyPublic(scalaMods)) {
+      modifierNamesBuilder ++= JavaModifierImplyingPublicResolver.resolve(scalaTree, javaTreeType, javaScope)
     }
 
     modifierNamesBuilder.result()

--- a/src/main/scala/effiban/scala2java/resolvers/JavaModifiersResolverParams.scala
+++ b/src/main/scala/effiban/scala2java/resolvers/JavaModifiersResolverParams.scala
@@ -1,0 +1,11 @@
+package effiban.scala2java.resolvers
+
+import effiban.scala2java.entities.JavaTreeType.JavaTreeType
+
+import scala.meta.{Mod, Tree}
+
+case class JavaModifiersResolverParams(scalaTree: Tree,
+                                       scalaMods: List[Mod],
+                                       javaTreeType: JavaTreeType,
+                                       javaScope: JavaTreeType)
+

--- a/src/main/scala/effiban/scala2java/traversers/DeclTypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclTypeTraverser.scala
@@ -1,6 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.entities.JavaTreeType
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Decl
@@ -17,12 +19,22 @@ private[traversers] class DeclTypeTraverserImpl(typeParamListTraverser: => TypeP
   override def traverse(typeDecl: Decl.Type): Unit = {
     writeLine()
     //TODO handle annotations
-    writeTypeDeclaration(modifiers = javaModifiersResolver.resolveForInterface(typeDecl.mods),
+    writeTypeDeclaration(modifiers = resolveJavaModifiers(typeDecl),
       typeKeyword = "interface",
       name = typeDecl.name.toString)
     typeParamListTraverser.traverse(typeDecl.tparams)
     //TODO handle bounds properly
     writeBlockStart()
     writeBlockEnd()
+  }
+
+  private def resolveJavaModifiers(typeDecl: Decl.Type) = {
+    val params = JavaModifiersResolverParams(
+      scalaTree = typeDecl,
+      scalaMods = typeDecl.mods,
+      javaTreeType = JavaTreeType.Interface,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }

--- a/src/main/scala/effiban/scala2java/traversers/DeclValTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DeclValTraverser.scala
@@ -1,9 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Decl
@@ -20,21 +19,23 @@ private[traversers] class DeclValTraverserImpl(annotListTraverser: => AnnotListT
 
   import javaWriter._
 
+  //TODO replace interface data member declaration (invalid in Java) with method declaration
   override def traverse(valDecl: Decl.Val): Unit = {
     annotListTraverser.traverseMods(valDecl.mods)
-    val mods = valDecl.mods :+ Final()
-    val modifierNames = javaScope match {
-      case JavaTreeType.Class => javaModifiersResolver.resolveForClassDataMember(mods)
-      //TODO replace interface data member declaration (invalid in Java) with method declaration
-      case _ if javaScope == Interface => Nil
-      // The only possible Java modifier for a local var is 'final'
-      case Method => List(JavaModifier.Final)
-      case _ => Nil
-    }
-    writeModifiers(modifierNames)
+    writeModifiers(resolveJavaModifiers(valDecl))
     typeTraverser.traverse(valDecl.decltpe)
     write(" ")
     //TODO - verify when not simple case
     patListTraverser.traverse(valDecl.pats)
+  }
+
+  private def resolveJavaModifiers(valDecl: Decl.Val) = {
+    val params = JavaModifiersResolverParams(
+      scalaTree = valDecl,
+      scalaMods = valDecl.mods :+ Final(),
+      javaTreeType = JavaTreeType.Variable,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }

--- a/src/main/scala/effiban/scala2java/traversers/DefnTypeTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/DefnTypeTraverser.scala
@@ -1,6 +1,8 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.entities.JavaTreeType
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.{Defn, Type}
@@ -16,7 +18,7 @@ private[traversers] class DefnTypeTraverserImpl(typeParamListTraverser: => TypeP
 
   // Scala type definition : Can sometimes be replaced by an empty interface
   override def traverse(typeDef: Defn.Type): Unit = {
-    writeTypeDeclaration(modifiers = javaModifiersResolver.resolveForInterface(typeDef.mods),
+    writeTypeDeclaration(modifiers = resolveJavaModifiers(typeDef),
       typeKeyword = "interface",
       name = typeDef.name.toString)
     typeParamListTraverser.traverse(typeDef.tparams)
@@ -38,5 +40,15 @@ private[traversers] class DefnTypeTraverserImpl(typeParamListTraverser: => TypeP
     }
     writeBlockStart()
     writeBlockEnd()
+  }
+
+  private def resolveJavaModifiers(typeDef: Defn.Type) = {
+    val params = JavaModifiersResolverParams(
+      scalaTree = typeDef,
+      scalaMods = typeDef.mods,
+      javaTreeType = JavaTreeType.Interface,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }

--- a/src/main/scala/effiban/scala2java/traversers/ObjectTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ObjectTraverser.scala
@@ -2,7 +2,7 @@ package effiban.scala2java.traversers
 
 import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Defn
@@ -21,13 +21,23 @@ private[traversers] class ObjectTraverserImpl(annotListTraverser: => AnnotListTr
     writeComment("originally a Scala object")
     writeLine()
     annotListTraverser.traverseMods(objectDef.mods)
-    writeTypeDeclaration(modifiers = javaModifiersResolver.resolveForClass(objectDef.mods),
+    writeTypeDeclaration(modifiers = resolveJavaModifiers(objectDef),
       typeKeyword = "class",
       name = s"${objectDef.name.toString}")
     val outerJavaScope = javaScope
     javaScope = JavaTreeType.Class
     templateTraverser.traverse(objectDef.templ)
     javaScope = outerJavaScope
+  }
+
+  private def resolveJavaModifiers(objectDef: Defn.Object) = {
+    val params = JavaModifiersResolverParams(
+      scalaTree = objectDef,
+      scalaMods = objectDef.mods,
+      javaTreeType = JavaTreeType.Class,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }
 

--- a/src/main/scala/effiban/scala2java/traversers/RegularClassTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/RegularClassTraverser.scala
@@ -2,7 +2,7 @@ package effiban.scala2java.traversers
 
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.entities.{ClassInfo, JavaTreeType}
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.transformers.ParamToDeclValTransformer
 import effiban.scala2java.writers.JavaWriter
 
@@ -22,7 +22,7 @@ private[traversers] class RegularClassTraverserImpl(annotListTraverser: => Annot
   def traverse(classDef: Defn.Class): Unit = {
     writeLine()
     annotListTraverser.traverseMods(classDef.mods)
-    writeTypeDeclaration(modifiers = javaModifiersResolver.resolveForClass(classDef.mods),
+    writeTypeDeclaration(modifiers = resolveJavaModifiers(classDef),
       typeKeyword = "class",
       name = classDef.name.value)
     typeParamListTraverser.traverse(classDef.tparams)
@@ -36,5 +36,15 @@ private[traversers] class RegularClassTraverserImpl(annotListTraverser: => Annot
     templateTraverser.traverse(template = enrichedTemplate,
       maybeClassInfo = Some(ClassInfo(className = classDef.name, maybePrimaryCtor = Some(classDef.ctor))))
     javaScope = outerJavaScope
+  }
+
+  private def resolveJavaModifiers(classDef: Defn.Class) = {
+    val params = JavaModifiersResolverParams(
+      scalaTree = classDef,
+      scalaMods = classDef.mods,
+      javaTreeType = JavaTreeType.Class,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }

--- a/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
+++ b/src/main/scala/effiban/scala2java/traversers/ScalaTreeTraversers.scala
@@ -284,7 +284,8 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   private lazy val termParamTraverser: TermParamTraverser = new TermParamTraverserImpl(
     annotListTraverser,
     typeTraverser,
-    nameTraverser
+    nameTraverser,
+    JavaModifiersResolver
   )
 
   private lazy val termPlaceholderTraverser: TermPlaceholderTraverser = new TermPlaceholderTraverserImpl

--- a/src/main/scala/effiban/scala2java/traversers/TermParamTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TermParamTraverser.scala
@@ -1,34 +1,50 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaModifier
-import effiban.scala2java.entities.JavaTreeType.Lambda
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.writers.JavaWriter
 
-import scala.meta.Term
+import scala.meta.Mod.Final
+import scala.meta.{Mod, Term}
 
 trait TermParamTraverser extends ScalaTreeTraverser[Term.Param]
 
 private[traversers] class TermParamTraverserImpl(annotListTraverser: => AnnotListTraverser,
                                                  typeTraverser: => TypeTraverser,
-                                                 nameTraverser: => NameTraverser)
+                                                 nameTraverser: => NameTraverser,
+                                                 javaModifiersResolver: JavaModifiersResolver)
                                                 (implicit javaWriter: JavaWriter) extends TermParamTraverser {
 
   import javaWriter._
 
-  // method parameter declaration
+  // method/lambda parameter declaration
+  // Note that a primary ctor. param in Scala is also a class member which requires additional handling,
+  // but that aspect will be handled by one of the parent traversers before this one is called
   override def traverse(termParam: Term.Param): Unit = {
     annotListTraverser.traverseMods(termParam.mods, onSameLine = true)
-    val javaModifiers: List[JavaModifier] = javaScope match {
-      case Lambda => Nil
-      case _ => List(JavaModifier.Final)
-    }
-    writeModifiers(javaModifiers)
+    writeModifiers(resolveJavaModifiers(termParam))
     termParam.decltpe.foreach(declType => {
       typeTraverser.traverse(declType)
       write(" ")
     })
     nameTraverser.traverse(termParam.name)
     // TODO handle 'default'
+  }
+
+  private def resolveJavaModifiers(termParam: Term.Param) = {
+    val maybeAddedMod: Option[Mod] = javaScope match {
+      // Can't add final in a Lambda param because it might not have an explicit type,
+      // and we are not adding 'var' there either at this point since it has complicated rules
+      case JavaTreeType.Lambda => None
+      case _ => Some(Final())
+    }
+    val params = JavaModifiersResolverParams(
+      scalaTree = termParam,
+      scalaMods = termParam.mods :++ maybeAddedMod,
+      javaTreeType = JavaTreeType.Parameter,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }

--- a/src/main/scala/effiban/scala2java/traversers/TraitTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/TraitTraverser.scala
@@ -1,8 +1,9 @@
 package effiban.scala2java.traversers
 
+import effiban.scala2java.entities.JavaTreeType
 import effiban.scala2java.entities.JavaTreeType.Interface
 import effiban.scala2java.entities.TraversalContext.javaScope
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Defn.Trait
@@ -20,7 +21,7 @@ private[traversers] class TraitTraverserImpl(annotListTraverser: => AnnotListTra
   override def traverse(traitDef: Trait): Unit = {
     writeLine()
     annotListTraverser.traverseMods(traitDef.mods)
-    writeTypeDeclaration(modifiers = javaModifiersResolver.resolveForInterface(traitDef.mods),
+    writeTypeDeclaration(modifiers = resolveJavaModifiers(traitDef),
       typeKeyword = "interface",
       name = traitDef.name.toString)
     typeParamListTraverser.traverse(traitDef.tparams)
@@ -28,5 +29,15 @@ private[traversers] class TraitTraverserImpl(annotListTraverser: => AnnotListTra
     javaScope = Interface
     templateTraverser.traverse(traitDef.templ)
     javaScope = outerJavaScope
+  }
+
+  private def resolveJavaModifiers(traitDef: Trait) = {
+    val params = JavaModifiersResolverParams(
+      scalaTree = traitDef,
+      scalaMods = traitDef.mods,
+      javaTreeType = JavaTreeType.Interface,
+      javaScope = javaScope
+    )
+    javaModifiersResolver.resolve(params)
   }
 }

--- a/src/test/scala/effiban/scala2java/matchers/JavaModifiersResolverParamsMatcher.scala
+++ b/src/test/scala/effiban/scala2java/matchers/JavaModifiersResolverParamsMatcher.scala
@@ -1,0 +1,33 @@
+package effiban.scala2java.matchers
+
+import effiban.scala2java.resolvers.JavaModifiersResolverParams
+import org.mockito.ArgumentMatcher
+import org.mockito.ArgumentMatchers.argThat
+
+import scala.meta.Mod
+
+class JavaModifiersResolverParamsMatcher(expectedParams: JavaModifiersResolverParams) extends ArgumentMatcher[JavaModifiersResolverParams] {
+
+  override def matches(actualParams: JavaModifiersResolverParams): Boolean = {
+    scalaTreeMatches(actualParams) &&
+      scalaModsMatch(actualParams) &&
+      actualParams.javaTreeType == expectedParams.javaTreeType
+      actualParams.javaScope == expectedParams.javaScope
+  }
+
+  private def scalaTreeMatches(actualParams: JavaModifiersResolverParams) = {
+    new TreeMatcher(expectedParams.scalaTree).matches(actualParams.scalaTree)
+  }
+
+  private def scalaModsMatch(actualParams: JavaModifiersResolverParams): Boolean = {
+    new ListMatcher(expectedParams.scalaMods, new TreeMatcher[Mod](_)).matches(actualParams.scalaMods)
+  }
+
+  override def toString: String = s"Matcher for: $expectedParams"
+}
+
+object JavaModifiersResolverParamsMatcher {
+  def eqJavaModifiersResolverParams(expectedParams: JavaModifiersResolverParams): JavaModifiersResolverParams =
+    argThat(new JavaModifiersResolverParamsMatcher(expectedParams))
+}
+

--- a/src/test/scala/effiban/scala2java/resolvers/JavaAllowedModifiersResolverTest.scala
+++ b/src/test/scala/effiban/scala2java/resolvers/JavaAllowedModifiersResolverTest.scala
@@ -14,7 +14,7 @@ class JavaAllowedModifiersResolverTest extends UnitTestSuite {
     JavaModifier.Final
   )
 
-  private final val ExpectedInnerClassAllowedModifiers = Set[JavaModifier](
+  private final val ExpectedInnerClassOfClassAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
     JavaModifier.Protected,
     JavaModifier.Public,
@@ -24,14 +24,22 @@ class JavaAllowedModifiersResolverTest extends UnitTestSuite {
     JavaModifier.Final
   )
 
+  private final val ExpectedInnerClassOfInterfaceAllowedModifiers = Set[JavaModifier](
+    JavaModifier.Sealed,
+    JavaModifier.Abstract,
+    JavaModifier.Final
+  )
+
   private final val ExpectedOuterInterfaceAllowedModifiers = Set[JavaModifier](JavaModifier.Public, JavaModifier.Sealed)
 
-  private final val ExpectedInnerInterfaceAllowedModifiers = Set[JavaModifier](
+  private final val ExpectedInnerInterfaceOfClassAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
     JavaModifier.Protected,
     JavaModifier.Public,
     JavaModifier.Sealed
   )
+
+  private final val ExpectedInnerInterfaceOfInterfaceAllowedModifiers = Set[JavaModifier](JavaModifier.Sealed)
 
   private final val ExpectedClassMethodAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
@@ -44,7 +52,7 @@ class JavaAllowedModifiersResolverTest extends UnitTestSuite {
 
   private final val ExpectedInterfaceMethodAllowedModifiers = Set[JavaModifier](JavaModifier.Private, JavaModifier.Default)
 
-  private final val ExpectedClassDataMemberAllowedModifiers = Set[JavaModifier](
+  private final val ExpectedClassVariableAllowedModifiers = Set[JavaModifier](
     JavaModifier.Private,
     JavaModifier.Protected,
     JavaModifier.Public,
@@ -52,16 +60,20 @@ class JavaAllowedModifiersResolverTest extends UnitTestSuite {
     JavaModifier.Final
   )
 
+  private final val ExpectedLocalVariableAllowedModifiers = Set[JavaModifier](JavaModifier.Final)
+
+  private final val ExpectedParameterAllowedModifiers = Set[JavaModifier](JavaModifier.Final)
+
   test("resolve() for outer class") {
     resolve(JavaTreeType.Class, JavaTreeType.Package) shouldBe ExpectedOuterClassAllowedModifiers
   }
 
   test("resolve() for inner class of class") {
-    resolve(JavaTreeType.Class, JavaTreeType.Class) shouldBe ExpectedInnerClassAllowedModifiers
+    resolve(JavaTreeType.Class, JavaTreeType.Class) shouldBe ExpectedInnerClassOfClassAllowedModifiers
   }
 
   test("resolve() for inner class of interface") {
-    resolve(JavaTreeType.Class, JavaTreeType.Interface) shouldBe ExpectedInnerClassAllowedModifiers
+    resolve(JavaTreeType.Class, JavaTreeType.Interface) shouldBe ExpectedInnerClassOfInterfaceAllowedModifiers
   }
 
   test("resolve() for outer interface") {
@@ -69,11 +81,11 @@ class JavaAllowedModifiersResolverTest extends UnitTestSuite {
   }
 
   test("resolve() for inner interface of class") {
-    resolve(JavaTreeType.Interface, JavaTreeType.Class) shouldBe ExpectedInnerInterfaceAllowedModifiers
+    resolve(JavaTreeType.Interface, JavaTreeType.Class) shouldBe ExpectedInnerInterfaceOfClassAllowedModifiers
   }
 
   test("resolve() for inner interface of interface") {
-    resolve(JavaTreeType.Interface, JavaTreeType.Interface) shouldBe ExpectedInnerInterfaceAllowedModifiers
+    resolve(JavaTreeType.Interface, JavaTreeType.Interface) shouldBe ExpectedInnerInterfaceOfInterfaceAllowedModifiers
   }
 
   test("resolve() for class method") {
@@ -84,11 +96,31 @@ class JavaAllowedModifiersResolverTest extends UnitTestSuite {
     resolve(JavaTreeType.Method, JavaTreeType.Interface) shouldBe ExpectedInterfaceMethodAllowedModifiers
   }
 
-  test("resolve() for class data member") {
-    resolve(JavaTreeType.DataMember, JavaTreeType.Class) shouldBe ExpectedClassDataMemberAllowedModifiers
+  test("resolve() for class variable") {
+    resolve(JavaTreeType.Variable, JavaTreeType.Class) shouldBe ExpectedClassVariableAllowedModifiers
   }
 
-  test("resolve() for interface data member should return empty") {
-    resolve(JavaTreeType.DataMember, JavaTreeType.Interface) shouldBe Set.empty
+  test("resolve() for interface variable should return empty") {
+    resolve(JavaTreeType.Variable, JavaTreeType.Interface) shouldBe Set.empty
+  }
+
+  test("resolve() for method variable") {
+    resolve(JavaTreeType.Variable, JavaTreeType.Method) shouldBe ExpectedLocalVariableAllowedModifiers
+  }
+
+  test("resolve() for lambda variable") {
+    resolve(JavaTreeType.Variable, JavaTreeType.Lambda) shouldBe ExpectedLocalVariableAllowedModifiers
+  }
+
+  test("resolve() for class (ctor.) parameter") {
+    resolve(JavaTreeType.Parameter, JavaTreeType.Class) shouldBe ExpectedParameterAllowedModifiers
+  }
+
+  test("resolve() for method parameter") {
+    resolve(JavaTreeType.Parameter, JavaTreeType.Method) shouldBe ExpectedParameterAllowedModifiers
+  }
+
+  test("resolve() for lambda parameter") {
+    resolve(JavaTreeType.Parameter, JavaTreeType.Lambda) shouldBe ExpectedParameterAllowedModifiers
   }
 }

--- a/src/test/scala/effiban/scala2java/resolvers/JavaModifierImplyingPublicResolverTest.scala
+++ b/src/test/scala/effiban/scala2java/resolvers/JavaModifierImplyingPublicResolverTest.scala
@@ -3,42 +3,113 @@ package effiban.scala2java.resolvers
 import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.resolvers.JavaModifierImplyingPublicResolver.resolve
 import effiban.scala2java.testsuites.UnitTestSuite
+import effiban.scala2java.testtrees.{PrimaryCtors, Templates, TypeNames}
+
+import scala.meta.{Decl, Defn, Lit, Pat, Term, Type}
 
 class JavaModifierImplyingPublicResolverTest extends UnitTestSuite {
 
+  private val TheClass = Defn.Class(
+    mods = Nil,
+    name = Type.Name("MyClass"),
+    tparams = Nil,
+    ctor = PrimaryCtors.Empty,
+    templ = Templates.Empty
+  )
+
+  private val TheTrait = Defn.Trait(
+    mods = Nil,
+    name = Type.Name("MyTrait"),
+    tparams = Nil,
+    ctor = PrimaryCtors.Empty,
+    templ = Templates.Empty
+  )
+
+  private val TheDeclDef = Decl.Def(
+    mods = Nil,
+    name = Term.Name("myMethod"),
+    tparams = Nil,
+    paramss = List(Nil),
+    decltpe = Type.Name("Unit")
+  )
+
+  private val TheDefnDef = Defn.Def(
+    mods = Nil,
+    name = Term.Name("myMethod"),
+    tparams = Nil,
+    paramss = List(Nil),
+    decltpe = Some(TypeNames.Unit),
+    body = Lit.Int(3)
+  )
+
+  private val TheVal = Defn.Val(
+    mods = Nil,
+    pats = List(Pat.Var(Term.Name("x"))),
+    decltpe = Some(TypeNames.Int),
+    rhs = Lit.Int(3)
+  )
+
   test("resolve() for outer class should return 'public'") {
-    resolve(JavaTreeType.Class, JavaTreeType.Package).value shouldBe JavaModifier.Public
+    resolve(TheClass, JavaTreeType.Class, JavaTreeType.Package).value shouldBe JavaModifier.Public
   }
 
-  test("resolve() for inner class should return 'public'") {
-    resolve(JavaTreeType.Class, JavaTreeType.Class).value shouldBe JavaModifier.Public
+  test("resolve() for inner class of class should return 'public'") {
+    resolve(TheClass, JavaTreeType.Class, JavaTreeType.Class).value shouldBe JavaModifier.Public
+  }
+
+  test("resolve() for inner class of interface should return None") {
+    resolve(TheClass, JavaTreeType.Class, JavaTreeType.Interface) shouldBe None
   }
 
   test("resolve() for outer interface should return 'public'") {
-    resolve(JavaTreeType.Interface, JavaTreeType.Package).value shouldBe JavaModifier.Public
+    resolve(TheTrait, JavaTreeType.Interface, JavaTreeType.Package).value shouldBe JavaModifier.Public
   }
 
-  test("resolve() for inner interface should return 'public'") {
-    resolve(JavaTreeType.Interface, JavaTreeType.Interface).value shouldBe JavaModifier.Public
+  test("resolve() for inner interface of class should return 'public'") {
+    resolve(TheTrait, JavaTreeType.Interface, JavaTreeType.Class).value shouldBe JavaModifier.Public
+  }
+
+  test("resolve() for inner interface of interface should return None") {
+    resolve(TheTrait, JavaTreeType.Interface, JavaTreeType.Interface) shouldBe None
   }
 
   test("resolve() for class method should return 'public'") {
-    resolve(JavaTreeType.Method, JavaTreeType.Class).value shouldBe JavaModifier.Public
+    resolve(TheDefnDef, JavaTreeType.Method, JavaTreeType.Class).value shouldBe JavaModifier.Public
   }
 
   test("resolve() for interface method definition should return 'default'") {
-    resolve(JavaTreeType.Method, JavaTreeType.Interface, hasBody = true).value shouldBe JavaModifier.Default
+    resolve(TheDefnDef, JavaTreeType.Method, JavaTreeType.Interface).value shouldBe JavaModifier.Default
   }
 
   test("resolve() for interface method declaration should return None") {
-    resolve(JavaTreeType.Method, JavaTreeType.Interface) shouldBe None
+    resolve(TheDeclDef, JavaTreeType.Method, JavaTreeType.Interface) shouldBe None
   }
 
-  test("resolve() for class data member should return 'public'") {
-    resolve(JavaTreeType.DataMember, JavaTreeType.Class).value shouldBe JavaModifier.Public
+  test("resolve() for class variable should return 'public'") {
+    resolve(TheVal, JavaTreeType.Variable, JavaTreeType.Class).value shouldBe JavaModifier.Public
   }
 
-  test("resolve() for interface data member should return None") {
-    resolve(JavaTreeType.DataMember, JavaTreeType.Interface) shouldBe None
+  test("resolve() for interface variable should return None") {
+    resolve(TheVal, JavaTreeType.Variable, JavaTreeType.Interface) shouldBe None
+  }
+
+  test("resolve() for method variable should return None") {
+    resolve(TheVal, JavaTreeType.Variable, JavaTreeType.Method) shouldBe None
+  }
+
+  test("resolve() for lambda variable should return None") {
+    resolve(TheVal, JavaTreeType.Variable, JavaTreeType.Lambda) shouldBe None
+  }
+
+  test("resolve() for class (ctor.) parameter should return None since the 'public' will be transferred to a generated member") {
+    resolve(TheVal, JavaTreeType.Parameter, JavaTreeType.Class) shouldBe None
+  }
+
+  test("resolve() for method parameter should return None") {
+    resolve(TheVal, JavaTreeType.Parameter, JavaTreeType.Method) shouldBe None
+  }
+
+  test("resolve() for lambda parameter should return None") {
+    resolve(TheVal, JavaTreeType.Parameter, JavaTreeType.Lambda) shouldBe None
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/CaseClassTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/CaseClassTraverserImplTest.scala
@@ -1,11 +1,13 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.{ClassInfo, JavaModifier}
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.entities.{ClassInfo, JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.ClassInfoMatcher
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.SomeMatcher.eqSome
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -94,7 +96,7 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClass(eqTreeList(modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
     doWrite("(int arg1, int arg2)").when(termParamListTraverser).traverse(
       termParams = eqTreeList(CtorArgs1),
@@ -148,7 +150,7 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClass(eqTreeList(modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
     doWrite("(int arg1, int arg2)").when(termParamListTraverser).traverse(
       termParams = eqTreeList(CtorArgs1),
@@ -197,7 +199,7 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClass(eqTreeList(modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
     doWrite("(int arg1, int arg2, int arg3, int arg4)").when(termParamListTraverser).traverse(
       termParams = eqTreeList(CtorArgs1 ++ CtorArgs2),
@@ -223,5 +225,10 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
 
   private def termParam(name: String, typeName: String) = {
     Term.Param(mods = List(), name = Term.Name(name), decltpe = Some(Type.Name(typeName)), default = None)
+  }
+
+  private def whenResolveJavaModifiersThenReturnPublic(cls: Defn.Class, modifiers: List[Mod]): Unit = {
+    val expectedResolverParams = JavaModifiersResolverParams(cls, modifiers, JavaTreeType.Class, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams))).thenReturn(List(JavaModifier.Public))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/DeclDefTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DeclDefTraverserImplTest.scala
@@ -4,8 +4,9 @@ import effiban.scala2java.entities.JavaTreeType.Interface
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -76,7 +77,7 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(declDef).thenReturn(List(JavaModifier.Public))
     doWrite("int").when(typeTraverser).traverse(eqTree(MethodType))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -107,7 +108,7 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(declDef).thenReturn(List(JavaModifier.Public))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
     doWrite("int").when(typeTraverser).traverse(eqTree(MethodType))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
@@ -139,7 +140,7 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForInterfaceMethod(eqTreeList(Modifiers), ArgumentMatchers.eq(false))).thenReturn(List.empty)
+    whenResolveJavaModifiers(declDef).thenReturn(List.empty)
     doWrite("int").when(typeTraverser).traverse(eqTree(MethodType))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -170,7 +171,7 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForInterfaceMethod(eqTreeList(Modifiers), ArgumentMatchers.eq(false))).thenReturn(List.empty)
+    whenResolveJavaModifiers(declDef).thenReturn(List.empty)
     doWrite("int").when(typeTraverser).traverse(eqTree(MethodType))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2, int param3, int param4)").when(termParamListTraverser).traverse(
@@ -188,5 +189,10 @@ class DeclDefTraverserImplTest extends UnitTestSuite {
 
   private def termParamInt(name: String) = {
     Term.Param(mods = List(), name = Term.Name(name), decltpe = Some(TypeNames.Int), default = None)
+  }
+
+  private def whenResolveJavaModifiers(declDef: Decl.Def) = {
+    val expectedResolverParams = JavaModifiersResolverParams(declDef, Modifiers, JavaTreeType.Method, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams)))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/DeclTypeTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DeclTypeTraverserImplTest.scala
@@ -1,8 +1,10 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaModifier
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 
@@ -45,7 +47,7 @@ class DeclTypeTraverserImplTest extends UnitTestSuite {
       bounds = Bounds(lo = None, hi = Some(Type.Name("T")))
     )
 
-    when(javaModifiersResolver.resolveForInterface(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Private))
+    whenResolveJavaModifiers(declType).thenReturn(List(JavaModifier.Private))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
 
     declTypeTraverser.traverse(declType)
@@ -55,5 +57,10 @@ class DeclTypeTraverserImplTest extends UnitTestSuite {
         |private interface MyType<T> {
         |}
         |""".stripMargin
+  }
+
+  private def whenResolveJavaModifiers(declType: Decl.Type) = {
+    val expectedResolverParams = JavaModifiersResolverParams(declType, Modifiers, JavaTreeType.Interface, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams)))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/DeclVarTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DeclVarTraverserImplTest.scala
@@ -4,8 +4,9 @@ import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -49,7 +50,7 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassDataMember(eqTreeList(modifiers))).thenReturn(JavaPrivateModifiers)
+    whenResolveJavaModifiers(declVar, modifiers).thenReturn(JavaPrivateModifiers)
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -75,6 +76,7 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(declVar, modifiers).thenReturn(List.empty)
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -100,6 +102,7 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(declVar, modifiers).thenReturn(List.empty)
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -108,5 +111,10 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
     outputWriter.toString shouldBe
       """@MyAnnotation
         |int myVar""".stripMargin
+  }
+
+  private def whenResolveJavaModifiers(declVar: Decl.Var, modifiers: List[Mod]) = {
+    val expectedResolverParams = JavaModifiersResolverParams(declVar, modifiers, JavaTreeType.Variable, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams)))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/DefnDefTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnDefTraverserImplTest.scala
@@ -4,10 +4,11 @@ import effiban.scala2java.entities.JavaTreeType.Interface
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.SomeMatcher.eqSome
 import effiban.scala2java.matchers.TreeMatcher
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -86,7 +87,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     doWrite("int").when(typeTraverser).traverse(eqTree(TypeNames.Int))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -129,7 +130,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     doWrite("void").when(typeTraverser).traverse(eqTree(TypeNames.Unit))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -172,7 +173,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
     doWrite("void").when(typeTraverser).traverse(eqTree(TypeNames.Unit))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
@@ -222,7 +223,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     doWrite("").when(typeTraverser).traverse(eqTree(TypeNames.Unit))
     doWrite("MyClass").when(termNameTraverser).traverse(eqTree(ClassName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -265,7 +266,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     when(termTypeInferrer.infer(eqTree(Statement1))).thenReturn(None)
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -308,7 +309,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     when(termTypeInferrer.infer(eqTree(Statement1))).thenReturn(Some(TypeNames.String))
     doWrite("String").when(typeTraverser).traverse(eqTree(TypeNames.String))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
@@ -354,7 +355,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassMethod(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Public))
     doWrite("int").when(typeTraverser).traverse(eqTree(TypeNames.Int))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -397,8 +398,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForInterfaceMethod(eqTreeList(Modifiers), hasBody = ArgumentMatchers.eq(true)))
-      .thenReturn(List(JavaModifier.Default))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Default))
     doWrite("int").when(typeTraverser).traverse(eqTree(TypeNames.Int))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2)").when(termParamListTraverser).traverse(
@@ -441,8 +441,7 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForInterfaceMethod(eqTreeList(Modifiers), hasBody = ArgumentMatchers.eq(true)))
-      .thenReturn(List(JavaModifier.Default))
+    whenResolveJavaModifiers(defnDef).thenReturn(List(JavaModifier.Default))
     doWrite("int").when(typeTraverser).traverse(eqTree(TypeNames.Int))
     doWrite("myMethod").when(termNameTraverser).traverse(eqTree(MethodName))
     doWrite("(int param1, int param2, int param3, int param4)").when(termParamListTraverser).traverse(
@@ -471,5 +470,10 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
 
   private def termParamInt(name: String) = {
     Term.Param(mods = List(), name = Term.Name(name), decltpe = Some(TypeNames.Int), default = None)
+  }
+
+  private def whenResolveJavaModifiers(defnDef: Defn.Def) = {
+    val expectedResolverParams = JavaModifiersResolverParams(defnDef, Modifiers, JavaTreeType.Method, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams)))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/DefnTypeTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnTypeTraverserImplTest.scala
@@ -1,9 +1,11 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaModifier
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 
@@ -50,7 +52,7 @@ class DefnTypeTraverserImplTest extends UnitTestSuite {
       body = MyOtherType
     )
 
-    when(javaModifiersResolver.resolveForInterface(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Private))
+    whenResolveJavaModifiersThenReturnPrivate(defnType)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
     doWrite("MyOtherType").when(typeTraverser).traverse(eqTree(MyOtherType))
 
@@ -71,7 +73,7 @@ class DefnTypeTraverserImplTest extends UnitTestSuite {
       bounds = Bounds(lo = None, hi = Some(MyOtherType))
     )
 
-    when(javaModifiersResolver.resolveForInterface(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Private))
+    whenResolveJavaModifiersThenReturnPrivate(defnType)
     doWrite("MyOtherType").when(typeTraverser).traverse(eqTree(MyOtherType))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
 
@@ -92,7 +94,7 @@ class DefnTypeTraverserImplTest extends UnitTestSuite {
       bounds = Bounds(lo = Some(MyOtherType), hi = None)
     )
 
-    when(javaModifiersResolver.resolveForInterface(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Private))
+    whenResolveJavaModifiersThenReturnPrivate(defnType)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
 
     defnTypeTraverser.traverse(defnType)
@@ -102,4 +104,10 @@ class DefnTypeTraverserImplTest extends UnitTestSuite {
         |}
         |""".stripMargin
   }
+
+  private def whenResolveJavaModifiersThenReturnPrivate(defnType: Defn.Type): Unit = {
+    val expectedResolverParams = JavaModifiersResolverParams(defnType, Modifiers, JavaTreeType.Interface, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams))).thenReturn(List(JavaModifier.Private))
+  }
+
 }

--- a/src/test/scala/effiban/scala2java/traversers/DefnVarTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/DefnVarTraverserImplTest.scala
@@ -4,8 +4,9 @@ import effiban.scala2java.entities.JavaTreeType.{Interface, Method}
 import effiban.scala2java.entities.TraversalContext.javaScope
 import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -53,7 +54,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassDataMember(eqTreeList(Modifiers))).thenReturn(JavaPrivateModifiers)
+    whenResolveJavaModifiers(defnVar).thenReturn(JavaPrivateModifiers)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(eqSomeTree(IntType), eqSomeTree(Rhs))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
     doWrite("3").when(termTraverser).traverse(eqTree(Rhs))
@@ -79,7 +80,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassDataMember(eqTreeList(Modifiers))).thenReturn(JavaPrivateModifiers)
+    whenResolveJavaModifiers(defnVar).thenReturn(JavaPrivateModifiers)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(eqSomeTree(IntType), ArgumentMatchers.eq(None))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -104,7 +105,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClassDataMember(eqTreeList(Modifiers))).thenReturn(JavaPrivateModifiers)
+    whenResolveJavaModifiers(defnVar).thenReturn(JavaPrivateModifiers)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(ArgumentMatchers.eq(None), eqSomeTree(Rhs))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
     doWrite("3").when(termTraverser).traverse(eqTree(Rhs))
@@ -130,6 +131,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(defnVar).thenReturn(Nil)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(eqSomeTree(IntType), eqSomeTree(Rhs))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
     doWrite("3").when(termTraverser).traverse(eqTree(Rhs))
@@ -155,6 +157,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(defnVar).thenReturn(Nil)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(eqSomeTree(IntType), ArgumentMatchers.eq(None))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -179,6 +182,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(defnVar).thenReturn(Nil)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(ArgumentMatchers.eq(None), eqSomeTree(Rhs))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
     doWrite("3").when(termTraverser).traverse(eqTree(Rhs))
@@ -204,6 +208,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(defnVar).thenReturn(Nil)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(eqSomeTree(IntType), eqSomeTree(Rhs))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
     doWrite("3").when(termTraverser).traverse(eqTree(Rhs))
@@ -229,6 +234,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(defnVar).thenReturn(Nil)
     doWrite("int").when(defnValOrVarTypeTraverser).traverse(eqSomeTree(IntType), ArgumentMatchers.eq(None))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -253,6 +259,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
+    whenResolveJavaModifiers(defnVar).thenReturn(Nil)
     doWrite("var").when(defnValOrVarTypeTraverser).traverse(ArgumentMatchers.eq(None), eqSomeTree(Rhs))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
     doWrite("3").when(termTraverser).traverse(eqTree(Rhs))
@@ -262,5 +269,10 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     outputWriter.toString shouldBe
       """@MyAnnotation
         |var myVar = 3""".stripMargin
+  }
+
+  private def whenResolveJavaModifiers(defnVar: Defn.Var) = {
+    val expectedResolverParams = JavaModifiersResolverParams(defnVar, Modifiers, JavaTreeType.Variable, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams)))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/ObjectTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/ObjectTraverserImplTest.scala
@@ -1,9 +1,11 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaModifier
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.TypeNames
@@ -60,7 +62,7 @@ class ObjectTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClass(eqTreeList(modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(objectDef, modifiers)
     doWrite(
       """ {
         |  /* BODY */
@@ -82,5 +84,10 @@ class ObjectTraverserImplTest extends UnitTestSuite {
 
   private def termParam(name: String, typeName: String) = {
     Term.Param(mods = List(), name = Term.Name(name), decltpe = Some(Type.Name(typeName)), default = None)
+  }
+
+  private def whenResolveJavaModifiersThenReturnPublic(obj: Defn.Object, modifiers: List[Mod]): Unit = {
+    val expectedResolverParams = JavaModifiersResolverParams(obj, modifiers, JavaTreeType.Class, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams))).thenReturn(List(JavaModifier.Public))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/RegularClassTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/RegularClassTraverserImplTest.scala
@@ -1,12 +1,14 @@
 package effiban.scala2java.traversers
 
 import effiban.scala2java.entities
-import effiban.scala2java.entities.JavaModifier
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.ClassInfoMatcher
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.SomeMatcher.eqSome
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.transformers.ParamToDeclValTransformer
@@ -109,7 +111,7 @@ class RegularClassTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClass(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(cls)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
 
     when(paramToDeclValTransformer.transform(any[Term.Param])).thenAnswer( (ctorArg: Term.Param) => ctorArg match {
@@ -168,7 +170,7 @@ class RegularClassTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForClass(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(cls)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
 
     when(paramToDeclValTransformer.transform(any[Term.Param])).thenAnswer( (ctorArg: Term.Param) => ctorArg match {
@@ -214,5 +216,10 @@ class RegularClassTraverserImplTest extends UnitTestSuite {
       pats = List(Pat.Var(Term.Name(name))),
       decltpe = Type.Name(typeName)
     )
+  }
+
+  private def whenResolveJavaModifiersThenReturnPublic(cls: Defn.Class): Unit = {
+    val expectedResolverParams = JavaModifiersResolverParams(cls, Modifiers, JavaTreeType.Class, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams))).thenReturn(List(JavaModifier.Public))
   }
 }

--- a/src/test/scala/effiban/scala2java/traversers/TraitTraverserImplTest.scala
+++ b/src/test/scala/effiban/scala2java/traversers/TraitTraverserImplTest.scala
@@ -1,14 +1,17 @@
 package effiban.scala2java.traversers
 
-import effiban.scala2java.entities.JavaModifier
+import effiban.scala2java.entities.TraversalContext.javaScope
+import effiban.scala2java.entities.{JavaModifier, JavaTreeType}
 import effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import effiban.scala2java.matchers.JavaModifiersResolverParamsMatcher.eqJavaModifiersResolverParams
 import effiban.scala2java.matchers.TreeMatcher.eqTree
-import effiban.scala2java.resolvers.JavaModifiersResolver
+import effiban.scala2java.resolvers.{JavaModifiersResolver, JavaModifiersResolverParams}
 import effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import effiban.scala2java.testsuites.UnitTestSuite
 import effiban.scala2java.testtrees.{PrimaryCtors, TypeNames}
 import org.mockito.ArgumentMatchers
 
+import scala.meta.Defn.Trait
 import scala.meta.Term.Block
 import scala.meta.Type.Bounds
 import scala.meta.{Defn, Init, Mod, Name, Self, Template, Term, Type}
@@ -82,7 +85,7 @@ class TraitTraverserImplTest extends UnitTestSuite {
       """@MyAnnotation
         |""".stripMargin)
       .when(annotListTraverser).traverseMods(eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    when(javaModifiersResolver.resolveForInterface(eqTreeList(Modifiers))).thenReturn(List(JavaModifier.Public))
+    whenResolveJavaModifiersThenReturnPublic(`trait`)
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
 
     doWrite(
@@ -101,5 +104,10 @@ class TraitTraverserImplTest extends UnitTestSuite {
         |  /* BODY */
         |}
         |""".stripMargin
+  }
+
+  private def whenResolveJavaModifiersThenReturnPublic(`trait`: Trait): Unit = {
+    val expectedResolverParams = JavaModifiersResolverParams(`trait`, Modifiers, JavaTreeType.Interface, javaScope)
+    when(javaModifiersResolver.resolve(eqJavaModifiersResolverParams(expectedResolverParams))).thenReturn(List(JavaModifier.Public))
   }
 }


### PR DESCRIPTION
Refactored `JavaModifiersResolver` to expose only one `resolve()` method and encapsulate the logic of the different scenarios.
Also fixed some minor related bugs. 