### PR TITLE
Force upgrade of protobuf to resolve security vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ repositories {
 
 dependencies {
     implementation 'org.scalameta:scalameta_2.13:4.6.0'
+    constraints {
+        implementation('com.google.protobuf:protobuf-java:3.19.6') {
+            because 'previous versions have a security vulnerability'
+        }
+    }
 }
 
 testing {


### PR DESCRIPTION
The protobuf version 3.19.2 (brought transitively from scalameta) has [this security vulnerability](https://github.com/opensearch-project/data-prepper/issues/1891) which is blocking the release of scala2java - so I forced it to a higher maintenance version **3.19.6** until scalameta is itself upgraded.