### PR TITLE
Extract the `scala2java-test-utils` module

### DIFF
--- a/buildSrc/src/main/groovy/scala2java.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/scala2java.library-conventions.gradle
@@ -26,12 +26,13 @@ repositories {
 
 testing {
     suites {
-        test {
+        configureEach {
             dependencies {
-                implementation "org.scalatest:scalatest_$scalaMajorVersion:3.2.12"
-                implementation "org.mockito:mockito-scala_$scalaMajorVersion:1.17.5"
+                implementation project(':scala2java-test-utils')
                 runtimeOnly 'com.vladsch.flexmark:flexmark-all:0.64.0'
             }
+        }
+        test {
             targets {
                 all {
                     testTask.configure {

--- a/scala2java-core/src/integrationTest/scala/io/github/effiban/scala2java/core/integrationtest/CoreIntegrationTestRunner.scala
+++ b/scala2java-core/src/integrationTest/scala/io/github/effiban/scala2java/core/integrationtest/CoreIntegrationTestRunner.scala
@@ -1,0 +1,12 @@
+package io.github.effiban.scala2java.core.integrationtest
+
+import io.github.effiban.scala2java.test.utils.integration.runner.IntegrationTestRunner
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file.{Path, Paths}
+
+class CoreIntegrationTestRunner extends AnyFunSuite with IntegrationTestRunner {
+
+  override protected def resolveTestFilesBasePath(): Path = Paths.get(getClass.getClassLoader.getResource("testfiles").toURI)
+  override protected def resolveSelectedTestPath(): String = Option(System.getenv("INTEGRATION_TEST_PATH")).getOrElse("")
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/classifiers/TermTypeClassifierImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/classifiers/TermTypeClassifierImplTest.scala
@@ -3,10 +3,10 @@ package io.github.effiban.scala2java.core.classifiers
 import io.github.effiban.scala2java.core.entities.Decision.{No, Uncertain, Yes}
 import io.github.effiban.scala2java.core.entities.TermApplyInfixKind
 import io.github.effiban.scala2java.core.entities.TermApplyInfixKind.Association
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
 import io.github.effiban.scala2java.core.typeinference.TermTypeInferrer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArrayInitializerSizeContextMockitoMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArrayInitializerSizeContextMockitoMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.ArrayInitializerSizeContext
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArrayInitializerValuesContextMockitoMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArrayInitializerValuesContextMockitoMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.ArrayInitializerValuesContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/BlockContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/BlockContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.BlockContext
+import io.github.effiban.scala2java.test.utils.matchers.{OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ClassOrTraitContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ClassOrTraitContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.ClassOrTraitContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/CtorContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/CtorContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.CtorContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/DefnDefContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/DefnDefContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.DefnDefContext
+import io.github.effiban.scala2java.test.utils.matchers.{OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/JavaChildScopeContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/JavaChildScopeContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.JavaChildScopeContext
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/JavaTreeTypeContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/JavaTreeTypeContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.JavaTreeTypeContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ModifiersContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ModifiersContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.ModifiersContext
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TemplateBodyContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TemplateBodyContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.TemplateBodyContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TemplateChildContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TemplateChildContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.TemplateChildContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TemplateContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TemplateContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.TemplateContext
+import io.github.effiban.scala2java.test.utils.matchers.{OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TermSelectContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/TermSelectContextMatcher.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.TermSelectContext
+import io.github.effiban.scala2java.test.utils.matchers.{ListMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/predicates/CoreImporterExcludedPredicateTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/predicates/CoreImporterExcludedPredicateTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.predicates
 
 import io.github.effiban.scala2java.core.classifiers.ImporterClassifier
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames.Scala
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Importee, Importer, Name, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/JavaChildScopeResolverImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/JavaChildScopeResolverImplTest.scala
@@ -4,11 +4,11 @@ import io.github.effiban.scala2java.core.classifiers.ObjectClassifier
 import io.github.effiban.scala2java.core.contexts.JavaChildScopeContext
 import io.github.effiban.scala2java.core.entities.JavaTreeType
 import io.github.effiban.scala2java.core.entities.JavaTreeType.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, Templates, TypeNames}
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Decl, Defn, Import, Importee, Importer, Name, Pat, Pkg, Term, Tree, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/JavaPublicModifierResolverTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/JavaPublicModifierResolverTest.scala
@@ -5,11 +5,11 @@ import io.github.effiban.scala2java.core.contexts.ModifiersContext
 import io.github.effiban.scala2java.core.entities.JavaModifier.Public
 import io.github.effiban.scala2java.core.entities.JavaTreeType.JavaTreeType
 import io.github.effiban.scala2java.core.entities.{JavaModifier, JavaTreeType}
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, Templates, TypeNames}
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 
 import scala.meta.{Decl, Defn, Lit, Mod, Name, Pat, Term, Tree, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/JavaTreeTypeResolverImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/JavaTreeTypeResolverImplTest.scala
@@ -4,9 +4,9 @@ import io.github.effiban.scala2java.core.classifiers.TemplateClassifier
 import io.github.effiban.scala2java.core.contexts.JavaTreeTypeContext
 import io.github.effiban.scala2java.core.entities.JavaTreeType
 import io.github.effiban.scala2java.core.entities.JavaTreeType.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, Selfs, Templates, TypeNames}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
 import scala.meta.Term.Apply

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/SealedHierarchiesResolverImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/SealedHierarchiesResolverImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.resolvers
 
 import io.github.effiban.scala2java.core.classifiers.ModsClassifier
 import io.github.effiban.scala2java.core.entities.SealedHierarchies
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, Selfs}
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 
 import scala.meta.{Defn, Import, Importee, Importer, Init, Mod, Name, Template, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/ShouldReturnValueResolverImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/resolvers/ShouldReturnValueResolverImplTest.scala
@@ -2,8 +2,8 @@ package io.github.effiban.scala2java.core.resolvers
 
 import io.github.effiban.scala2java.core.classifiers.TermTypeClassifier
 import io.github.effiban.scala2java.core.entities.Decision.{No, Uncertain, Yes}
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeClassTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeClassTransformerTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, Templates}
 import io.github.effiban.scala2java.spi.transformers.ClassTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Defn, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnDefTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnDefTransformerTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.transformers.DefnDefTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Defn, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnValToDeclVarTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeDefnValToDeclVarTransformerTest.scala
@@ -1,11 +1,11 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Decl, Defn, Lit, Pat, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyInfixToTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyInfixToTermApplyTransformerTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.classifiers.TermApplyInfixClassifier
 import io.github.effiban.scala2java.core.entities.TermApplyInfixKind.{Range, _}
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTransformerTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermApplyTypeToTermApplyTransformerTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.transformers.TermApplyTypeToTermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermSelectTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CompositeTermSelectTransformerTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformerTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames
 import io.github.effiban.scala2java.core.testtrees.TermNames._
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/ForVariantToTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/ForVariantToTermApplyTransformerTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.transformers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AlternativeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AlternativeTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Pat}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AnnotListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AnnotListTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Mod.Annot
 import scala.meta.{Init, Name, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AnnotTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AnnotTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.InitContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Mod.Annot

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AnonymousFunctionTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AnonymousFunctionTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.Decision.{Uncertain, Yes}
 import io.github.effiban.scala2java.core.entities.TraversalConstants.JavaPlaceholder
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyTypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyTypeTraverserImplTest.scala
@@ -1,12 +1,12 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.TermSelectContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.TermSelectContextMatcher.eqTermSelectContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.transformers.TermApplyTypeToTermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyUnaryTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyUnaryTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ArgumentListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ArgumentListTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.Parentheses
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ArrayInitializerTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ArrayInitializerTraverserImplTest.scala
@@ -3,12 +3,12 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{ArrayInitializerSizeContext, ArrayInitializerValuesContext}
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.CurlyBrace
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.typeinference.ScalarArgListTypeInferrer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Lit

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AscribeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AscribeTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AssignTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AssignTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/BlockStatTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/BlockStatTraverserImplTest.scala
@@ -3,12 +3,12 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.classifiers.JavaStatClassifier
 import io.github.effiban.scala2java.core.contexts.{StatContext, TryContext}
 import io.github.effiban.scala2java.core.entities.Decision.{No, Uncertain, Yes}
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.ShouldReturnValueResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.{Return, TryWithHandler}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/BlockTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/BlockTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{BlockContext, InitContext}
 import io.github.effiban.scala2java.core.entities.Decision.{No, Yes}
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.{Block, This}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CaseClassTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CaseClassTraverserImplTest.scala
@@ -2,17 +2,17 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts._
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.JavaChildScopeContextMatcher.eqJavaChildScopeContext
 import io.github.effiban.scala2java.core.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.matchers.TemplateContextMatcher.eqTemplateContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.Block

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CaseTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CaseTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Case, Lit, Pat}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CatchHandlerTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CatchHandlerTraverserImplTest.scala
@@ -2,10 +2,10 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{BlockContext, StatContext}
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Name, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ClassTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ClassTraverserImplTest.scala
@@ -1,11 +1,11 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.ClassOrTraitContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, Templates}
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.transformers.ClassTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Defn, Mod, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CtorPrimaryTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CtorPrimaryTraverserImplTest.scala
@@ -3,11 +3,11 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{CtorContext, DefnDefContext}
 import io.github.effiban.scala2java.core.matchers.CtorContextMatcher.eqCtorContext
 import io.github.effiban.scala2java.core.matchers.DefnDefContextMatcher.eqDefnDefContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.transformers.CtorPrimaryTransformer
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Ctor, Defn, Init, Name, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CtorSecondaryTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/CtorSecondaryTraverserImplTest.scala
@@ -3,11 +3,11 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{CtorContext, DefnDefContext}
 import io.github.effiban.scala2java.core.matchers.CtorContextMatcher.eqCtorContext
 import io.github.effiban.scala2java.core.matchers.DefnDefContextMatcher.eqDefnDefContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.transformers.CtorSecondaryTransformer
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Ctor, Defn, Init, Name, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclDefTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclDefTraverserImplTest.scala
@@ -2,14 +2,14 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Type.Bounds

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.StatContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Type.Bounds

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclTypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclTypeTraverserImplTest.scala
@@ -2,13 +2,13 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{JavaTreeTypeContext, ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.resolvers.JavaTreeTypeResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Type.Bounds

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclValTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclValTraverserImplTest.scala
@@ -2,14 +2,14 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Decl, Init, Mod, Name, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclVarTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DeclVarTraverserImplTest.scala
@@ -2,14 +2,14 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Decl, Init, Mod, Name, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnDefTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnDefTraverserImplTest.scala
@@ -4,9 +4,7 @@ import io.github.effiban.scala2java.core.contexts.{BlockContext, DefnDefContext,
 import io.github.effiban.scala2java.core.entities.Decision.{Uncertain, Yes}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
@@ -14,6 +12,8 @@ import io.github.effiban.scala2java.core.typeinference.TermTypeInferrer
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.spi.transformers.DefnDefTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.Block

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnTraverserImplTest.scala
@@ -2,10 +2,10 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ClassOrTraitContext, DefnDefContext, StatContext}
 import io.github.effiban.scala2java.core.matchers.DefnDefContextMatcher.eqDefnDefContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Ctor.Primary

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnTypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnTypeTraverserImplTest.scala
@@ -2,14 +2,14 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{JavaTreeTypeContext, ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.JavaTreeTypeResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Type.Bounds

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnValOrVarTypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnValOrVarTypeTraverserImplTest.scala
@@ -1,12 +1,12 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.StatContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.typeinference.TermTypeInferrer
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnValTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnValTraverserImplTest.scala
@@ -2,15 +2,15 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Decl, Defn, Init, Lit, Mod, Name, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnVarTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnVarTraverserImplTest.scala
@@ -2,14 +2,14 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.{eqSomeTree, eqTreeList}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Defn, Init, Lit, Mod, Name, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DoTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DoTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.BlockContext
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.{ApplyInfix, Block, Do}
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/EtaTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/EtaTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 import scala.meta.Term.Eta

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FinallyTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FinallyTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.BlockContext
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 import scala.meta.Term.Block

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ForTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ForTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.ForToTermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Enumerator.Generator
 import scala.meta.Term.{For, Select}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ForYieldTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ForYieldTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.ForYieldToTermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Enumerator.Generator
 import scala.meta.Term.{ForYield, Select}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/IfTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/IfTraverserImplTest.scala
@@ -3,9 +3,9 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.BlockContext
 import io.github.effiban.scala2java.core.entities.Decision.Yes
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.{Apply, ApplyInfix, Block, If}
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImportTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImportTraverserImplTest.scala
@@ -1,12 +1,12 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.StatContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames.Scala
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.predicates.ImporterExcludedPredicate
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
 import scala.meta.{Import, Importee, Importer, Name, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporteeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporteeTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Importee, Name}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporterTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporterTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Importee, Importer, Name, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InitListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InitListTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.InitContext
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 
 import scala.meta.{Init, Name, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InitTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InitTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{InitContext, InvocationArgListContext}
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Init, Name, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InvocationArgListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InvocationArgListTraverserImplTest.scala
@@ -3,9 +3,9 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{InvocationArgContext, InvocationArgListContext}
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.Parentheses
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 
 import scala.meta.Term

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InvocationArgTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/InvocationArgTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.InvocationArgContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ModListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ModListTraverserImplTest.scala
@@ -3,13 +3,13 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.ModifiersContext
 import io.github.effiban.scala2java.core.entities.JavaModifier.{Final, Private}
 import io.github.effiban.scala2java.core.entities.{JavaModifier, JavaTreeType}
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.resolvers.JavaModifiersResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Decl, Mod, Name, Pat, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NameTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NameTraverserImplTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Name, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NewAnonymousTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NewAnonymousTraverserImplTest.scala
@@ -2,10 +2,10 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.TemplateContext
 import io.github.effiban.scala2java.core.matchers.TemplateContextMatcher.eqTemplateContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.NewAnonymous
 import scala.meta.{Init, Name, Self, Template, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NewTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NewTraverserImplTest.scala
@@ -2,11 +2,11 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ArrayInitializerSizeContext, InitContext}
 import io.github.effiban.scala2java.core.matchers.ArrayInitializerSizeContextMockitoMatcher.eqArrayInitializerSizeContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.ArrayInitializerContextResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.New

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ObjectTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ObjectTraverserImplTest.scala
@@ -6,12 +6,12 @@ import io.github.effiban.scala2java.core.matchers.JavaChildScopeContextMatcher.e
 import io.github.effiban.scala2java.core.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.matchers.TemplateContextMatcher.eqTemplateContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.Block

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PartialFunctionTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PartialFunctionTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.Decision.{Uncertain, Yes}
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Case, Pat, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatExtractInfixTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatExtractInfixTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Pat, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatListTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Pat, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatTraverserImplTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Pat.{Alternative, Bind}
 import scala.meta.{Lit, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatTypedTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatTypedTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Pat, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatVarTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PatVarTraverserImplTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Pat, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgStatListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgStatListTraverserImplTest.scala
@@ -1,13 +1,13 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.SealedHierarchies
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.SealedHierarchiesMatcher.eqSealedHierarchies
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.SealedHierarchiesResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.PrimaryCtors
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Decl, Defn, Name, Pat, Self, Template, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgStatTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgStatTraverserImplTest.scala
@@ -3,10 +3,10 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{ClassOrTraitContext, StatContext}
 import io.github.effiban.scala2java.core.entities.SealedHierarchies
 import io.github.effiban.scala2java.core.matchers.ClassOrTraitContextMatcher.eqClassOrTraitContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.PrimaryCtors
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Decl, Defn, Import, Importee, Importer, Name, Pat, Self, Template, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgTraverserImplTest.scala
@@ -1,11 +1,11 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, TermNames}
 import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Decl, Defn, Import, Importee, Importer, Name, Pat, Pkg, Self, Template, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/RegularClassTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/RegularClassTraverserImplTest.scala
@@ -2,17 +2,17 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts._
 import io.github.effiban.scala2java.core.entities.JavaTreeType
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.JavaChildScopeContextMatcher.eqJavaChildScopeContext
 import io.github.effiban.scala2java.core.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.matchers.TemplateContextMatcher.eqTemplateContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.ParamToDeclValTransformer
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ReturnTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ReturnTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 import scala.meta.Term.Return

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/SourceTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/SourceTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.StatContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Ctor, Defn, Mod, Name, Pkg, Self, Source, Template, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/StatTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/StatTraverserImplTest.scala
@@ -1,11 +1,11 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.StatContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Ctor.Primary

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/SuperTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/SuperTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.Super
 import scala.meta.{Name, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TemplateBodyTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TemplateBodyTraverserImplTest.scala
@@ -3,12 +3,12 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.classifiers.DefnTypeClassifier
 import io.github.effiban.scala2java.core.contexts.{TemplateBodyContext, TemplateChildContext}
 import io.github.effiban.scala2java.core.matchers.TemplateChildContextMatcher.eqTemplateChildContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.orderings.JavaTemplateChildOrdering
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TemplateChildTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TemplateChildTraverserImplTest.scala
@@ -3,11 +3,11 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.classifiers.{DefnValClassifier, JavaStatClassifier}
 import io.github.effiban.scala2java.core.contexts.{CtorContext, StatContext, TemplateChildContext}
 import io.github.effiban.scala2java.core.matchers.CtorContextMatcher.eqCtorContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Ctor, Defn, Init, Lit, Name, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TemplateTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TemplateTraverserImplTest.scala
@@ -2,9 +2,7 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{InitContext, TemplateBodyContext, TemplateContext}
 import io.github.effiban.scala2java.core.entities.JavaKeyword.Implements
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.TemplateBodyContextMatcher.eqTemplateBodyContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.JavaInheritanceKeywordResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
@@ -12,6 +10,8 @@ import io.github.effiban.scala2java.core.testtrees.{Selfs, Templates, TypeNames}
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.spi.predicates.TemplateInitExcludedPredicate
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermAnnotateTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermAnnotateTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Mod.Annot

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermApplyInfixTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermApplyInfixTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames.{Plus, ScalaRange, ScalaTo}
 import io.github.effiban.scala2java.core.transformers.TermApplyInfixToTermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermApplyTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermApplyTraverserImplTest.scala
@@ -2,13 +2,13 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.{ArrayInitializerValuesContext, InvocationArgListContext}
 import io.github.effiban.scala2java.core.matchers.ArrayInitializerValuesContextMockitoMatcher.eqArrayInitializerValuesContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.ArrayInitializerContextResolver
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
 import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermFunctionTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermFunctionTraverserImplTest.scala
@@ -3,11 +3,11 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{BlockContext, StatContext}
 import io.github.effiban.scala2java.core.entities.Decision.{Uncertain, Yes}
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Term.Block

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermInterpolateTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermInterpolateTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.TermInterpolateTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.{Apply, Select}
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermMatchTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermMatchTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Case, Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermNameTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermNameTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames
 import io.github.effiban.scala2java.core.testtrees.TermNames.{Empty, ScalaOption}
 import io.github.effiban.scala2java.core.transformers.TermNameTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermParamListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermParamListTraverserImplTest.scala
@@ -3,10 +3,10 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.StatContext
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.Parentheses
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 
 import scala.meta.{Name, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermParamTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermParamTraverserImplTest.scala
@@ -3,11 +3,11 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{ModifiersContext, StatContext}
 import io.github.effiban.scala2java.core.entities.JavaTreeType
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.{Init, Lit, Mod, Name, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermRefTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermRefTraverserImplTest.scala
@@ -2,8 +2,8 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.TermSelectContext
 import io.github.effiban.scala2java.core.matchers.TermSelectContextMatcher.eqTermSelectContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.{ApplyUnary, Super, This}
 import scala.meta.{Name, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermRepeatedTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermRepeatedTraverserImplTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermSelectTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermSelectTraverserImplTest.scala
@@ -1,12 +1,12 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.TermSelectContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermTraverserImplTest.scala
@@ -3,10 +3,10 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{BlockContext, TryContext}
 import io.github.effiban.scala2java.core.entities.Decision.{No, Uncertain}
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TermNames.Plus
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Enumerator.Generator

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermTupleTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermTupleTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.TermTupleToTermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.Tuple
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ThisTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ThisTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.This
 import scala.meta.{Name, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ThrowTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ThrowTraverserImplTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.Throw
 import scala.meta.{Init, Name, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TraitTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TraitTraverserImplTest.scala
@@ -3,17 +3,17 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts._
 import io.github.effiban.scala2java.core.entities.JavaTreeType
 import io.github.effiban.scala2java.core.entities.JavaTreeType.Interface
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.matchers.JavaChildScopeContextMatcher.eqJavaChildScopeContext
 import io.github.effiban.scala2java.core.matchers.JavaTreeTypeContextMatcher.eqJavaTreeTypeContext
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.matchers.TemplateContextMatcher.eqTemplateContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.resolvers.{JavaChildScopeResolver, JavaTreeTypeResolver}
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{PrimaryCtors, TypeNames}
 import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Defn.Trait

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TryTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TryTraverserImplTest.scala
@@ -3,11 +3,11 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{BlockContext, CatchHandlerContext, TryContext}
 import io.github.effiban.scala2java.core.entities.Decision.Yes
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqSomeTree
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.PatToTermParamTransformer
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqSomeTree
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TryWithHandlerTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TryWithHandlerTraverserImplTest.scala
@@ -3,9 +3,9 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.{BlockContext, TryContext}
 import io.github.effiban.scala2java.core.entities.Decision.Yes
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term
 import scala.meta.Term.Block

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeAnnotateTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeAnnotateTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Mod.Annot

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeApplyTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeApplyTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeBoundsTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeBoundsTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeByNameTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeByNameTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.TypeByNameToSupplierTypeTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeExistentialTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeExistentialTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Decl, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeFunctionTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeFunctionTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.transformers.FunctionTypeTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeListTraverserImplTest.scala
@@ -2,8 +2,8 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter._
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Type

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeParamListTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeParamListTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter._
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeBounds
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchers
 
 import scala.meta.Type

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeParamTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeParamTraverserImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeBounds
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeProjectTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeProjectTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeRefTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeRefTraverserImplTest.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeRefineTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeRefineTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Decl, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeRepeatedTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeRepeatedTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeSelectTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeSelectTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeSingletonTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeSingletonTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.transformers.TypeSingletonToTermTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TypeBounds, TypeNames}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Mod.Annot
 import scala.meta.Type.Bounds

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeTupleTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeTupleTraverserImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.transformers.TypeTupleToTypeApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeWildcardTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeWildcardTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeWithTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeWithTraverserImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Type
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/WhileTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/WhileTraverserImplTest.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.BlockContext
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.{Block, While}
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeInferrerImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.typeinference
 
 import io.github.effiban.scala2java.core.classifiers.TypeNameClassifier
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term, Type}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeTypeInferrerImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.ApplyType
 import scala.meta.{Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/BlockTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/BlockTypeInferrerImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Term.Block
 import scala.meta.{Import, Importee, Importer, Name, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/CaseListTypeInferrerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/CaseListTypeInferrerTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqOptionTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqOptionTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
 import scala.meta.Term.{New, Throw}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/CaseTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/CaseTypeInferrerImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Case, Lit, Term}
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/CompositeArgListTypesInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/CompositeArgListTypesInferrerImplTest.scala
@@ -2,10 +2,10 @@ package io.github.effiban.scala2java.core.typeinference
 
 import io.github.effiban.scala2java.core.classifiers.TermTypeClassifier
 import io.github.effiban.scala2java.core.entities.TermNameValues.ScalaAssociate
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.core.transformers.TermToTupleCaster
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchersSugar.any
 
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/IfTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/IfTypeInferrerImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
 import scala.meta.Term.{If, New, Throw}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ScalarArgListTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ScalarArgListTypeInferrerImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqOptionTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqOptionTreeList
 import org.mockito.ArgumentMatchersSugar.any
 
 import scala.meta.{Lit, Term}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TermTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TermTypeInferrerImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.Enumerator.Generator
 import scala.meta.Term.{Ascribe, Assign, Block, ForYield, If, Match, New}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TryTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TryTypeInferrerImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.{eqOptionTreeList, eqTreeList}
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.{eqOptionTreeList, eqTreeList}
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
 import scala.meta.{Case, Lit, Pat, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TryWithHandlerTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TryWithHandlerTypeInferrerImplTest.scala
@@ -1,9 +1,9 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqOptionTreeList
-import io.github.effiban.scala2java.core.matchers.TreeMatcher.eqTree
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqOptionTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
 import scala.meta.{Lit, Term, Type}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TupleArgListTypesInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/TupleArgListTypesInferrerImplTest.scala
@@ -1,8 +1,8 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchersSugar.any
 
 import scala.meta.{Lit, Term, Type}

--- a/scala2java-test-utils/build.gradle
+++ b/scala2java-test-utils/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'scala2java.library-conventions'
+}
+
+project.ext.scalatestVersion = "3.2.12"
+project.ext.mockitoScalaVersion = "1.17.5"
+
+dependencies {
+    implementation project(':scala2java-spi')
+    implementation project(':scala2java-core')
+
+    api "org.scalatest:scalatest_$scalaMajorVersion:$scalatestVersion"
+    api "org.mockito:mockito-scala_$scalaMajorVersion:$mockitoScalaVersion"
+}
+
+publishing {
+    publications {
+        scala2java(MavenPublication) {
+            pom {
+                name = 'Scala2Java Test Utils'
+                description = 'Test Utils for the Scala2Java Tool and its extensions'
+            }
+        }
+    }
+}

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/matchers/FileMatchers.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/matchers/FileMatchers.scala
@@ -1,6 +1,6 @@
-package io.github.effiban.scala2java.core.integrationtest.matchers
+package io.github.effiban.scala2java.test.utils.integration.matchers
 
-import io.github.effiban.scala2java.core.integrationtest.matchers.FileMatchers.SameFileContentsMessage
+import io.github.effiban.scala2java.test.utils.integration.matchers.FileMatchers.SameFileContentsMessage
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 import java.nio.file.Path

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/matchers/FileMismatchMessageGenerator.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/matchers/FileMismatchMessageGenerator.scala
@@ -1,4 +1,4 @@
-package io.github.effiban.scala2java.core.integrationtest.matchers
+package io.github.effiban.scala2java.test.utils.integration.matchers
 
 import java.nio.file.{Files, Path}
 import scala.collection.mutable

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/runner/IntegrationTestRunner.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/runner/IntegrationTestRunner.scala
@@ -1,8 +1,8 @@
-package io.github.effiban.scala2java.core.integrationtest
+package io.github.effiban.scala2java.test.utils.integration.runner
 
 import io.github.effiban.scala2java.core.Scala2JavaTranslator.translate
-import io.github.effiban.scala2java.core.integrationtest.matchers.FileMatchers.equalContentsOf
-import org.scalatest.funsuite.AnyFunSuite
+import io.github.effiban.scala2java.test.utils.integration.matchers.FileMatchers.equalContentsOf
+import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 
@@ -10,14 +10,19 @@ import java.nio.file.{Files, Path, Paths}
 import scala.jdk.StreamConverters._
 import scala.util.Using
 
-class IntegrationTestRunner extends AnyFunSuite
-  with Matchers
+trait IntegrationTestRunner
+  extends Matchers
   with OptionValues
-  with BeforeAndAfterAll {
+  with BeforeAndAfterAll { this: AnyFunSuiteLike =>
 
-  private val testFilesBasePath = Paths.get(getClass.getClassLoader.getResource("testfiles").toURI)
-  private val selectedTestPath = Option(System.getenv("INTEGRATION_TEST_PATH")).getOrElse("")
+  private val testFilesBasePath: Path = resolveTestFilesBasePath()
+  private val selectedTestPath: String = resolveSelectedTestPath()
+
   private var outputJavaBasePath: Path = _
+
+  protected def resolveTestFilesBasePath(): Path
+
+  protected def resolveSelectedTestPath(): String
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/CombinedMatchers.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/CombinedMatchers.scala
@@ -1,12 +1,10 @@
-package io.github.effiban.scala2java.core.matchers
+package io.github.effiban.scala2java.test.utils.matchers
 
-import io.github.effiban.scala2java.core.contexts.CtorContext
 import org.mockito.ArgumentMatchers.argThat
 
 import scala.meta.Tree
 
 object CombinedMatchers {
-
   def eqSomeTree[T <: Tree](expectedTree: T): Option[T] =
     argThat(new SomeMatcher[T](expectedTree, new TreeMatcher[T](_)))
 
@@ -17,7 +15,4 @@ object CombinedMatchers {
 
   def eqOptionTreeList[T <: Tree](expected: List[Option[T]]): List[Option[T]] =
     argThat(new ListMatcher(expected, new OptionMatcher[T](_, new TreeMatcher[T](_))))
-
-  def eqOptionCtorContext(expected: Option[CtorContext]): Option[CtorContext] =
-    argThat(new OptionMatcher(expected, new CtorContextMatcher(_)))
 }

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/ListMatcher.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/ListMatcher.scala
@@ -1,4 +1,4 @@
-package io.github.effiban.scala2java.core.matchers
+package io.github.effiban.scala2java.test.utils.matchers
 
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/OptionMatcher.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/OptionMatcher.scala
@@ -1,4 +1,4 @@
-package io.github.effiban.scala2java.core.matchers
+package io.github.effiban.scala2java.test.utils.matchers
 
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/SomeMatcher.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/SomeMatcher.scala
@@ -1,4 +1,4 @@
-package io.github.effiban.scala2java.core.matchers
+package io.github.effiban.scala2java.test.utils.matchers
 
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat

--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/TreeMatcher.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/matchers/TreeMatcher.scala
@@ -1,4 +1,4 @@
-package io.github.effiban.scala2java.core.matchers
+package io.github.effiban.scala2java.test.utils.matchers
 
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'scala2java'
 include 'scala2java-core'
 include 'scala2java-spi'
+include 'scala2java-test-utils'
 


### PR DESCRIPTION
Extracted a new module for test utils that will also be published as an artifact. 
This module contains common test utils that can be useful both to this repo internally, and also to extensions