### PR TITLE
Extract most of the build logic to a convention plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation 'gradle.plugin.com.github.maiflai:gradle-scalatest:0.32'
+}

--- a/buildSrc/src/main/groovy/scala2java.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/scala2java.library-conventions.gradle
@@ -1,0 +1,117 @@
+plugins {
+    id 'java-library'
+    id 'scala'
+    id 'com.github.maiflai.scalatest'
+    id 'maven-publish'
+    id 'signing'
+}
+
+group 'io.github.effiban'
+version '2.0.0-alpha'
+
+project.ext.scalaMajorVersion = "2.13"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+
+    withJavadocJar()
+    withSourcesJar()
+}
+
+repositories {
+    mavenCentral()
+}
+
+testing {
+    suites {
+        test {
+            dependencies {
+                implementation "org.scalatest:scalatest_$scalaMajorVersion:3.2.12"
+                implementation "org.mockito:mockito-scala_$scalaMajorVersion:1.17.5"
+                runtimeOnly 'com.vladsch.flexmark:flexmark-all:0.64.0'
+            }
+            targets {
+                all {
+                    testTask.configure {
+                        maxParallelForks = 1
+                    }
+                }
+            }
+        }
+        integrationTest(JvmTestSuite) {
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
+}
+
+sourceSets {
+    integrationTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+tasks.named('check') {
+    dependsOn(testing.suites.integrationTest)
+}
+
+publishing {
+    publications {
+        scala2java(MavenPublication) {
+            artifactId = "${project.name}_$scalaMajorVersion"
+            from components.java
+
+            pom {
+                url = 'https://github.com/effiban/scala2java'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'effiban'
+                        name = 'Effi Ban'
+                        email = 'effi.ban@skai.io'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/effiban/scala2java.git'
+                    developerConnection = 'scm:git:ssh://github.com/effiban/scala2java.git'
+                    url = 'https://github.com/effiban/scala2java'
+                }
+            }
+        }
+    }
+    repositories {
+
+        def user = project.hasProperty('ossrhUsername') ? "$ossrhUsername" : ''
+        def pass = project.hasProperty('ossrhPassword') ? "$ossrhPassword" : ''
+
+        maven {
+            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username = user
+                password = pass
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.scala2java
+}

--- a/scala2java-core/build.gradle
+++ b/scala2java-core/build.gradle
@@ -1,28 +1,6 @@
 plugins {
-    id 'java-library'
-    id 'scala'
-    id "com.github.maiflai.scalatest" version "0.32"
+    id 'scala2java.library-conventions'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
-    id 'maven-publish'
-    id 'signing'
-}
-
-def scalaMajorVersion = "2.13"
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-
-    withJavadocJar()
-    withSourcesJar()
-}
-
-group 'io.github.effiban'
-version '2.0.0-alpha'
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -32,50 +10,6 @@ dependencies {
             because 'previous versions have a security vulnerability'
         }
     }
-}
-
-testing {
-    suites {
-        test {
-            dependencies {
-                implementation "org.scalatest:scalatest_$scalaMajorVersion:3.2.12"
-                implementation "org.mockito:mockito-scala_$scalaMajorVersion:1.17.5"
-                runtimeOnly 'com.vladsch.flexmark:flexmark-all:0.64.0'
-            }
-            targets {
-                all {
-                    testTask.configure {
-                        maxParallelForks = 1
-                    }
-                }
-            }
-        }
-        integrationTest(JvmTestSuite) {
-            targets {
-                all {
-                    testTask.configure {
-                        shouldRunAfter(test)
-                    }
-                }
-            }
-        }
-    }
-}
-
-sourceSets {
-    integrationTest {
-        compileClasspath += sourceSets.main.output
-        runtimeClasspath += sourceSets.main.output
-    }
-}
-
-configurations {
-    integrationTestImplementation.extendsFrom testImplementation
-    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
-}
-
-tasks.named('check') {
-    dependsOn(testing.suites.integrationTest)
 }
 
 jar {
@@ -90,50 +24,11 @@ shadowJar {
 
 publishing {
     publications {
-        scala2javaCore(MavenPublication) {
-            artifactId = "${project.name}_$scalaMajorVersion"
-            from components.java
-
+        scala2java(MavenPublication) {
             pom {
                 name = 'Scala2Java'
                 description = 'Tool for translating Scala source files into Java'
-                url = 'https://github.com/effiban/scala2java'
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'effiban'
-                        name = 'Effi Ban'
-                        email = 'effi.ban@skai.io'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/effiban/scala2java.git'
-                    developerConnection = 'scm:git:ssh://github.com/effiban/scala2java.git'
-                    url = 'https://github.com/effiban/scala2java'
-                }
             }
         }
     }
-    repositories {
-
-        def user = project.hasProperty('ossrhUsername') ? "$ossrhUsername" : ''
-        def pass = project.hasProperty('ossrhPassword') ? "$ossrhPassword" : ''
-
-        maven {
-            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            credentials {
-                username = user
-                password = pass
-            }
-        }
-    }
-}
-
-signing {
-    sign publishing.publications.scala2javaCore
 }


### PR DESCRIPTION
Extracting most of the buld logic from **scala2java-core/build.gradle** to a [convention plugin](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins) - so it can be shared later on with additional sub-projects.