### PR TITLE
For integration tests, flip the position of 'expected' and 'actual' in error messages

### DIFF
--- a/scala2java-core/src/integrationTest/scala/io/github/effiban/scala2java/core/integrationtest/matchers/FileMatchers.scala
+++ b/scala2java-core/src/integrationTest/scala/io/github/effiban/scala2java/core/integrationtest/matchers/FileMatchers.scala
@@ -10,7 +10,7 @@ trait FileMatchers {
   class FileContentsEqualMatcher(expectedPath: Path) extends Matcher[Path] {
 
     override def apply(actualPath: Path): MatchResult = {
-      val maybeFileMismatchMessage = FileMismatchMessageGenerator.generate(actualPath, expectedPath)
+      val maybeFileMismatchMessage = FileMismatchMessageGenerator.generate(expectedPath, actualPath)
 
       MatchResult(matches = maybeFileMismatchMessage.isEmpty,
         rawFailureMessage = maybeFileMismatchMessage.getOrElse(""),

--- a/scala2java-core/src/integrationTest/scala/io/github/effiban/scala2java/core/integrationtest/matchers/FileMismatchMessageGenerator.scala
+++ b/scala2java-core/src/integrationTest/scala/io/github/effiban/scala2java/core/integrationtest/matchers/FileMismatchMessageGenerator.scala
@@ -10,29 +10,29 @@ private[matchers] object FileMismatchMessageGenerator {
   final val Divider = " |"
   final val Highlight = "~"
   final val Missing = "<MISSING>"
-  final val Actual = "ACTUAL"
   final val Expected = "EXPECTED"
+  final val Actual = "ACTUAL"
 
-  def generate(actualPath: Path, expectedPath: Path): Option[String] = {
-    val actualLines = Files.readAllLines(actualPath).asScala.toSeq
+  def generate(expectedPath: Path, actualPath: Path): Option[String] = {
     val expectedLines = Files.readAllLines(expectedPath).asScala.toSeq
+    val actualLines = Files.readAllLines(actualPath).asScala.toSeq
 
-    findMismatchingLineNum(actualLines, expectedLines)
-      .map(mismatchingLineNum => generate(actualLines, expectedLines, mismatchingLineNum))
+    findMismatchingLineNum(expectedLines, actualLines)
+      .map(mismatchingLineNum => generate(expectedLines, actualLines, mismatchingLineNum))
   }
 
-  private def generate(actualLines: Seq[String], expectedLines: Seq[String], mismatchingLineNum: Int) = {
+  private def generate(expectedLines: Seq[String], actualLines: Seq[String], mismatchingLineNum: Int): String = {
     val maxNumLines = max(actualLines.size, expectedLines.size)
     val maxLineNumDigits = numDigitsOf(maxNumLines)
-    val maxActualLineLength = actualLines.map(_.length).max
     val maxExpectedLineLength = expectedLines.map(_.length).max
-    val maxRowLength = maxLineNumDigits + maxActualLineLength + maxExpectedLineLength + (2 * Divider.length)
+    val maxActualLineLength = actualLines.map(_.length).max
+    val maxRowLength = maxLineNumDigits + maxExpectedLineLength + maxActualLineLength + (2 * Divider.length)
 
     val diffBuilder = new mutable.StringBuilder(500)
     diffBuilder ++= "\n"
     diffBuilder ++= s"Actual file did not match expected file at line ${mismatchingLineNum + 1}:\n"
     diffBuilder ++= "\n"
-    diffBuilder ++= generateHeader(maxLineNumDigits, maxActualLineLength)
+    diffBuilder ++= generateHeader(maxLineNumDigits, maxExpectedLineLength)
 
     (0 until maxNumLines).foreach(lineNum => {
       if (mismatchingLineNum == lineNum - 1 || mismatchingLineNum == lineNum) {
@@ -40,9 +40,9 @@ private[matchers] object FileMismatchMessageGenerator {
       }
       diffBuilder ++= generateLineNumber(lineNum = lineNum, maxLineNumDigits = maxLineNumDigits)
       diffBuilder ++= Divider
-      diffBuilder ++= generateActualLinePart(actualLines, lineNum = lineNum, maxActualLineLength = maxActualLineLength)
+      diffBuilder ++= generateExpectedLinePart(expectedLines, lineNum = lineNum, maxExpectedLineLength = maxExpectedLineLength)
       diffBuilder ++= Divider
-      diffBuilder ++= generateExpectedLinePart(expectedLines, lineNum)
+      diffBuilder ++= generateActualLinePart(actualLines, lineNum)
       diffBuilder ++= "\n"
     })
     if (mismatchingLineNum == maxNumLines - 1) {
@@ -51,8 +51,8 @@ private[matchers] object FileMismatchMessageGenerator {
     diffBuilder.toString()
   }
 
-  private def generateHeader(maxLineNumDigits: Int, maxActualLineLength: Int) = {
-    (" " * maxLineNumDigits) + Divider + Actual + (" " * (maxActualLineLength - Actual.length)) + Divider + Expected + "\n"
+  private def generateHeader(maxLineNumDigits: Int, maxExpectedLineLength: Int) = {
+    (" " * maxLineNumDigits) + Divider + Expected + (" " * (maxExpectedLineLength - Expected.length)) + Divider + Actual + "\n"
   }
 
   private def generateHighlightedRow(maxRowLength: Int) = (Highlight * maxRowLength) + "\n"
@@ -61,31 +61,32 @@ private[matchers] object FileMismatchMessageGenerator {
     (" " * (maxLineNumDigits - numDigitsOf(lineNum + 1))) + (lineNum + 1)
   }
 
-  private def generateActualLinePart(actualLines: Seq[String], lineNum: Int, maxActualLineLength: Int) = {
-    if (lineNum < actualLines.size) {
-      actualLines(lineNum) + (" " * (maxActualLineLength - actualLines(lineNum).length))
+
+  private def generateExpectedLinePart(expectedLines: Seq[String], lineNum: Int, maxExpectedLineLength: Int) = {
+    if (lineNum < expectedLines.size) {
+      expectedLines(lineNum) + (" " * (maxExpectedLineLength - expectedLines(lineNum).length))
     } else {
-      Missing + (" " * (maxActualLineLength - Missing.length))
+      Missing + (" " * (maxExpectedLineLength - Missing.length))
     }
   }
 
-  private def generateExpectedLinePart(expectedLines: Seq[String], lineNum: Int) = {
-    if (lineNum < expectedLines.size) {
-      expectedLines(lineNum)
+  private def generateActualLinePart(actualLines: Seq[String], lineNum: Int) = {
+    if (lineNum < actualLines.size) {
+      actualLines(lineNum)
     } else {
       Missing
     }
   }
 
-  private def findMismatchingLineNum(actualLines: Seq[String], expectedLines: Seq[String]): Option[Int] = {
-    val minNumLines = min(actualLines.size, expectedLines.size)
+  private def findMismatchingLineNum(expectedLines: Seq[String], actualLines: Seq[String]) = {
+    val minNumLines = min(expectedLines.size, actualLines.size)
 
     val maybeMismatchingLineNum = (0 until minNumLines)
-      .find(lineNum => actualLines(lineNum).trim != expectedLines(lineNum).trim)
+      .find(lineNum => expectedLines(lineNum).trim != actualLines(lineNum).trim)
 
     maybeMismatchingLineNum match {
       case Some(mismatchingLineNum) => Some(mismatchingLineNum)
-      case None if actualLines.size != expectedLines.size => Some(minNumLines)
+      case None if expectedLines.size != actualLines.size => Some(minNumLines)
       case _ => None
     }
   }


### PR DESCRIPTION
The integration tests display a formatted multi-line error message, showing expected and actual side-by-side.
Until now the actual was on the left, but I think that a more common convention is to do the opposite - so flipping them here.