### PR TITLE
Add the ability to filter an extension by the source file

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/Scala2JavaTranslator.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/Scala2JavaTranslator.scala
@@ -20,7 +20,7 @@ object Scala2JavaTranslator {
     val input = Input.VirtualFile(scalaFileName, scalaText)
     val sourceTree = input.parse[Source].get
 
-    implicit val extensionRegistry: ExtensionRegistry = ExtensionRegistryBuilder.build()
+    implicit val extensionRegistry: ExtensionRegistry = ExtensionRegistryBuilder.buildFor(sourceTree)
     implicit val fileNameTransformer: FileNameTransformer = new CompositeFileNameTransformer()
 
     implicit val javaWriter: JavaWriter = maybeOutputJavaBasePath match {

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistry.scala
@@ -5,7 +5,7 @@ import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, T
 import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
 import io.github.effiban.scala2java.spi.transformers._
 
-case class ExtensionRegistry(extensions: List[Scala2JavaExtension]) {
+case class ExtensionRegistry(extensions: List[Scala2JavaExtension] = Nil) {
 
   val fileNameTransformers: List[FileNameTransformer] = extensions.map(_.fileNameTransformer())
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilder.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilder.scala
@@ -3,15 +3,23 @@ package io.github.effiban.scala2java.core.extensions
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
 
 import java.util.ServiceLoader
-import scala.jdk.CollectionConverters._
+import scala.jdk.StreamConverters._
+import scala.meta.Source
 
-object ExtensionRegistryBuilder {
+class ExtensionRegistryBuilder {
 
-  def build(): ExtensionRegistry = {
-    val extensions = ServiceLoader.load(classOf[Scala2JavaExtension])
-      .iterator
-      .asScala
+  def buildFor(source: Source): ExtensionRegistry = {
+    val extensions = loadExtensions()
+      .map(_.get)
+      .filter(_.shouldBeAppliedTo(source))
       .toList
     ExtensionRegistry(extensions)
   }
+
+  // Visible for testing
+  private[extensions] def loadExtensions() = ServiceLoader.load(classOf[Scala2JavaExtension])
+    .stream()
+    .toScala(LazyList)
 }
+
+object ExtensionRegistryBuilder extends ExtensionRegistryBuilder

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilderTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilderTest.scala
@@ -1,0 +1,63 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.spi.Scala2JavaExtension
+
+import java.util.ServiceLoader.Provider
+import scala.meta.{Source, Term}
+
+class ExtensionRegistryBuilderTest extends UnitTestSuite {
+
+  private val TheSource = Source(List(Term.Apply(Term.Name("fun"), List(Term.Name("arg")))))
+
+  test("build() when there are two extensions and both should be applied, should return a registry with both") {
+    val extension1 = extensionThatShouldBeApplied()
+    val extension2 = extensionThatShouldBeApplied()
+    val extensions = List(extension1, extension2)
+
+    registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(extensions)
+  }
+
+  test("build() when there is are two extensions and only second should be applied, should return a registry with second only") {
+    val extension1 = extensionThatShouldNotBeApplied()
+    val extension2 = extensionThatShouldBeApplied()
+    val extensions = List(extension1, extension2)
+
+    registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(List(extension2))
+  }
+
+  test("build() when there is one extension that should be applied should return a registry with it") {
+    val extension = extensionThatShouldBeApplied()
+    registryBuilderFrom(List(extension)).buildFor(TheSource) shouldBe ExtensionRegistry(List(extension))
+  }
+
+  test("build() when there is one extension that should not be applied, should return an empty registry") {
+    val extension = extensionThatShouldNotBeApplied()
+    registryBuilderFrom(List(extension)).buildFor(TheSource) shouldBe ExtensionRegistry()
+  }
+
+  test("build() when there no extensions should return an empty registry") {
+    emptyRegistryBuilder().buildFor(TheSource) shouldBe ExtensionRegistry()
+  }
+
+  private def emptyRegistryBuilder() = registryBuilderFrom(Nil)
+
+  private def registryBuilderFrom(extensions: List[Scala2JavaExtension]) = new ExtensionRegistryBuilder() {
+
+    override private[extensions] def loadExtensions() = {
+      val extensionProviders = extensions.map(extension => new Provider[Scala2JavaExtension] {
+        override def `type`(): Class[Scala2JavaExtension] = classOf[Scala2JavaExtension]
+        override def get(): Scala2JavaExtension = extension
+      })
+      LazyList.from(extensionProviders)
+    }
+  }
+
+  private def extensionThatShouldBeApplied() = new Scala2JavaExtension() {
+    override def shouldBeAppliedTo(source: Source): Boolean = source.structure == TheSource.structure
+  }
+
+  private def extensionThatShouldNotBeApplied() = new Scala2JavaExtension() {
+    override def shouldBeAppliedTo(source: Source): Boolean = source.structure != TheSource.structure
+  }
+}

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
@@ -4,7 +4,11 @@ import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, T
 import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
 import io.github.effiban.scala2java.spi.transformers._
 
+import scala.meta.Source
+
 trait Scala2JavaExtension {
+
+  def shouldBeAppliedTo(source: Source): Boolean
 
   def fileNameTransformer(): FileNameTransformer = FileNameTransformer.Identity
 


### PR DESCRIPTION
Most extensions will be designed to maniuplate particular aspects of the code, corresponding to specific features or frameworks - and may not necessarily be relevant to all source files.
For efficiency and in order to avoid conflicts - adding a mandatory method to the extension which verifies if it should be applied to the given source file.