### PR TITLE
Allow an extension to transform a `Term.ApplyType` to a `Term.Apply`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
@@ -3,7 +3,7 @@ package io.github.effiban.scala2java.core.extensions
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
 import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
 import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
-import io.github.effiban.scala2java.spi.transformers.{ClassNameTransformer, DefnDefTransformer}
+import io.github.effiban.scala2java.spi.transformers.{ClassNameTransformer, DefnDefTransformer, TermApplyTypeToTermApplyTransformer}
 
 case class ExtensionRegistry(extensions: List[Scala2JavaExtension]) {
 
@@ -16,4 +16,7 @@ case class ExtensionRegistry(extensions: List[Scala2JavaExtension]) {
   val classNameTransformers: List[ClassNameTransformer] = extensions.map(_.classNameTransformer())
 
   val defnDefTransformers: List[DefnDefTransformer] = extensions.map(_.defnDefTransformer())
+
+  val termApplyTypeToTermApplyTransformers: List[TermApplyTypeToTermApplyTransformer] =
+    extensions.map(_.termApplyTypeToTermApplyTransformer())
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformer.scala
@@ -1,0 +1,31 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
+import io.github.effiban.scala2java.spi.transformers.TermApplyTypeToTermApplyTransformer
+
+import scala.meta.Term
+
+class CompositeTermApplyTypeToTermApplyTransformer(implicit extensionRegistry: ExtensionRegistry)
+  extends TermApplyTypeToTermApplyTransformer {
+
+  /**
+   * If several extensions transform the 'ApplyType' - they will applied in encounter order, until one returns a non-empty result (if any).<br>
+   * Therefore the output might not be deterministic.<br>
+   * It is the responsibility of the user to understand the consequences of applying multiple extensions.
+   */
+  override def transform(termApplyType: Term.ApplyType): Option[Term.Apply] = {
+    extensionRegistry.termApplyTypeToTermApplyTransformers
+      .foldLeft[Option[Term.Apply]](None)(
+        (maybeTermApply, transformer) => firstTransformedOrNone(maybeTermApply, transformer, termApplyType)
+      )
+  }
+
+  private def firstTransformedOrNone(maybeTermApply: Option[Term.Apply],
+                                     transformer: TermApplyTypeToTermApplyTransformer,
+                                     termApplyType: Term.ApplyType) = {
+    maybeTermApply match {
+      case Some(termApply) => Some(termApply)
+      case None => transformer.transform(termApplyType)
+    }
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ApplyTypeTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ApplyTypeTraverser.scala
@@ -2,6 +2,7 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.TermSelectContext
 import io.github.effiban.scala2java.core.writers.JavaWriter
+import io.github.effiban.scala2java.spi.transformers.TermApplyTypeToTermApplyTransformer
 
 import scala.meta.Term
 import scala.meta.Term.ApplyType
@@ -11,28 +12,41 @@ trait ApplyTypeTraverser extends ScalaTreeTraverser[ApplyType]
 private[traversers] class ApplyTypeTraverserImpl(typeTraverser: => TypeTraverser,
                                                  termSelectTraverser: => TermSelectTraverser,
                                                  typeListTraverser: => TypeListTraverser,
-                                                 termTraverser: => TermTraverser)
+                                                 termTraverser: => TermTraverser,
+                                                 termApplyTraverser: => TermApplyTraverser,
+                                                 termApplyTypeToTermTransformer: TermApplyTypeToTermApplyTransformer)
                                                 (implicit javaWriter: JavaWriter) extends ApplyTypeTraverser {
 
   import javaWriter._
 
   // parametrized type application, e.g.: classOf[X], identity[X]
   override def traverse(termApplyType: ApplyType): Unit = {
-    termApplyType.fun match {
-      case Term.Name("classOf") =>
-        termApplyType.targs match {
-          case arg :: _ =>
-            typeTraverser.traverse(arg)
-            write(".class")
-          case _ => write(s"UNPARSEABLE class type: $termApplyType")
-        }
-      case termSelect: Term.Select => termSelectTraverser.traverse(termSelect, TermSelectContext(termApplyType.targs))
-      case term =>
-        // In Java a type can only be applied to a qualified name, so the best we can do is guess the qualifier in a comment
-        writeComment("this?")
-        writeQualifierSeparator()
-        typeListTraverser.traverse(termApplyType.targs)
-        termTraverser.traverse(term)
+    termApplyTypeToTermTransformer.transform(termApplyType) match {
+      case Some(termApply) => termApplyTraverser.traverse(termApply)
+      case None => traverseOriginal(termApplyType)
     }
+  }
+
+  private def traverseOriginal(termApplyType: ApplyType): Unit = termApplyType.fun match {
+    case Term.Name("classOf") => traverseClassOf(termApplyType)
+    case termSelect: Term.Select => termSelectTraverser.traverse(termSelect, TermSelectContext(termApplyType.targs))
+    case term => traverseUnqualified(termApplyType, term)
+  }
+
+  private def traverseClassOf(termApplyType: ApplyType): Unit = {
+    termApplyType.targs match {
+      case arg :: _ =>
+        typeTraverser.traverse(arg)
+        write(".class")
+      case _ => write(s"UNPARSEABLE class type: $termApplyType")
+    }
+  }
+
+  private def traverseUnqualified(termApplyType: ApplyType, term: Term): Unit = {
+    // In Java a type can only be applied to a qualified name, so the best we can do is guess the qualifier in a comment
+    writeComment("this?")
+    writeQualifierSeparator()
+    typeListTraverser.traverse(termApplyType.targs)
+    termTraverser.traverse(term)
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -28,7 +28,9 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter,
     typeTraverser,
     termSelectTraverser,
     typeListTraverser,
-    termTraverser
+    termTraverser,
+    termApplyTraverser,
+    new CompositeTermApplyTypeToTermApplyTransformer()
   )
 
   private lazy val applyUnaryTraverser: ApplyUnaryTraverser = new ApplyUnaryTraverserImpl(termNameTraverser, termTraverser)

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryTest.scala
@@ -4,7 +4,7 @@ import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
 import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
 import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
-import io.github.effiban.scala2java.spi.transformers.{ClassNameTransformer, DefnDefTransformer}
+import io.github.effiban.scala2java.spi.transformers.{ClassNameTransformer, DefnDefTransformer, TermApplyTypeToTermApplyTransformer}
 
 class ExtensionRegistryTest extends UnitTestSuite {
 
@@ -75,5 +75,18 @@ class ExtensionRegistryTest extends UnitTestSuite {
     val extensionRegistry = ExtensionRegistry(extensions)
 
     extensionRegistry.defnDefTransformers shouldBe defnDefTransformers
+  }
+
+  test("termApplyTypeToTermApplyTransformers") {
+    val termApplyTypeToTermApplyTransformer1 = mock[TermApplyTypeToTermApplyTransformer]
+    val termApplyTypeToTermApplyTransformer2 = mock[TermApplyTypeToTermApplyTransformer]
+    val termApplyTypeToTermApplyTransformers = List(termApplyTypeToTermApplyTransformer1, termApplyTypeToTermApplyTransformer2)
+
+    when(extension1.termApplyTypeToTermApplyTransformer()).thenReturn(termApplyTypeToTermApplyTransformer1)
+    when(extension2.termApplyTypeToTermApplyTransformer()).thenReturn(termApplyTypeToTermApplyTransformer2)
+
+    val extensionRegistry = ExtensionRegistry(extensions)
+
+    extensionRegistry.termApplyTypeToTermApplyTransformers shouldBe termApplyTypeToTermApplyTransformers
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformerTest.scala
@@ -1,0 +1,62 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
+import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.spi.transformers.TermApplyTypeToTermApplyTransformer
+
+import scala.meta.{Term, Type}
+
+class CompositeTermApplyTypeToTermApplyTransformerTest extends UnitTestSuite {
+
+  private val TheTermApplyType = termApplyTypeWithFun("fun")
+  private val TheTermApply = termApplyWithFun("fun")
+
+  private implicit val extensionRegistry: ExtensionRegistry = mock[ExtensionRegistry]
+
+  private val transformer1 = mock[TermApplyTypeToTermApplyTransformer]
+  private val transformer2 = mock[TermApplyTypeToTermApplyTransformer]
+
+  private val compositeTransformer = new CompositeTermApplyTypeToTermApplyTransformer()
+
+  test("transform when there are no transformers - should return empty") {
+    when(extensionRegistry.termApplyTypeToTermApplyTransformers).thenReturn(Nil)
+
+    compositeTransformer.transform(TheTermApplyType) shouldBe None
+  }
+
+  test("transform when there is one transformer returning non-empty should return its result") {
+    when(extensionRegistry.termApplyTypeToTermApplyTransformers).thenReturn(List(transformer1))
+    when(transformer1.transform(eqTree(TheTermApplyType))).thenReturn(Some(TheTermApply))
+
+    compositeTransformer.transform(TheTermApplyType).value.structure shouldBe TheTermApply.structure
+  }
+
+  test("transform when there are two transformers and first returns non-empty should return result of first") {
+    when(extensionRegistry.termApplyTypeToTermApplyTransformers).thenReturn(List(transformer1, transformer2))
+    when(transformer1.transform(eqTree(TheTermApplyType))).thenReturn(Some(TheTermApply))
+
+    compositeTransformer.transform(TheTermApplyType).value.structure shouldBe TheTermApply.structure
+  }
+
+  test("transform when there are two transformers, first returns empty and second returns non-empty - should return result of second") {
+    when(extensionRegistry.termApplyTypeToTermApplyTransformers).thenReturn(List(transformer1, transformer2))
+    when(transformer1.transform(eqTree(TheTermApplyType))).thenReturn(None)
+    when(transformer2.transform(eqTree(TheTermApplyType))).thenReturn(Some(TheTermApply))
+
+    compositeTransformer.transform(TheTermApplyType).value.structure shouldBe TheTermApply.structure
+  }
+
+  test("transform when there are two transformers, both returning empty - should return empty") {
+    when(extensionRegistry.termApplyTypeToTermApplyTransformers).thenReturn(List(transformer1, transformer2))
+    when(transformer1.transform(eqTree(TheTermApplyType))).thenReturn(None)
+    when(transformer2.transform(eqTree(TheTermApplyType))).thenReturn(None)
+
+    compositeTransformer.transform(TheTermApplyType) shouldBe None
+  }
+
+  private def termApplyTypeWithFun(name: String) = Term.ApplyType(Term.Name(name), List(Type.Name("T")))
+
+  private def termApplyWithFun(name: String) = Term.Apply(Term.Name(name), Nil)
+
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyTypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyTypeTraverserImplTest.scala
@@ -6,6 +6,7 @@ import io.github.effiban.scala2java.core.matchers.TermSelectContextMatcher.eqTer
 import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.spi.transformers.TermApplyTypeToTermApplyTransformer
 
 import scala.meta.{Term, Type}
 
@@ -15,42 +16,53 @@ class ApplyTypeTraverserImplTest extends UnitTestSuite {
   private val termSelectTraverser = mock[TermSelectTraverser]
   private val typeListTraverser = mock[TypeListTraverser]
   private val termTraverser = mock[TermTraverser]
+  private val termApplyTraverser = mock[TermApplyTraverser]
+  private val termApplyTypeToTermApplyTransformer = mock[TermApplyTypeToTermApplyTransformer]
 
   private val applyTypeTraverser = new ApplyTypeTraverserImpl(
     typeTraverser,
     termSelectTraverser,
     typeListTraverser,
-    termTraverser)
+    termTraverser,
+    termApplyTraverser,
+    termApplyTypeToTermApplyTransformer)
 
-  test("traverse() when function is 'classOf' should convert to the Java equivalent") {
+
+  test("traverse() when not transformed and function is 'classOf' should convert to the Java equivalent") {
     val typeName = Type.Name("T")
+    val termApplyType = Term.ApplyType(fun = Term.Name("classOf"), targs = List(typeName))
+
+    when(termApplyTypeToTermApplyTransformer.transform(termApplyType)).thenReturn(None)
     doWrite("T").when(typeTraverser).traverse(eqTree(typeName))
 
-    applyTypeTraverser.traverse(Term.ApplyType(fun = Term.Name("classOf"), targs = List(typeName)))
+    applyTypeTraverser.traverse(termApplyType)
 
     outputWriter.toString shouldBe "T.class"
 
-    verifyNoMoreInteractions(termSelectTraverser, termTraverser)
+    verifyNoMoreInteractions(termSelectTraverser, termTraverser, termApplyTraverser)
   }
 
-  test("traverse() when function is a Select") {
-    val fun = Term.Select(Term.Name("myObj"), Term.Name("myFunc"))
+  test("traverse() when not transformed and function is a 'Select', should traverse properly") {
+    val fun = Term.Select(Term.Name("myObj"), Term.Name("myFunc1"))
     val typeArgs = List(Type.Name("T1"), Type.Name("T2"))
+    val termApplyType = Term.ApplyType(fun = fun, targs = typeArgs)
 
+    when(termApplyTypeToTermApplyTransformer.transform(eqTree(termApplyType))).thenReturn(None)
     doWrite("myObj<T1, T2>.myFunc")
       .when(termSelectTraverser).traverse(eqTree(fun), eqTermSelectContext(TermSelectContext(typeArgs)))
-
     applyTypeTraverser.traverse(Term.ApplyType(fun = fun, targs = typeArgs))
 
     outputWriter.toString shouldBe "myObj<T1, T2>.myFunc"
 
-    verifyNoMoreInteractions(typeTraverser, termTraverser)
+    verifyNoMoreInteractions(typeTraverser, termTraverser, termApplyTraverser)
   }
 
-  test("traverse() when function is a Term.Name") {
-    val fun = Term.Name("myFunc")
+  test("traverse() when when not transformed and function is a 'Term.Name', should prefix with a commented 'this'") {
+    val fun = Term.Name("myFunc1")
     val typeArgs = List(Type.Name("T1"), Type.Name("T2"))
+    val termApplyType = Term.ApplyType(fun = fun, targs = typeArgs)
 
+    when(termApplyTypeToTermApplyTransformer.transform(eqTree(termApplyType))).thenReturn(None)
     doWrite("myFunc").when(termTraverser).traverse(eqTree(fun))
     doWrite("<T1, T2>").when(typeListTraverser).traverse(eqTreeList(typeArgs))
 
@@ -58,6 +70,23 @@ class ApplyTypeTraverserImplTest extends UnitTestSuite {
 
     outputWriter.toString shouldBe "/* this? */.<T1, T2>myFunc"
 
-    verifyNoMoreInteractions(typeTraverser, termSelectTraverser)
+    verifyNoMoreInteractions(typeTraverser, termSelectTraverser, termApplyTraverser)
+  }
+
+  test("traverse() when transformed should call the 'TermApplyTraverser'") {
+    val fun = Term.Name("myFunc")
+    val typeArgs = List(Type.Name("T"))
+    val termApplyType = Term.ApplyType(fun = fun, targs = typeArgs)
+    val termApply = Term.Apply(fun, List(Term.ApplyType(Term.Name("classOf"), typeArgs)))
+
+    when(termApplyTypeToTermApplyTransformer.transform(eqTree(termApplyType))).thenReturn(Some(termApply))
+    doWrite("myFunc(classOf[T])")
+      .when(termApplyTraverser).traverse(eqTree(termApply))
+
+    applyTypeTraverser.traverse(Term.ApplyType(fun = fun, targs = typeArgs))
+
+    outputWriter.toString shouldBe "myFunc(classOf[T])"
+
+    verifyNoMoreInteractions(typeTraverser, termTraverser, termSelectTraverser)
   }
 }

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
@@ -2,7 +2,7 @@ package io.github.effiban.scala2java.spi
 
 import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
 import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
-import io.github.effiban.scala2java.spi.transformers.{ClassNameTransformer, DefnDefTransformer}
+import io.github.effiban.scala2java.spi.transformers.{ClassNameTransformer, DefnDefTransformer, TermApplyTypeToTermApplyTransformer}
 
 trait Scala2JavaExtension {
 
@@ -15,4 +15,6 @@ trait Scala2JavaExtension {
   def classNameTransformer(): ClassNameTransformer = ClassNameTransformer.Identity
 
   def defnDefTransformer(): DefnDefTransformer = DefnDefTransformer.Identity
+
+  def termApplyTypeToTermApplyTransformer(): TermApplyTypeToTermApplyTransformer = TermApplyTypeToTermApplyTransformer.Empty
 }

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/providers/AdditionalImportersProvider.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/providers/AdditionalImportersProvider.scala
@@ -4,9 +4,9 @@ import scala.meta.Importer
 
 trait AdditionalImportersProvider {
 
-  def provide(): List[Importer] = Nil
+  def provide(): List[Importer]
 }
 
 object AdditionalImportersProvider {
-  val Empty: AdditionalImportersProvider = new AdditionalImportersProvider {}
+  val Empty: AdditionalImportersProvider = () => Nil
 }

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/TermApplyTypeToTermApplyTransformer.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/TermApplyTypeToTermApplyTransformer.scala
@@ -1,0 +1,12 @@
+package io.github.effiban.scala2java.spi.transformers
+
+import scala.meta.Term
+
+trait TermApplyTypeToTermApplyTransformer {
+
+  def transform(applyType: Term.ApplyType): Option[Term.Apply]
+}
+
+object TermApplyTypeToTermApplyTransformer {
+  def Empty: TermApplyTypeToTermApplyTransformer = _ => None
+}


### PR DESCRIPTION
This capability is required for supporting transformations of expressions utilizing Scala's `ClassTag` which has no equivalent in Java.
For example, the expression `mock[Foo]` in Scala Mockito needs to be transformed to `mock(classOf[Foo])`, so it can then be translated into the Java equivalent `mock(Foo.class)`