### PR TITLE
Allow an extension to transform a `Defn.Val` to a `Decl.Var`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
@@ -17,6 +17,8 @@ case class ExtensionRegistry(extensions: List[Scala2JavaExtension]) {
 
   val classTransformers: List[ClassTransformer] = extensions.map(_.classTransformer())
 
+  val defnValToDeclVarTransformers: List[DefnValToDeclVarTransformer] = extensions.map(_.defnValToDeclVarTransformer())
+
   val defnDefTransformers: List[DefnDefTransformer] = extensions.map(_.defnDefTransformer())
 
   val termApplyTypeToTermApplyTransformers: List[TermApplyTypeToTermApplyTransformer] =

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnValToDeclVarTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnValToDeclVarTransformer.scala
@@ -1,0 +1,20 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
+import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
+
+import scala.meta.{Decl, Defn}
+
+class CompositeDefnValToDeclVarTransformer(implicit extensionRegistry: ExtensionRegistry) extends DefnValToDeclVarTransformer {
+
+  /**
+   * If several extensions transform the same 'Defn.Val', the transformations will be applied in encounter order, until one returns a non-empty result (if any)..<br>
+   * Therefore the output method might not be deterministic.<br>
+   * It is the responsibility of the user to understand the consequences of applying multiple extensions.
+   */
+  override def transform(defnVal: Defn.Val, javaScope: JavaScope): Option[Decl.Var] = {
+    extensionRegistry.defnValToDeclVarTransformers
+      .foldLeft[Option[Decl.Var]](None)((maybeDeclVar, transformer) => maybeDeclVar.orElse(transformer.transform(defnVal, javaScope)))
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformer.scala
@@ -15,17 +15,6 @@ class CompositeTermApplyTypeToTermApplyTransformer(implicit extensionRegistry: E
    */
   override def transform(termApplyType: Term.ApplyType): Option[Term.Apply] = {
     extensionRegistry.termApplyTypeToTermApplyTransformers
-      .foldLeft[Option[Term.Apply]](None)(
-        (maybeTermApply, transformer) => firstTransformedOrNone(maybeTermApply, transformer, termApplyType)
-      )
-  }
-
-  private def firstTransformedOrNone(maybeTermApply: Option[Term.Apply],
-                                     transformer: TermApplyTypeToTermApplyTransformer,
-                                     termApplyType: Term.ApplyType) = {
-    maybeTermApply match {
-      case Some(termApply) => Some(termApply)
-      case None => transformer.transform(termApplyType)
-    }
+      .foldLeft[Option[Term.Apply]](None)((maybeTermApply, transformer) => maybeTermApply.orElse(transformer.transform(termApplyType)))
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefnValTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefnValTraverser.scala
@@ -3,6 +3,7 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
 import io.github.effiban.scala2java.core.writers.JavaWriter
+import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
 
 import scala.meta.Defn
 
@@ -13,13 +14,22 @@ trait DefnValTraverser {
 private[traversers] class DefnValTraverserImpl(modListTraverser: => ModListTraverser,
                                                defnValOrVarTypeTraverser: => DefnValOrVarTypeTraverser,
                                                patListTraverser: => PatListTraverser,
-                                               rhsTermTraverser: => RhsTermTraverser)
+                                               rhsTermTraverser: => RhsTermTraverser,
+                                               declVarTraverser: => DeclVarTraverser,
+                                               defnValToDeclVarTransformer: DefnValToDeclVarTransformer)
                                               (implicit javaWriter: JavaWriter) extends DefnValTraverser {
 
   import javaWriter._
 
   //TODO if it is non-public it will be invalid in a Java interface - replace with method
   override def traverse(valDef: Defn.Val, context: StatContext = StatContext()): Unit = {
+    defnValToDeclVarTransformer.transform(valDef, context.javaScope) match {
+      case Some(varDecl) => declVarTraverser.traverse(varDecl, context)
+      case None => traverseOriginal(valDef, context)
+    }
+  }
+
+  private def traverseOriginal(valDef: Defn.Val, context: StatContext): Unit = {
     modListTraverser.traverse(ModifiersContext(valDef, JavaTreeType.Variable, context.javaScope))
     defnValOrVarTypeTraverser.traverse(valDef.decltpe, Some(valDef.rhs), context)
     write(" ")

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -153,7 +153,9 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
     modListTraverser,
     defnValOrVarTypeTraverser,
     patListTraverser,
-    rhsTermTraverser
+    rhsTermTraverser,
+    declVarTraverser,
+    new CompositeDefnValToDeclVarTransformer
   )
 
   private lazy val defnVarTraverser: DefnVarTraverser = new DefnVarTraverserImpl(

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryTest.scala
@@ -90,6 +90,19 @@ class ExtensionRegistryTest extends UnitTestSuite {
     extensionRegistry.classTransformers shouldBe classNameTransformers
   }
 
+  test("defnValToDeclVarTransformers") {
+    val defnValToDeclVarTransformer1 = mock[DefnValToDeclVarTransformer]
+    val defnValToDeclVarTransformer2 = mock[DefnValToDeclVarTransformer]
+    val defnValToDeclVarTransformers = List(defnValToDeclVarTransformer1, defnValToDeclVarTransformer2)
+
+    when(extension1.defnValToDeclVarTransformer()).thenReturn(defnValToDeclVarTransformer1)
+    when(extension2.defnValToDeclVarTransformer()).thenReturn(defnValToDeclVarTransformer2)
+
+    val extensionRegistry = ExtensionRegistry(extensions)
+
+    extensionRegistry.defnValToDeclVarTransformers shouldBe defnValToDeclVarTransformers
+  }
+
   test("defnDefTransformers") {
     val defnDefTransformer1 = mock[DefnDefTransformer]
     val defnDefTransformer2 = mock[DefnDefTransformer]

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnValToDeclVarTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnValToDeclVarTransformerTest.scala
@@ -1,0 +1,67 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
+import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
+import org.mockito.ArgumentMatchers
+
+import scala.meta.{Decl, Defn, Lit, Pat, Term}
+
+class CompositeDefnValToDeclVarTransformerTest extends UnitTestSuite {
+
+  private val TheJavaScope = JavaScope.Class
+
+  private val TheDefnVal = defnValWithName("x")
+  private val TheDeclVar = declVarWithName("x")
+
+  private implicit val extensionRegistry: ExtensionRegistry = mock[ExtensionRegistry]
+
+  private val transformer1 = mock[DefnValToDeclVarTransformer]
+  private val transformer2 = mock[DefnValToDeclVarTransformer]
+
+  private val compositeTransformer = new CompositeDefnValToDeclVarTransformer()
+
+  test("transform when there are no transformers - should return empty") {
+    when(extensionRegistry.defnValToDeclVarTransformers).thenReturn(Nil)
+
+    compositeTransformer.transform(TheDefnVal, TheJavaScope) shouldBe None
+  }
+
+  test("transform when there is one transformer returning non-empty should return its result") {
+    when(extensionRegistry.defnValToDeclVarTransformers).thenReturn(List(transformer1))
+    when(transformer1.transform(eqTree(TheDefnVal), ArgumentMatchers.eq(TheJavaScope))).thenReturn(Some(TheDeclVar))
+
+    compositeTransformer.transform(TheDefnVal, TheJavaScope).value.structure shouldBe TheDeclVar.structure
+  }
+
+  test("transform when there are two transformers and first returns non-empty should return result of first") {
+    when(extensionRegistry.defnValToDeclVarTransformers).thenReturn(List(transformer1, transformer2))
+    when(transformer1.transform(eqTree(TheDefnVal), ArgumentMatchers.eq(TheJavaScope))).thenReturn(Some(TheDeclVar))
+
+    compositeTransformer.transform(TheDefnVal, TheJavaScope).value.structure shouldBe TheDeclVar.structure
+  }
+
+  test("transform when there are two transformers, first returns empty and second returns non-empty - should return result of second") {
+    when(extensionRegistry.defnValToDeclVarTransformers).thenReturn(List(transformer1, transformer2))
+    when(transformer1.transform(eqTree(TheDefnVal), ArgumentMatchers.eq(TheJavaScope))).thenReturn(None)
+    when(transformer2.transform(eqTree(TheDefnVal), ArgumentMatchers.eq(TheJavaScope))).thenReturn(Some(TheDeclVar))
+
+    compositeTransformer.transform(TheDefnVal, TheJavaScope).value.structure shouldBe TheDeclVar.structure
+  }
+
+  test("transform when there are two transformers, both returning empty - should return empty") {
+    when(extensionRegistry.defnValToDeclVarTransformers).thenReturn(List(transformer1, transformer2))
+    when(transformer1.transform(eqTree(TheDefnVal), ArgumentMatchers.eq(TheJavaScope))).thenReturn(None)
+    when(transformer2.transform(eqTree(TheDefnVal), ArgumentMatchers.eq(TheJavaScope))).thenReturn(None)
+
+    compositeTransformer.transform(TheDefnVal, TheJavaScope) shouldBe None
+  }
+
+  private def defnValWithName(name: String) = Defn.Val(Nil, List(Pat.Var(Term.Name(name))), Some(TypeNames.Int), Lit.Int(3))
+
+  private def declVarWithName(name: String) = Decl.Var(Nil, List(Pat.Var(Term.Name(name))), TypeNames.Int)
+
+}

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
@@ -16,6 +16,8 @@ trait Scala2JavaExtension {
 
   def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = TemplateInitExcludedPredicate.None
 
+  def defnValToDeclVarTransformer(): DefnValToDeclVarTransformer = DefnValToDeclVarTransformer.Empty
+
   def defnDefTransformer(): DefnDefTransformer = DefnDefTransformer.Identity
 
   def termApplyTypeToTermApplyTransformer(): TermApplyTypeToTermApplyTransformer = TermApplyTypeToTermApplyTransformer.Empty

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/DefnValToDeclVarTransformer.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/DefnValToDeclVarTransformer.scala
@@ -1,0 +1,14 @@
+package io.github.effiban.scala2java.spi.transformers
+
+import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+
+import scala.meta.{Decl, Defn}
+
+trait DefnValToDeclVarTransformer {
+
+  def transform(defnVal: Defn.Val, javaScope: JavaScope): Option[Decl.Var]
+}
+
+object DefnValToDeclVarTransformer {
+  def Empty: DefnValToDeclVarTransformer = (_, _) => None
+}


### PR DESCRIPTION
This capability is provided to accommodate frameworks which dynamically generate variable definitions from declarations - usually by parsing some specific annotation.
For example, in Mockito Scala a mock might be defined like this:
```scala
val foo = mock[Foo]
```
For which the Java equivalent would be:
```java
@Mock
Foo foo;
```
In order to perform the complete translation to Java properly, a Mockito extension would first of all need to transform the Scala `val` into a `var` like this:
```scala
@Mock
var foo: Foo
```

