### PR TITLE
Infra for dynamic extensions (plugins) + allow extending Java imports

### DIFF
--- a/scala2java-core/build.gradle
+++ b/scala2java-core/build.gradle
@@ -4,12 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation "org.scalameta:scalameta_$scalaMajorVersion:4.6.0"
-    constraints {
-        implementation('com.google.protobuf:protobuf-java:3.19.6') {
-            because 'previous versions have a security vulnerability'
-        }
-    }
+    implementation project(':scala2java-spi')
 }
 
 jar {

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/Scala2JavaTranslator.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/Scala2JavaTranslator.scala
@@ -1,5 +1,6 @@
 package io.github.effiban.scala2java.core
 
+import io.github.effiban.scala2java.core.extensions.{ExtensionRegistry, ExtensionRegistryBuilder}
 import io.github.effiban.scala2java.core.traversers.ScalaTreeTraversers
 import io.github.effiban.scala2java.core.writers.{ConsoleJavaWriter, JavaWriter, JavaWriterImpl}
 
@@ -20,6 +21,8 @@ object Scala2JavaTranslator {
       case Some(outputJavaBasePath) => createFileJavaWriter(scalaFileName, outputJavaBasePath)
       case None => ConsoleJavaWriter
     }
+    implicit val extensionRegistry: ExtensionRegistry = ExtensionRegistryBuilder.build()
+
     try {
       new ScalaTreeTraversers().sourceTraverser.traverse(sourceTree)
     } finally {

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
@@ -1,0 +1,10 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.spi.Scala2JavaExtension
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
+
+case class ExtensionRegistry(extensions: List[Scala2JavaExtension]) {
+
+  val javaImportersProviders: List[JavaImportersProvider] = extensions.map(_.javaImportersProvider())
+
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilder.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilder.scala
@@ -1,0 +1,17 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.spi.Scala2JavaExtension
+
+import java.util.ServiceLoader
+import scala.jdk.CollectionConverters._
+
+object ExtensionRegistryBuilder {
+
+  def build(): ExtensionRegistry = {
+    val extensions = ServiceLoader.load(classOf[Scala2JavaExtension])
+      .iterator
+      .asScala
+      .toList
+    ExtensionRegistry(extensions)
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/generators/JavaImportersProvider.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/generators/JavaImportersProvider.scala
@@ -1,7 +1,0 @@
-package io.github.effiban.scala2java.core.generators
-
-import scala.meta.Importer
-
-trait JavaImportersProvider {
-  def provide(): List[Importer]
-}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/providers/CompositeJavaImportersProvider.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/providers/CompositeJavaImportersProvider.scala
@@ -1,0 +1,12 @@
+package io.github.effiban.scala2java.core.providers
+
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
+
+import scala.meta.Importer
+
+class CompositeJavaImportersProvider(defaultProvider: JavaImportersProvider,
+                                     extensionRegistry: ExtensionRegistry) extends JavaImportersProvider {
+
+  override def provide(): List[Importer] = (defaultProvider +: extensionRegistry.javaImportersProviders).flatMap(_.provide())
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/providers/DefaultJavaImportersProvider.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/providers/DefaultJavaImportersProvider.scala
@@ -1,6 +1,7 @@
-package io.github.effiban.scala2java.core.generators
+package io.github.effiban.scala2java.core.providers
 
 import io.github.effiban.scala2java.core.entities.TermNameValues.{Java, Util}
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
 
 import scala.meta.Importee.Wildcard
 import scala.meta.Term.Select

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/PkgTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/PkgTraverser.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.generators.JavaImportersProvider
 import io.github.effiban.scala2java.core.writers.JavaWriter
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
 
 import scala.meta.{Import, Pkg}
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -1,16 +1,17 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.classifiers.{DefnTypeClassifier, DefnValClassifier, JavaStatClassifier, TermApplyInfixClassifier}
-import io.github.effiban.scala2java.core.generators.DefaultJavaImportersProvider
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
 import io.github.effiban.scala2java.core.orderings.JavaTemplateChildOrdering
 import io.github.effiban.scala2java.core.predicates.{ImporterIncludedPredicate, TemplateInitIncludedPredicate}
+import io.github.effiban.scala2java.core.providers.{CompositeJavaImportersProvider, DefaultJavaImportersProvider}
 import io.github.effiban.scala2java.core.resolvers.Resolvers.shouldReturnValueResolver
 import io.github.effiban.scala2java.core.resolvers._
 import io.github.effiban.scala2java.core.transformers._
 import io.github.effiban.scala2java.core.typeinference.TypeInferrers.{scalarArgListTypeInferrer, termTypeInferrer}
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
-class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
+class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: ExtensionRegistry) {
 
   private lazy val alternativeTraverser: AlternativeTraverser = new AlternativeTraverserImpl(patTraverser)
 
@@ -269,7 +270,7 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter) {
   private lazy val pkgTraverser: PkgTraverser = new PkgTraverserImpl(
     termRefTraverser,
     pkgStatListTraverser,
-    DefaultJavaImportersProvider
+    new CompositeJavaImportersProvider(DefaultJavaImportersProvider, extensionRegistry)
   )
 
   private lazy val regularClassTraverser: RegularClassTraverser = new RegularClassTraverserImpl(

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryTest.scala
@@ -1,0 +1,23 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.spi.Scala2JavaExtension
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
+
+class ExtensionRegistryTest extends UnitTestSuite {
+
+  private val extension1 = mock[Scala2JavaExtension]
+  private val extension2 = mock[Scala2JavaExtension]
+
+  private val importersProvider1 = mock[JavaImportersProvider]
+  private val importersProvider2 = mock[JavaImportersProvider]
+
+  test("javaImportersProviders") {
+    when(extension1.javaImportersProvider()).thenReturn(importersProvider1)
+    when(extension2.javaImportersProvider()).thenReturn(importersProvider2)
+
+    val extensionRegistry = ExtensionRegistry(List(extension1, extension2))
+
+    extensionRegistry.javaImportersProviders shouldBe List(importersProvider1, importersProvider2)
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/providers/CompositeJavaImportersProviderTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/providers/CompositeJavaImportersProviderTest.scala
@@ -1,0 +1,43 @@
+package io.github.effiban.scala2java.core.providers
+
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.core.testtrees.TermNames
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
+
+import scala.meta.Importee.Wildcard
+import scala.meta.Term.Select
+import scala.meta.{Importer, Term}
+
+class CompositeJavaImportersProviderTest extends UnitTestSuite {
+
+  private val DefaultImporter1 = Importer(Select(TermNames.Java, Term.Name("io")), List(Wildcard()))
+  private val DefaultImporter2 = Importer(Select(TermNames.Java, Term.Name("lang")), List(Wildcard()))
+  private val ExtraImporter1A = Importer(Select(Term.Name("aaa"), Term.Name("bbb")), List(Wildcard()))
+  private val ExtraImporter1B = Importer(Select(Term.Name("ccc"), Term.Name("ddd")), List(Wildcard()))
+  private val ExtraImporter2 = Importer(Select(Term.Name("eee"), Term.Name("fff")), List(Wildcard()))
+
+  private val AllImporters = List(
+    DefaultImporter1,
+    DefaultImporter2,
+    ExtraImporter1A,
+    ExtraImporter1B,
+    ExtraImporter2
+  )
+
+  private val defaultProvider = mock[JavaImportersProvider]
+  private val extraProvider1 = mock[JavaImportersProvider]
+  private val extraProvider2 = mock[JavaImportersProvider]
+  private val extensionRegistry = mock[ExtensionRegistry]
+
+  private val compositeProvider = new CompositeJavaImportersProvider(defaultProvider, extensionRegistry)
+
+  test("provide") {
+    when(extensionRegistry.javaImportersProviders).thenReturn(List(extraProvider1, extraProvider2))
+    when(defaultProvider.provide()).thenReturn(List(DefaultImporter1, DefaultImporter2))
+    when(extraProvider1.provide()).thenReturn(List(ExtraImporter1A, ExtraImporter1B))
+    when(extraProvider2.provide()).thenReturn(List(ExtraImporter2))
+
+    compositeProvider.provide().structure shouldBe AllImporters.structure
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgTraverserImplTest.scala
@@ -1,11 +1,11 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.generators.JavaImportersProvider
 import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, TermNames}
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
 
 import scala.meta.{Decl, Defn, Import, Importee, Importer, Name, Pat, Pkg, Self, Template, Term, Type}
 

--- a/scala2java-spi/build.gradle
+++ b/scala2java-spi/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'scala2java.library-conventions'
+}
+
+dependencies {
+    api "org.scalameta:scalameta_$scalaMajorVersion:4.6.0"
+    constraints {
+        api('com.google.protobuf:protobuf-java:3.19.6') {
+            because 'previous versions have a security vulnerability'
+        }
+    }
+}
+
+publishing {
+    publications {
+        scala2java(MavenPublication) {
+            pom {
+                name = 'Scala2Java SPI'
+                description = 'Plugin Interface for Scala2Java Tool'
+            }
+        }
+    }
+}

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
@@ -1,0 +1,8 @@
+package io.github.effiban.scala2java.spi
+
+import io.github.effiban.scala2java.spi.providers.JavaImportersProvider
+
+trait Scala2JavaExtension {
+
+  def javaImportersProvider(): JavaImportersProvider = JavaImportersProvider.Empty
+}

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/providers/JavaImportersProvider.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/providers/JavaImportersProvider.scala
@@ -1,0 +1,12 @@
+package io.github.effiban.scala2java.spi.providers
+
+import scala.meta.Importer
+
+trait JavaImportersProvider {
+
+  def provide(): List[Importer] = Nil
+}
+
+object JavaImportersProvider {
+  val Empty: JavaImportersProvider = new JavaImportersProvider {}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'scala2java'
 include 'scala2java-core'
+include 'scala2java-spi'
 


### PR DESCRIPTION
Adding infra for an extension mechanism, allowing 3rd party libraries to add functionality to the support provided by the core library. The infra is defined in a new module **scala2java-spi**.
The extension will be automatically discovered as an implementation of the `Scala2JavaExtension` interface using the Java `ServiceLoader` mechanism

These extensions are designed for extending the basic support of translation beyond the Scala standard library to support other popular Scala frameworks such as ScalaTest, Akka which have Java analogs.

In addition, added the first extensible method which is `Scala2JavaExtension.javaImportersProvider`. It allows the extension to supply a provider for additional Java imports that should be automatically added to the generated class.
