### PR TITLE
Extract `ModListTraverser`

### DIFF
--- a/src/main/scala/io/github/effiban/scala2java/traversers/DeclDefTraverser.scala
+++ b/src/main/scala/io/github/effiban/scala2java/traversers/DeclDefTraverser.scala
@@ -3,7 +3,6 @@ package io.github.effiban.scala2java.traversers
 import io.github.effiban.scala2java.contexts.{JavaModifiersContext, StatContext}
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.entities.{JavaScope, JavaTreeType}
-import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.writers.JavaWriter
 
 import scala.meta.{Decl, Type}
@@ -12,37 +11,32 @@ trait DeclDefTraverser {
   def traverse(defDecl: Decl.Def, context: StatContext = StatContext()): Unit
 }
 
-private[traversers] class DeclDefTraverserImpl(annotListTraverser: => AnnotListTraverser,
+private[traversers] class DeclDefTraverserImpl(modListTraverser: => ModListTraverser,
                                                typeParamListTraverser: => TypeParamListTraverser,
                                                typeTraverser: => TypeTraverser,
                                                termNameTraverser: => TermNameTraverser,
-                                               termParamListTraverser: => TermParamListTraverser,
-                                               javaModifiersResolver: JavaModifiersResolver)
+                                               termParamListTraverser: => TermParamListTraverser)
                                               (implicit javaWriter: JavaWriter) extends DeclDefTraverser {
 
   import javaWriter._
 
   override def traverse(defDecl: Decl.Def, context: StatContext = StatContext()): Unit = {
     writeLine()
-    annotListTraverser.traverseMods(defDecl.mods)
-    writeModifiers(resolveJavaModifiers(defDecl, context.javaScope))
+    modListTraverser.traverse(toJavaModifiersContext(defDecl, context.javaScope))
     traverseTypeParams(defDecl.tparams)
     typeTraverser.traverse(defDecl.decltpe)
     write(" ")
     termNameTraverser.traverse(defDecl.name)
-
     termParamListTraverser.traverse(termParams = defDecl.paramss.flatten, context = StatContext(JavaScope.MethodSignature))
   }
 
-  private def resolveJavaModifiers(defDecl: Decl.Def, parentJavaScope: JavaScope) = {
-    val javaModifiersContext = JavaModifiersContext(
+  private def toJavaModifiersContext(defDecl: Decl.Def, parentJavaScope: JavaScope) =
+    JavaModifiersContext(
       scalaTree = defDecl,
       scalaMods = defDecl.mods,
       javaTreeType = JavaTreeType.Method,
       javaScope = parentJavaScope
     )
-    javaModifiersResolver.resolve(javaModifiersContext)
-  }
 
   private def traverseTypeParams(tparams: List[Type.Param]): Unit = {
     tparams match {

--- a/src/main/scala/io/github/effiban/scala2java/traversers/DeclValTraverser.scala
+++ b/src/main/scala/io/github/effiban/scala2java/traversers/DeclValTraverser.scala
@@ -3,7 +3,6 @@ package io.github.effiban.scala2java.traversers
 import io.github.effiban.scala2java.contexts.{JavaModifiersContext, StatContext}
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.entities.JavaTreeType
-import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Decl
@@ -12,32 +11,27 @@ trait DeclValTraverser {
   def traverse(valDecl: Decl.Val, context: StatContext = StatContext()): Unit
 }
 
-//TODO - if Java owner is an interface, the output should be an accessor method
-private[traversers] class DeclValTraverserImpl(annotListTraverser: => AnnotListTraverser,
+private[traversers] class DeclValTraverserImpl(modListTraverser: => ModListTraverser,
                                                typeTraverser: => TypeTraverser,
-                                               patListTraverser: => PatListTraverser,
-                                               javaModifiersResolver: JavaModifiersResolver)
+                                               patListTraverser: => PatListTraverser)
                                               (implicit javaWriter: JavaWriter) extends DeclValTraverser {
 
   import javaWriter._
 
   //TODO replace interface data member declaration (invalid in Java) with method declaration
   override def traverse(valDecl: Decl.Val, context: StatContext = StatContext()): Unit = {
-    annotListTraverser.traverseMods(valDecl.mods)
-    writeModifiers(resolveJavaModifiers(valDecl, context.javaScope))
+    modListTraverser.traverse(toJavaModifiersContext(valDecl, context.javaScope))
     typeTraverser.traverse(valDecl.decltpe)
     write(" ")
     //TODO - verify when not simple case
     patListTraverser.traverse(valDecl.pats)
   }
 
-  private def resolveJavaModifiers(valDecl: Decl.Val, javaScope: JavaScope) = {
-    val context = JavaModifiersContext(
+  private def toJavaModifiersContext(valDecl: Decl.Val, javaScope: JavaScope) =
+    JavaModifiersContext(
       scalaTree = valDecl,
       scalaMods = valDecl.mods,
       javaTreeType = JavaTreeType.Variable,
       javaScope = javaScope
     )
-    javaModifiersResolver.resolve(context)
-  }
 }

--- a/src/main/scala/io/github/effiban/scala2java/traversers/ModListTraverser.scala
+++ b/src/main/scala/io/github/effiban/scala2java/traversers/ModListTraverser.scala
@@ -1,0 +1,21 @@
+package io.github.effiban.scala2java.traversers
+
+import io.github.effiban.scala2java.contexts.JavaModifiersContext
+import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
+import io.github.effiban.scala2java.writers.JavaWriter
+
+trait ModListTraverser {
+  def traverse(javaModifiersContext: JavaModifiersContext, annotsOnSameLine: Boolean = false): Unit
+}
+
+class ModListTraverserImpl(annotListTraverser: => AnnotListTraverser,
+                           javaModifiersResolver: JavaModifiersResolver)
+                          (implicit javaWriter: JavaWriter) extends ModListTraverser {
+
+  import javaWriter._
+
+  override def traverse(javaModifiersContext: JavaModifiersContext, annotsOnSameLine: Boolean = false): Unit = {
+    annotListTraverser.traverseMods(javaModifiersContext.scalaMods, annotsOnSameLine)
+    writeModifiers(javaModifiersResolver.resolve(javaModifiersContext))
+  }
+}

--- a/src/main/scala/io/github/effiban/scala2java/traversers/ObjectTraverser.scala
+++ b/src/main/scala/io/github/effiban/scala2java/traversers/ObjectTraverser.scala
@@ -4,7 +4,7 @@ import io.github.effiban.scala2java.contexts._
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.entities.JavaTreeType.JavaTreeType
 import io.github.effiban.scala2java.entities.JavaTreeTypeToKeywordMapping
-import io.github.effiban.scala2java.resolvers.{JavaChildScopeResolver, JavaModifiersResolver, JavaTreeTypeResolver}
+import io.github.effiban.scala2java.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Defn
@@ -13,9 +13,8 @@ trait ObjectTraverser {
   def traverse(objectDef: Defn.Object, context: StatContext = StatContext()): Unit
 }
 
-private[traversers] class ObjectTraverserImpl(annotListTraverser: => AnnotListTraverser,
+private[traversers] class ObjectTraverserImpl(modListTraverser: => ModListTraverser,
                                               templateTraverser: => TemplateTraverser,
-                                              javaModifiersResolver: JavaModifiersResolver,
                                               javaTreeTypeResolver: JavaTreeTypeResolver,
                                               javaChildScopeResolver: JavaChildScopeResolver)
                                              (implicit javaWriter: JavaWriter) extends ObjectTraverser {
@@ -24,26 +23,22 @@ private[traversers] class ObjectTraverserImpl(annotListTraverser: => AnnotListTr
 
   override def traverse(objectDef: Defn.Object, context: StatContext = StatContext()): Unit = {
     writeLine()
-    annotListTraverser.traverseMods(objectDef.mods)
     val javaTreeType = javaTreeTypeResolver.resolve(JavaTreeTypeContext(objectDef, objectDef.mods))
-    writeTypeDeclaration(modifiers = resolveJavaModifiers(objectDef, javaTreeType, context.javaScope),
-      typeKeyword = JavaTreeTypeToKeywordMapping(javaTreeType),
-      name = s"${objectDef.name.toString}")
+    modListTraverser.traverse(toJavaModifiersContext(objectDef, javaTreeType, context.javaScope))
+    writeNamedType(JavaTreeTypeToKeywordMapping(javaTreeType), objectDef.name.value)
     val javaChildScope = javaChildScopeResolver.resolve(JavaChildScopeContext(objectDef, javaTreeType))
     // TODO if child scope is utility class, add private ctor.
     templateTraverser.traverse(objectDef.templ, TemplateContext(javaScope = javaChildScope))
   }
 
-  private def resolveJavaModifiers(objectDef: Defn.Object,
-                                   javaTreeType: JavaTreeType,
-                                   javaScope: JavaScope) = {
-    val javaModifiersContext = JavaModifiersContext(
+  private def toJavaModifiersContext(objectDef: Defn.Object,
+                                     javaTreeType: JavaTreeType,
+                                     javaScope: JavaScope) =
+    JavaModifiersContext(
       scalaTree = objectDef,
       scalaMods = objectDef.mods,
       javaTreeType = javaTreeType,
       javaScope = javaScope
     )
-    javaModifiersResolver.resolve(javaModifiersContext)
-  }
 }
 

--- a/src/main/scala/io/github/effiban/scala2java/traversers/ScalaTreeTraversers.scala
+++ b/src/main/scala/io/github/effiban/scala2java/traversers/ScalaTreeTraversers.scala
@@ -58,11 +58,10 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   )
 
   private lazy val caseClassTraverser: CaseClassTraverser = new CaseClassTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     termParamListTraverser,
     templateTraverser,
-    JavaModifiersResolver,
     JavaTreeTypeResolver,
     JavaChildScopeResolver
   )
@@ -78,12 +77,11 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   private lazy val ctorSecondaryTraverser: CtorSecondaryTraverser = new CtorSecondaryTraverserImpl(CtorSecondaryTransformer, defnDefTraverser)
 
   private lazy val declDefTraverser: DeclDefTraverser = new DeclDefTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     typeTraverser,
     termNameTraverser,
     termParamListTraverser,
-    JavaModifiersResolver
   )
 
   private lazy val declTraverser: DeclTraverser = new DeclTraverserImpl(
@@ -93,33 +91,30 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
     declTypeTraverser)
 
   private lazy val declTypeTraverser: DeclTypeTraverser = new DeclTypeTraverserImpl(
+    modListTraverser,
     typeParamListTraverser,
-    JavaModifiersResolver,
     JavaTreeTypeResolver)
 
   private lazy val declValTraverser: DeclValTraverser = new DeclValTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeTraverser,
-    patListTraverser,
-    JavaModifiersResolver
+    patListTraverser
   )
 
   private lazy val declVarTraverser: DeclVarTraverser = new DeclVarTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeTraverser,
-    patListTraverser,
-    JavaModifiersResolver
+    patListTraverser
   )
 
   private lazy val defnDefTraverser: DefnDefTraverser = new DefnDefTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     termNameTraverser,
     typeTraverser,
     termParamListTraverser,
     blockTraverser,
-    termTypeInferrer,
-    JavaModifiersResolver
+    termTypeInferrer
   )
 
   private lazy val defnTraverser: DefnTraverser = new DefnTraverserImpl(
@@ -133,10 +128,10 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   )
 
   private lazy val defnTypeTraverser: DefnTypeTraverser = new DefnTypeTraverserImpl(
+    modListTraverser,
     typeParamListTraverser,
     typeTraverser,
     typeBoundsTraverser,
-    JavaModifiersResolver,
     JavaTreeTypeResolver
   )
 
@@ -146,19 +141,17 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   )
 
   private lazy val defnValTraverser: DefnValTraverser = new DefnValTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     defnValOrVarTypeTraverser,
     patListTraverser,
-    rhsTermTraverser,
-    JavaModifiersResolver
+    rhsTermTraverser
   )
 
   private lazy val defnVarTraverser: DefnVarTraverser = new DefnVarTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     defnValOrVarTypeTraverser,
     patListTraverser,
-    rhsTermTraverser,
-    JavaModifiersResolver
+    rhsTermTraverser
   )
 
   private lazy val doTraverser: DoTraverser = new DoTraverserImpl(termTraverser, blockTraverser)
@@ -198,6 +191,8 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
 
   private lazy val litTraverser: LitTraverser = new LitTraverserImpl()
 
+  private lazy val modListTraverser: ModListTraverser = new ModListTraverserImpl(annotListTraverser, JavaModifiersResolver)
+
   private lazy val nameIndeterminateTraverser: NameIndeterminateTraverser = new NameIndeterminateTraverserImpl()
 
   private lazy val nameTraverser: NameTraverser = new NameTraverserImpl(
@@ -216,9 +211,8 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   )
 
   private lazy val objectTraverser: ObjectTraverser = new ObjectTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     templateTraverser,
-    JavaModifiersResolver,
     JavaTreeTypeResolver,
     JavaChildScopeResolver)
 
@@ -274,11 +268,10 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   private lazy val pkgTraverser: PkgTraverser = new PkgTraverserImpl(termRefTraverser, pkgStatListTraverser)
 
   private lazy val regularClassTraverser: RegularClassTraverser = new RegularClassTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     templateTraverser,
     ParamToDeclValTransformer,
-    JavaModifiersResolver,
     JavaTreeTypeResolver,
     JavaChildScopeResolver
   )
@@ -361,10 +354,9 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   private lazy val termParamListTraverser: TermParamListTraverser = new TermParamListTraverserImpl(argumentListTraverser, termParamTraverser)
 
   private lazy val termParamTraverser: TermParamTraverser = new TermParamTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeTraverser,
-    nameTraverser,
-    JavaModifiersResolver
+    nameTraverser
   )
 
   private lazy val termPlaceholderTraverser: TermPlaceholderTraverser = new TermPlaceholderTraverserImpl
@@ -428,10 +420,9 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   private lazy val throwTraverser: ThrowTraverser = new ThrowTraverserImpl(termTraverser)
 
   private lazy val traitTraverser: TraitTraverser = new TraitTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     templateTraverser,
-    JavaModifiersResolver,
     JavaTreeTypeResolver,
     JavaChildScopeResolver
   )

--- a/src/main/scala/io/github/effiban/scala2java/traversers/TermParamTraverser.scala
+++ b/src/main/scala/io/github/effiban/scala2java/traversers/TermParamTraverser.scala
@@ -3,7 +3,6 @@ package io.github.effiban.scala2java.traversers
 import io.github.effiban.scala2java.contexts.{JavaModifiersContext, StatContext}
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.entities.JavaTreeType
-import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.writers.JavaWriter
 
 import scala.meta.Term
@@ -12,10 +11,9 @@ trait TermParamTraverser {
   def traverse(termParam: Term.Param, context: StatContext): Unit
 }
 
-private[traversers] class TermParamTraverserImpl(annotListTraverser: => AnnotListTraverser,
+private[traversers] class TermParamTraverserImpl(modListTraverser: => ModListTraverser,
                                                  typeTraverser: => TypeTraverser,
-                                                 nameTraverser: => NameTraverser,
-                                                 javaModifiersResolver: JavaModifiersResolver)
+                                                 nameTraverser: => NameTraverser)
                                                 (implicit javaWriter: JavaWriter) extends TermParamTraverser {
 
   import javaWriter._
@@ -24,8 +22,7 @@ private[traversers] class TermParamTraverserImpl(annotListTraverser: => AnnotLis
   // Note that a primary ctor. param in Scala is also a class member which requires additional handling,
   // but that aspect will be handled by one of the parent traversers before this one is called
   override def traverse(termParam: Term.Param, context: StatContext): Unit = {
-    annotListTraverser.traverseMods(termParam.mods, onSameLine = true)
-    writeModifiers(resolveJavaModifiers(termParam, context.javaScope))
+    modListTraverser.traverse(toJavaModifiersContext(termParam, context.javaScope), annotsOnSameLine = true)
     termParam.decltpe.foreach(declType => {
       typeTraverser.traverse(declType)
       write(" ")
@@ -34,13 +31,11 @@ private[traversers] class TermParamTraverserImpl(annotListTraverser: => AnnotLis
     termParam.default.foreach(default => writeComment(s"= ${default.toString()}"))
   }
 
-  private def resolveJavaModifiers(termParam: Term.Param, parentJavaScope: JavaScope) = {
-    val context = JavaModifiersContext(
+  private def toJavaModifiersContext(termParam: Term.Param, parentJavaScope: JavaScope) =
+    JavaModifiersContext(
       scalaTree = termParam,
       scalaMods = termParam.mods,
       javaTreeType = JavaTreeType.Parameter,
       javaScope = parentJavaScope
     )
-    javaModifiersResolver.resolve(context)
-  }
 }

--- a/src/main/scala/io/github/effiban/scala2java/writers/JavaWriter.scala
+++ b/src/main/scala/io/github/effiban/scala2java/writers/JavaWriter.scala
@@ -9,6 +9,7 @@ trait JavaWriter {
 
   def writeTypeDeclaration(modifiers: List[JavaModifier], typeKeyword: JavaKeyword, name: String): Unit
 
+  def writeNamedType(typeKeyword: JavaKeyword, name: String): Unit
   def writeModifiers(modifiers: List[JavaModifier]): Unit
 
   def writeKeyword(keyword: JavaKeyword): Unit
@@ -51,6 +52,10 @@ class JavaWriterImpl(writer: Writer) extends JavaWriter {
 
   override def writeTypeDeclaration(modifiers: List[JavaModifier], typeKeyword: JavaKeyword, name: String): Unit = {
     writeModifiers(modifiers)
+    writeNamedType(typeKeyword, name)
+  }
+
+  override def writeNamedType(typeKeyword: JavaKeyword, name: String): Unit = {
     write(s"${typeKeyword.name} $name")
   }
 

--- a/src/test/scala/io/github/effiban/scala2java/matchers/JavaModifiersContextMatcher.scala
+++ b/src/test/scala/io/github/effiban/scala2java/matchers/JavaModifiersContextMatcher.scala
@@ -11,7 +11,7 @@ class JavaModifiersContextMatcher(expectedContext: JavaModifiersContext) extends
   override def matches(actualContext: JavaModifiersContext): Boolean = {
     scalaTreeMatches(actualContext) &&
       scalaModsMatch(actualContext) &&
-      actualContext.javaTreeType == expectedContext.javaTreeType
+      actualContext.javaTreeType == expectedContext.javaTreeType &&
       actualContext.javaScope == expectedContext.javaScope
   }
 

--- a/src/test/scala/io/github/effiban/scala2java/testwriters/TestJavaWriter.scala
+++ b/src/test/scala/io/github/effiban/scala2java/testwriters/TestJavaWriter.scala
@@ -9,6 +9,10 @@ import java.io.StringWriter
 class TestJavaWriter(sw: StringWriter) extends JavaWriter {
   override def writeTypeDeclaration(modifiers: List[JavaModifier], typeKeyword: JavaKeyword, name: String): Unit = {
     writeModifiers(modifiers)
+    writeNamedType(typeKeyword, name)
+  }
+
+  override def writeNamedType(typeKeyword: JavaKeyword, name: String): Unit = {
     write(s"${typeKeyword.name} $name")
   }
 

--- a/src/test/scala/io/github/effiban/scala2java/traversers/CaseClassTraverserImplTest.scala
+++ b/src/test/scala/io/github/effiban/scala2java/traversers/CaseClassTraverserImplTest.scala
@@ -1,14 +1,14 @@
 package io.github.effiban.scala2java.traversers
 
 import io.github.effiban.scala2java.contexts._
-import io.github.effiban.scala2java.entities.{JavaModifier, JavaScope, JavaTreeType}
+import io.github.effiban.scala2java.entities.{JavaScope, JavaTreeType}
 import io.github.effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.matchers.JavaChildScopeContextMatcher.eqJavaChildScopeContext
 import io.github.effiban.scala2java.matchers.JavaModifiersContextMatcher.eqJavaModifiersContext
 import io.github.effiban.scala2java.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.matchers.TemplateContextMatcher.eqTemplateContext
 import io.github.effiban.scala2java.matchers.TreeMatcher.eqTree
-import io.github.effiban.scala2java.resolvers.{JavaChildScopeResolver, JavaModifiersResolver, JavaTreeTypeResolver}
+import io.github.effiban.scala2java.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.testtrees.TypeNames
@@ -60,22 +60,20 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
     )
   )
 
-  private val annotListTraverser = mock[AnnotListTraverser]
+  private val modListTraverser = mock[ModListTraverser]
   private val typeParamListTraverser = mock[TypeParamListTraverser]
   private val termParamListTraverser = mock[TermParamListTraverser]
   private val templateTraverser = mock[TemplateTraverser]
-  private val javaModifiersResolver = mock[JavaModifiersResolver]
   private val javaTreeTypeResolver = mock[JavaTreeTypeResolver]
   private val javaChildScopeResolver = mock[JavaChildScopeResolver]
 
 
 
   private val classTraverser = new CaseClassTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     termParamListTraverser,
     templateTraverser,
-    javaModifiersResolver,
     javaTreeTypeResolver,
     javaChildScopeResolver)
 
@@ -101,19 +99,17 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
       templ = TheTemplate
     )
 
-    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
-
+    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
-    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
+        |public """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(cls, modifiers), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
+    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
     doWrite("(int arg1, int arg2)").when(termParamListTraverser).traverse(
-      termParams = eqTreeList(CtorArgs1),
-      context = ArgumentMatchers.eq(StatContext(JavaScope.Class)),
-      onSameLine = ArgumentMatchers.eq(false)
+        termParams = eqTreeList(CtorArgs1),
+        context = ArgumentMatchers.eq(StatContext(JavaScope.Class)),
+        onSameLine = ArgumentMatchers.eq(false)
     )
     doWrite(
       """ {
@@ -160,15 +156,13 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
       templ = TheTemplate
     )
 
-    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
-
+    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
-    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
+        |public """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(cls, modifiers), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
+    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
     doWrite("(int arg1, int arg2)").when(termParamListTraverser).traverse(
       termParams = eqTreeList(CtorArgs1),
       context = ArgumentMatchers.eq(StatContext(JavaScope.Class)),
@@ -215,15 +209,13 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
 
     val permittedSubTypeNames = List(Type.Name("A"), Term.Name("B"))
 
-    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
-
+    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
-    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
+        |public """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(cls, modifiers), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
+    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
     doWrite("(int arg1, int arg2)").when(termParamListTraverser).traverse(
       termParams = eqTreeList(CtorArgs1),
       context = ArgumentMatchers.eq(StatContext(JavaScope.Class)),
@@ -276,15 +268,13 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
       templ = TheTemplate
     )
 
-    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
-
+    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaTreeTypeThenReturnRecord(cls, modifiers)
-    whenResolveJavaModifiersThenReturnPublic(cls, modifiers)
+        |public """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(cls, modifiers), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
+    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(cls, JavaTreeType.Record)))).thenReturn(JavaScope.Class)
     doWrite("(int arg1, int arg2, int arg3, int arg4)").when(termParamListTraverser).traverse(
       termParams = eqTreeList(CtorArgs1 ++ CtorArgs2),
       context = ArgumentMatchers.eq(StatContext(JavaScope.Class)),
@@ -319,9 +309,8 @@ class CaseClassTraverserImplTest extends UnitTestSuite {
     when(javaTreeTypeResolver.resolve(eqJavaTreeTypeContext(expectedContext))).thenReturn(JavaTreeType.Record)
   }
 
-  private def whenResolveJavaModifiersThenReturnPublic(cls: Defn.Class, modifiers: List[Mod]): Unit = {
-    val expectedJavaModifiersContext = JavaModifiersContext(cls, modifiers, JavaTreeType.Class, JavaScope.Package)
-    when(javaModifiersResolver.resolve(eqJavaModifiersContext(expectedJavaModifiersContext))).thenReturn(List(JavaModifier.Public))
+  private def eqExpectedModifiers(classDef: Defn.Class, modifiers: List[Mod]) = {
+    val expectedJavaModifiersContext = JavaModifiersContext(classDef, modifiers, JavaTreeType.Record, JavaScope.Package)
+    eqJavaModifiersContext(expectedJavaModifiersContext)
   }
-
 }

--- a/src/test/scala/io/github/effiban/scala2java/traversers/DeclValTraverserImplTest.scala
+++ b/src/test/scala/io/github/effiban/scala2java/traversers/DeclValTraverserImplTest.scala
@@ -2,11 +2,10 @@ package io.github.effiban.scala2java.traversers
 
 import io.github.effiban.scala2java.contexts.{JavaModifiersContext, StatContext}
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
-import io.github.effiban.scala2java.entities.{JavaModifier, JavaScope, JavaTreeType}
+import io.github.effiban.scala2java.entities.{JavaScope, JavaTreeType}
 import io.github.effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.matchers.JavaModifiersContextMatcher.eqJavaModifiersContext
 import io.github.effiban.scala2java.matchers.TreeMatcher.eqTree
-import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.testtrees.TypeNames
@@ -16,42 +15,37 @@ import scala.meta.{Decl, Init, Mod, Name, Pat, Term, Type}
 
 class DeclValTraverserImplTest extends UnitTestSuite {
 
-  private val JavaPrivateFinalModifiers = List(JavaModifier.Private, JavaModifier.Final)
   private val IntType = TypeNames.Int
   private val MyValPat = Pat.Var(Term.Name("myVal"))
 
   private val TheAnnot = Mod.Annot(
     Init(tpe = Type.Name("MyAnnotation"), name = Name.Anonymous(), argss = List())
   )
+  private val Modifiers = List(TheAnnot)
 
-  private val annotListTraverser = mock[AnnotListTraverser]
+  private val modListTraverser = mock[ModListTraverser]
   private val typeTraverser = mock[TypeTraverser]
   private val patListTraverser = mock[PatListTraverser]
-  private val javaModifiersResolver = mock[JavaModifiersResolver]
 
   private val declValTraverser = new DeclValTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeTraverser,
-    patListTraverser,
-    javaModifiersResolver)
+    patListTraverser)
 
 
   test("traverse() when it is a class member") {
     val javaScope = JavaScope.Class
 
-    val modifiers = List(TheAnnot)
-
     val declVal = Decl.Val(
-      mods = modifiers,
+      mods = Modifiers,
       pats = List(MyValPat),
       decltpe = IntType
     )
 
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(declVal, modifiers, javaScope).thenReturn(JavaPrivateFinalModifiers)
+        |private final """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(declVal, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVal").when(patListTraverser).traverse(eqTreeList(List(MyValPat)))
 
@@ -76,8 +70,7 @@ class DeclValTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(declVal, modifiers, javaScope).thenReturn(List.empty)
+      .when(modListTraverser).traverse(eqExpectedModifiers(declVal, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVal").when(patListTraverser).traverse(eqTreeList(List(MyValPat)))
 
@@ -88,8 +81,8 @@ class DeclValTraverserImplTest extends UnitTestSuite {
         |int myVal""".stripMargin
   }
 
-  private def whenResolveJavaModifiers(declVal: Decl.Val, modifiers: List[Mod], javaScope: JavaScope) = {
-    val expectedJavaModifiersContext = JavaModifiersContext(declVal, modifiers, JavaTreeType.Variable, javaScope)
-    when(javaModifiersResolver.resolve(eqJavaModifiersContext(expectedJavaModifiersContext)))
+  private def eqExpectedModifiers(declVal: Decl.Val, javaScope: JavaScope) = {
+    val expectedJavaModifiersContext = JavaModifiersContext(declVal, Modifiers, JavaTreeType.Variable, javaScope)
+    eqJavaModifiersContext(expectedJavaModifiersContext)
   }
 }

--- a/src/test/scala/io/github/effiban/scala2java/traversers/DeclVarTraverserImplTest.scala
+++ b/src/test/scala/io/github/effiban/scala2java/traversers/DeclVarTraverserImplTest.scala
@@ -2,11 +2,10 @@ package io.github.effiban.scala2java.traversers
 
 import io.github.effiban.scala2java.contexts.{JavaModifiersContext, StatContext}
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
-import io.github.effiban.scala2java.entities.{JavaModifier, JavaScope, JavaTreeType}
+import io.github.effiban.scala2java.entities.{JavaScope, JavaTreeType}
 import io.github.effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.matchers.JavaModifiersContextMatcher.eqJavaModifiersContext
 import io.github.effiban.scala2java.matchers.TreeMatcher.eqTree
-import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.testtrees.TypeNames
@@ -16,41 +15,37 @@ import scala.meta.{Decl, Init, Mod, Name, Pat, Term, Type}
 
 class DeclVarTraverserImplTest extends UnitTestSuite {
 
-  private val JavaPrivateModifiers = List(JavaModifier.Private)
   private val TheAnnot = Mod.Annot(
     Init(tpe = Type.Name("MyAnnotation"), name = Name.Anonymous(), argss = List())
   )
+  private val Modifiers = List(TheAnnot)
   private val IntType = TypeNames.Int
   private val MyVarPat = Pat.Var(Term.Name("myVar"))
 
-  private val annotListTraverser = mock[AnnotListTraverser]
+  private val modListTraverser = mock[ModListTraverser]
   private val typeTraverser = mock[TypeTraverser]
   private val patListTraverser = mock[PatListTraverser]
-  private val javaModifiersResolver = mock[JavaModifiersResolver]
 
   private val declVarTraverser = new DeclVarTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeTraverser,
-    patListTraverser,
-    javaModifiersResolver)
+    patListTraverser
+  )
 
 
   test("traverse() when it is a class member") {
     val javaScope = JavaScope.Class
 
-    val modifiers = List(TheAnnot)
-
     val declVar = Decl.Var(
-      mods = modifiers,
+      mods = Modifiers,
       pats = List(MyVarPat),
       decltpe = IntType
     )
 
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(declVar, modifiers, javaScope).thenReturn(JavaPrivateModifiers)
+        |private """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(declVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -75,8 +70,7 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(declVar, modifiers, javaScope).thenReturn(List.empty)
+      .when(modListTraverser).traverse(eqExpectedModifiers(declVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -101,8 +95,7 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(declVar, modifiers, javaScope).thenReturn(List.empty)
+      .when(modListTraverser).traverse(eqExpectedModifiers(declVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int").when(typeTraverser).traverse(eqTree(IntType))
     doWrite("myVar").when(patListTraverser).traverse(eqTreeList(List(MyVarPat)))
 
@@ -113,8 +106,8 @@ class DeclVarTraverserImplTest extends UnitTestSuite {
         |int myVar""".stripMargin
   }
 
-  private def whenResolveJavaModifiers(declVar: Decl.Var, modifiers: List[Mod], javaScope: JavaScope) = {
-    val expectedJavaModifiersContext = JavaModifiersContext(declVar, modifiers, JavaTreeType.Variable, javaScope)
-    when(javaModifiersResolver.resolve(eqJavaModifiersContext(expectedJavaModifiersContext)))
+  private def eqExpectedModifiers(declVar: Decl.Var, javaScope: JavaScope) = {
+    val expectedJavaModifiersContext = JavaModifiersContext(declVar, Modifiers, JavaTreeType.Variable, javaScope)
+    eqJavaModifiersContext(expectedJavaModifiersContext)
   }
 }

--- a/src/test/scala/io/github/effiban/scala2java/traversers/DefnVarTraverserImplTest.scala
+++ b/src/test/scala/io/github/effiban/scala2java/traversers/DefnVarTraverserImplTest.scala
@@ -2,11 +2,10 @@ package io.github.effiban.scala2java.traversers
 
 import io.github.effiban.scala2java.contexts.{JavaModifiersContext, StatContext}
 import io.github.effiban.scala2java.entities.JavaScope.JavaScope
-import io.github.effiban.scala2java.entities.{JavaModifier, JavaScope, JavaTreeType}
+import io.github.effiban.scala2java.entities.{JavaScope, JavaTreeType}
 import io.github.effiban.scala2java.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
 import io.github.effiban.scala2java.matchers.JavaModifiersContextMatcher.eqJavaModifiersContext
 import io.github.effiban.scala2java.matchers.TreeMatcher.eqTree
-import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.testtrees.TypeNames
@@ -16,7 +15,6 @@ import scala.meta.{Defn, Init, Lit, Mod, Name, Pat, Term, Type}
 
 class DefnVarTraverserImplTest extends UnitTestSuite {
 
-  private val JavaPrivateModifiers = List(JavaModifier.Private)
   private val Modifiers = List(
     Mod.Annot(
       Init(tpe = Type.Name("MyAnnotation"), name = Name.Anonymous(), argss = List())
@@ -26,18 +24,16 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
   private val MyVarPat = Pat.Var(Term.Name("myVar"))
   private val Rhs = Lit.Int(3)
 
-  private val annotListTraverser = mock[AnnotListTraverser]
+  private val modListTraverser = mock[ModListTraverser]
   private val defnValOrVarTypeTraverser = mock[DefnValOrVarTypeTraverser]
   private val patListTraverser = mock[PatListTraverser]
   private val rhsTermTraverser = mock[RhsTermTraverser]
-  private val javaModifiersResolver = mock[JavaModifiersResolver]
 
   private val defnVarTraverser = new DefnVarTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     defnValOrVarTypeTraverser,
     patListTraverser,
-    rhsTermTraverser,
-    javaModifiersResolver)
+    rhsTermTraverser)
 
 
   test("traverse() when it is a class member - typed with value") {
@@ -52,9 +48,8 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
 
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(JavaPrivateModifiers)
+        |private """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       eqSomeTree(IntType),
@@ -83,9 +78,8 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
 
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(JavaPrivateModifiers)
+        |private """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       eqSomeTree(IntType),
@@ -113,9 +107,8 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
 
     doWrite(
       """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(JavaPrivateModifiers)
+        |private """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       ArgumentMatchers.eq(None),
@@ -145,8 +138,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(Nil)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       eqSomeTree(IntType),
@@ -176,8 +168,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(Nil)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       eqSomeTree(IntType),
@@ -206,8 +197,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(Nil)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       ArgumentMatchers.eq(None),
@@ -237,8 +227,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(Nil)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int").when(
       defnValOrVarTypeTraverser).traverse(
       eqSomeTree(IntType),
@@ -268,8 +257,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(Nil)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("int")
       .when(defnValOrVarTypeTraverser).traverse(
       eqSomeTree(IntType),
@@ -298,8 +286,7 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
     doWrite(
       """@MyAnnotation
         |""".stripMargin)
-      .when(annotListTraverser).traverseMods(mods = eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
-    whenResolveJavaModifiers(defnVar, javaScope).thenReturn(Nil)
+      .when(modListTraverser).traverse(eqExpectedModifiers(defnVar, javaScope), annotsOnSameLine = ArgumentMatchers.eq(false))
     doWrite("var")
       .when(defnValOrVarTypeTraverser).traverse(
       ArgumentMatchers.eq(None),
@@ -316,8 +303,8 @@ class DefnVarTraverserImplTest extends UnitTestSuite {
         |var myVar = 3""".stripMargin
   }
 
-  private def whenResolveJavaModifiers(defnVar: Defn.Var, javaScope: JavaScope) = {
+  private def eqExpectedModifiers(defnVar: Defn.Var, javaScope: JavaScope) = {
     val expectedJavaModifiersContext = JavaModifiersContext(defnVar, Modifiers, JavaTreeType.Variable, javaScope)
-    when(javaModifiersResolver.resolve(eqJavaModifiersContext(expectedJavaModifiersContext)))
+    eqJavaModifiersContext(expectedJavaModifiersContext)
   }
 }

--- a/src/test/scala/io/github/effiban/scala2java/traversers/ModListTraverserImplTest.scala
+++ b/src/test/scala/io/github/effiban/scala2java/traversers/ModListTraverserImplTest.scala
@@ -1,0 +1,52 @@
+package io.github.effiban.scala2java.traversers
+
+import io.github.effiban.scala2java.contexts.JavaModifiersContext
+import io.github.effiban.scala2java.entities.{JavaModifier, JavaScope, JavaTreeType}
+import io.github.effiban.scala2java.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.matchers.JavaModifiersContextMatcher.eqJavaModifiersContext
+import io.github.effiban.scala2java.resolvers.JavaModifiersResolver
+import io.github.effiban.scala2java.stubbers.OutputWriterStubber.doWrite
+import io.github.effiban.scala2java.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.testtrees.TypeNames
+import org.mockito.ArgumentMatchers
+
+import scala.meta.{Decl, Mod, Name, Pat, Term}
+
+class ModListTraverserImplTest extends UnitTestSuite {
+
+  private val Mods = List(Mod.Private(Name.Anonymous()))
+  private val Pats = List(Pat.Var(Term.Name("x")))
+  private val TheDeclVal = Decl.Val(Mods, Pats, TypeNames.Int)
+  private val TheModifiersContext = JavaModifiersContext(TheDeclVal, Mods, JavaTreeType.Variable, JavaScope.Class)
+
+  private val annotListTraverser = mock[AnnotListTraverser]
+  private val javaModifiersResolver = mock[JavaModifiersResolver]
+
+  private val modListTraverser = new ModListTraverserImpl(annotListTraverser, javaModifiersResolver)
+
+  test("traverse when annotations not on same line") {
+    doWrite(
+      """@MyAnnotation
+      |""".stripMargin)
+      .when(annotListTraverser).traverseMods(eqTreeList(Mods), onSameLine = ArgumentMatchers.eq(false))
+    when(javaModifiersResolver.resolve(eqJavaModifiersContext(TheModifiersContext)))
+      .thenReturn(List(JavaModifier.Private, JavaModifier.Final))
+
+    modListTraverser.traverse(TheModifiersContext)
+
+    outputWriter.toString shouldBe
+      """@MyAnnotation
+        |private final """.stripMargin
+  }
+
+  test("traverse when annotations on same line") {
+    doWrite("@MyAnnotation ")
+      .when(annotListTraverser).traverseMods(eqTreeList(Mods), onSameLine = ArgumentMatchers.eq(true))
+    when(javaModifiersResolver.resolve(eqJavaModifiersContext(TheModifiersContext)))
+      .thenReturn(List(JavaModifier.Private, JavaModifier.Final))
+
+    modListTraverser.traverse(TheModifiersContext, annotsOnSameLine = true)
+
+    outputWriter.toString shouldBe "@MyAnnotation private final "
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2java/traversers/TraitTraverserImplTest.scala
+++ b/src/test/scala/io/github/effiban/scala2java/traversers/TraitTraverserImplTest.scala
@@ -2,14 +2,14 @@ package io.github.effiban.scala2java.traversers
 
 import io.github.effiban.scala2java.contexts._
 import io.github.effiban.scala2java.entities.JavaTreeType.Interface
-import io.github.effiban.scala2java.entities.{JavaModifier, JavaScope, JavaTreeType}
+import io.github.effiban.scala2java.entities.{JavaScope, JavaTreeType}
 import io.github.effiban.scala2java.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.matchers.JavaChildScopeContextMatcher.eqJavaChildScopeContext
 import io.github.effiban.scala2java.matchers.JavaModifiersContextMatcher.eqJavaModifiersContext
 import io.github.effiban.scala2java.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.matchers.TemplateContextMatcher.eqTemplateContext
 import io.github.effiban.scala2java.matchers.TreeMatcher.eqTree
-import io.github.effiban.scala2java.resolvers.{JavaChildScopeResolver, JavaModifiersResolver, JavaTreeTypeResolver}
+import io.github.effiban.scala2java.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.testtrees.{PrimaryCtors, TypeNames}
@@ -63,19 +63,17 @@ class TraitTraverserImplTest extends UnitTestSuite {
       )
     )
 
-  private val annotListTraverser = mock[AnnotListTraverser]
+  private val modListTraverser = mock[ModListTraverser]
   private val typeParamListTraverser = mock[TypeParamListTraverser]
   private val templateTraverser = mock[TemplateTraverser]
-  private val javaModifiersResolver = mock[JavaModifiersResolver]
   private val javaTreeTypeResolver = mock[JavaTreeTypeResolver]
   private val javaChildScopeResolver = mock[JavaChildScopeResolver]
 
 
   private val traitTraverser = new TraitTraverserImpl(
-    annotListTraverser,
+    modListTraverser,
     typeParamListTraverser,
     templateTraverser,
-    javaModifiersResolver,
     javaTreeTypeResolver,
     javaChildScopeResolver
   )
@@ -92,24 +90,22 @@ class TraitTraverserImplTest extends UnitTestSuite {
 
     val permittedSubTypeNames = List(Type.Name("A"), Term.Name("B"))
 
-    doWrite(
-      """@MyAnnotation
-        |""".stripMargin)
-      .when(annotListTraverser).traverseMods(eqTreeList(Modifiers), onSameLine = ArgumentMatchers.eq(false))
     whenResolveJavaTreeTypeThenReturnInterface(`trait`)
-    whenResolveJavaModifiersThenReturnPublic(`trait`)
-    doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
-
     doWrite(
-      """ {
+    """@MyAnnotation
+        |public """.stripMargin)
+      .when(modListTraverser).traverse(eqExpectedModifiers(`trait`), annotsOnSameLine = ArgumentMatchers.eq(false))
+    doWrite("<T>").when(typeParamListTraverser).traverse(eqTreeList(TypeParams))
+    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(`trait`, JavaTreeType.Interface)))).thenReturn(JavaScope.Interface)
+    doWrite(
+    """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(templateTraverser).traverse(
-      eqTree(TheTemplate),
-      eqTemplateContext(TemplateContext(javaScope = JavaScope.Interface, permittedSubTypeNames = permittedSubTypeNames)))
+        eqTree(TheTemplate),
+        eqTemplateContext(TemplateContext(javaScope = JavaScope.Interface, permittedSubTypeNames = permittedSubTypeNames)))
 
-    when(javaChildScopeResolver.resolve(eqJavaChildScopeContext(JavaChildScopeContext(`trait`, JavaTreeType.Interface)))).thenReturn(JavaScope.Interface)
 
     val context = ClassOrTraitContext(javaScope = JavaScope.Package, permittedSubTypeNames = permittedSubTypeNames)
     traitTraverser.traverse(`trait`, context)
@@ -128,8 +124,8 @@ class TraitTraverserImplTest extends UnitTestSuite {
     when(javaTreeTypeResolver.resolve(eqJavaTreeTypeContext(expectedJavaTreeTypeContext))).thenReturn(Interface)
   }
 
-  private def whenResolveJavaModifiersThenReturnPublic(`trait`: Trait): Unit = {
-    val expectedJavaModifiersContext = JavaModifiersContext(`trait`, Modifiers, Interface, JavaScope.Package)
-    when(javaModifiersResolver.resolve(eqJavaModifiersContext(expectedJavaModifiersContext))).thenReturn(List(JavaModifier.Public))
+  private def eqExpectedModifiers(`trait`: Trait) = {
+    val expectedJavaModifiersContext = JavaModifiersContext(`trait`, Modifiers, JavaTreeType.Interface, JavaScope.Package)
+    eqJavaModifiersContext(expectedJavaModifiersContext)
   }
 }


### PR DESCRIPTION
Combine the traversal of annotations and visibility modifiers, which repeat often - into a single traverser