### PR TITLE
Add TODO for handling illegal scenarios of multiple top-level definitions in Java

### DIFF
--- a/src/main/scala/effiban/scala2java/traversers/PkgTraverser.scala
+++ b/src/main/scala/effiban/scala2java/traversers/PkgTraverser.scala
@@ -22,6 +22,7 @@ private[traversers] class PkgTraverserImpl(termRefTraverser: => TermRefTraverser
 
     val outerJavaScope = javaScope
     javaScope = JavaTreeType.Package
+    // TODO handle specific scenarios  of multiple top-level definitions which are illegal in Java (such as 2 public classes in the same file)
     pkg.stats.foreach(statTraverser.traverse)
     javaScope = outerJavaScope
   }


### PR DESCRIPTION
Java allows e.g. 2 package-private top-level classes in same file, but not 2 public ones