### PR TITLE
Flatten an `Importer` with multiple `Importee`-s before filtering

### DIFF
--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImportTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImportTraverserImplTest.scala
@@ -3,13 +3,12 @@ package io.github.effiban.scala2java.core.traversers
 import io.github.effiban.scala2java.core.contexts.StatContext
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
-import io.github.effiban.scala2java.core.testtrees.TermNames.Scala
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.predicates.ImporterExcludedPredicate
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchers.any
 
-import scala.meta.{Import, Importee, Importer, Name, Term}
+import scala.meta.{Import, Importee, Importer, Name, Term, XtensionQuasiquoteImporter}
 
 class ImportTraverserImplTest extends UnitTestSuite {
 
@@ -20,15 +19,10 @@ class ImportTraverserImplTest extends UnitTestSuite {
 
   private val importTraverser = new ImportTraverserImpl(importerTraverser, importerExcludedPredicate)
 
-  test("traverse() in package scope when all importers should be included") {
-    val importer1 = Importer(
-      ref = Term.Name("mypackage1"),
-      importees = List(Importee.Name(Name.Indeterminate("myclass1")))
-    )
-    val importer2 = Importer(
-      ref = Term.Name("mypackage2"),
-      importees = List(Importee.Name(Name.Indeterminate("myclass2")))
-    )
+  test("traverse() in package scope when all should be included") {
+    val importer1 = importer"mypackage1.myclass1"
+    val importer2 = importer"mypackage2.myclass2"
+    val allImporters = List(importer1, importer2)
 
     when(importerExcludedPredicate.apply(any[Importer])).thenReturn(false)
 
@@ -39,7 +33,7 @@ class ImportTraverserImplTest extends UnitTestSuite {
               |""".stripMargin)
       .when(importerTraverser).traverse(eqTree(importer2))
 
-    importTraverser.traverse(`import` = Import(List(importer1, importer2)), context = PackageStatContext)
+    importTraverser.traverse(`import` = Import(allImporters), context = PackageStatContext)
 
     outputWriter.toString shouldBe
       """import mypackage1.myclass1;
@@ -50,47 +44,114 @@ class ImportTraverserImplTest extends UnitTestSuite {
       .foreach(importer => verify(importerExcludedPredicate).apply(eqTree(importer)))
   }
 
-  test("traverse() in package scope when some importers should be excluded") {
-    val scalaImporter1 = Importer(
-      ref = Scala,
-      importees = List(Importee.Name(Name.Indeterminate("myclass1")))
-    )
-    val nonScalaImporter1 = Importer(
-      ref = Term.Name("mypackage1"),
-      importees = List(Importee.Name(Name.Indeterminate("myclass1")))
-    )
-    val scalaImporter2 = Importer(
-      ref = Scala,
-      importees = List(Importee.Name(Name.Indeterminate("myclass2")))
-    )
-    val nonScalaImporter2 = Importer(
-      ref = Term.Name("mypackage2"),
-      importees = List(Importee.Name(Name.Indeterminate("myclass2")))
-    )
+  test("traverse() in package scope when all should be included and importers have multiple importees") {
+    val importer1 = importer"mypackage1.{myclass1, myclass2}"
+    val importer2 = importer"mypackage2.{myclass3, myclass4}"
+    val allImporters = List(importer1, importer2)
 
-    when(importerExcludedPredicate.apply(any[Importer])).thenAnswer((importer: Importer) =>
-      Seq(scalaImporter1, scalaImporter2).exists(_.structure == importer.structure)
-    )
+    val flattenedImporter1 = importer"mypackage1.myclass1"
+    val flattenedImporter2 = importer"mypackage1.myclass2"
+    val flattenedImporter3 = importer"mypackage2.myclass3"
+    val flattenedImporter4 = importer"mypackage2.myclass4"
+    val allFlattenedImporters = List(flattenedImporter1, flattenedImporter2, flattenedImporter3, flattenedImporter4)
 
+    when(importerExcludedPredicate.apply(any[Importer])).thenReturn(false)
 
     doWrite(
       """import mypackage1.myclass1;
         |""".stripMargin)
-      .when(importerTraverser).traverse(eqTree(nonScalaImporter1))
+      .when(importerTraverser).traverse(eqTree(flattenedImporter1))
     doWrite(
-      """import mypackage2.myclass2;
+      """import mypackage1.myclass2;
         |""".stripMargin)
-      .when(importerTraverser).traverse(eqTree(nonScalaImporter2))
+      .when(importerTraverser).traverse(eqTree(flattenedImporter2))
+    doWrite(
+      """import mypackage2.myclass3;
+        |""".stripMargin)
+      .when(importerTraverser).traverse(eqTree(flattenedImporter3))
+    doWrite(
+      """import mypackage2.myclass4;
+        |""".stripMargin)
+      .when(importerTraverser).traverse(eqTree(flattenedImporter4))
 
-    importTraverser.traverse(
-      `import` = Import(List(scalaImporter1, nonScalaImporter1, scalaImporter2, nonScalaImporter2)),
-      context = PackageStatContext
-    )
+    importTraverser.traverse(`import` = Import(allImporters), context = PackageStatContext)
 
     outputWriter.toString shouldBe
       """import mypackage1.myclass1;
-        |import mypackage2.myclass2;
+        |import mypackage1.myclass2;
+        |import mypackage2.myclass3;
+        |import mypackage2.myclass4;
         |""".stripMargin
+
+    allFlattenedImporters.foreach(importer => verify(importerExcludedPredicate).apply(eqTree(importer)))
+  }
+
+  test("traverse() in package scope when some should be excluded") {
+    val excludedImporter1 = importer"excluded1.myclass1"
+    val excludedImporter2 = importer"excluded2.myclass2"
+    val includedImporter1 = importer"included1.myclass1"
+    val includedImporter2 = importer"included2.myclass2"
+    val allImporters = List(excludedImporter1, includedImporter1, excludedImporter2, includedImporter2)
+
+    when(importerExcludedPredicate.apply(any[Importer])).thenAnswer((importer: Importer) =>
+      Seq(excludedImporter1, excludedImporter2).exists(_.structure == importer.structure)
+    )
+
+
+    doWrite(
+      """import included1.myclass1;
+        |""".stripMargin)
+      .when(importerTraverser).traverse(eqTree(includedImporter1))
+    doWrite(
+      """import included2.myclass2;
+        |""".stripMargin)
+      .when(importerTraverser).traverse(eqTree(includedImporter2))
+
+    importTraverser.traverse(`import` = Import(allImporters), context = PackageStatContext)
+
+    outputWriter.toString shouldBe
+      """import included1.myclass1;
+        |import included2.myclass2;
+        |""".stripMargin
+  }
+
+  test("traverse() in package scope when some should be excluded and importers have multiple importees") {
+    val importer1 = importer"mypackage1.{included1, excluded1}"
+    val importer2 = importer"mypackage2.{included2, excluded2}"
+    val allImporters = List(importer1, importer2)
+
+    val includedFlattenedImporter1 = importer"mypackage1.included1"
+    val excludedFlattenedImporter1 = importer"mypackage1.excluded1"
+    val includedFlattenedImporter2 = importer"mypackage2.included2"
+    val excludedFlattenedImporter2 = importer"mypackage2.excluded2"
+    val allFlattenedImporters = List(
+      includedFlattenedImporter1,
+      excludedFlattenedImporter1,
+      includedFlattenedImporter2,
+      excludedFlattenedImporter2
+    )
+
+    when(importerExcludedPredicate.apply(any[Importer])).thenAnswer((importer: Importer) =>
+      Seq(excludedFlattenedImporter1, excludedFlattenedImporter2).exists(_.structure == importer.structure)
+    )
+
+    doWrite(
+      """import mypackage1.included1;
+        |""".stripMargin)
+      .when(importerTraverser).traverse(eqTree(includedFlattenedImporter1))
+    doWrite(
+      """import mypackage2.included2;
+        |""".stripMargin)
+      .when(importerTraverser).traverse(eqTree(includedFlattenedImporter2))
+
+    importTraverser.traverse(`import` = Import(allImporters), context = PackageStatContext)
+
+    outputWriter.toString shouldBe
+      """import mypackage1.included1;
+        |import mypackage2.included2;
+        |""".stripMargin
+
+    allFlattenedImporters.foreach(importer => verify(importerExcludedPredicate).apply(eqTree(importer)))
   }
 
   test("traverse() in class scope should write a comment") {

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/Scala2JavaExtension.scala
@@ -31,23 +31,24 @@ trait Scala2JavaExtension {
 
   /** Override this method if you need to produce an output Java file with a different name than the input Scala file.
    *
-   * @return if overriden - a transformer which changes the file name
-   *         otherwise - the default which leaves the name unchanged
+   * @return if overriden - a transformer which changes the file name<br>
+   *         otherwise - the default which leaves the name unchanged<br>
    */
   def fileNameTransformer(): FileNameTransformer = FileNameTransformer.Identity
 
   /** Override this method if you need to provide additional [[scala.meta.Importer]]-s (import statements) to the generated Java file.
    *
-   * @return if overriden - a transformer which adds [[scala.meta.Importer]]-s
-   *         otherwise - the default transformer which does not add any
+   * @return if overriden - a transformer which adds [[scala.meta.Importer]]-s<br>
+   *         otherwise - the default transformer which does not add any<br>
    */
   def additionalImportersProvider(): AdditionalImportersProvider = AdditionalImportersProvider.Empty
 
   /** Override this method if you need to exclude [[scala.meta.Importer]]-s (import statements) that exist in the Scala file,
-   * but do not belong in the generated Java file.
+   * but do not belong in the generated Java file.<br>
+   * @see [[ImporterExcludedPredicate]] for more information on how the framework will invoke this predicate.
    *
-   * @return if overriden - a transformer which excludes importers
-   *         otherwise - the default transformer which does not exclude anything
+   * @return if overriden - a transformer which excludes importers<br>
+   *         otherwise - the default transformer which does not exclude anything<br>
    */
   def importerExcludedPredicate(): ImporterExcludedPredicate = ImporterExcludedPredicate.None
 
@@ -55,15 +56,15 @@ trait Scala2JavaExtension {
    * NOTE that this transformer intended for manipulating the class declaration (e.g. name, visibility, annotations).<br>
    * For manipulating the template part (parents, body) - override one of the other transformers instead.
    *
-   * @return if overriden - a transformer which modifies a given class
-   *         otherwise - the default transformer which doesn't change anything
+   * @return if overriden - a transformer which modifies a given class<br>
+   *         otherwise - the default transformer which doesn't change anything<br>
    */
   def classTransformer(): ClassTransformer = ClassTransformer.Identity
 
   /** Override this method if you need to exclude [[scala.meta.Init]]-s (parents) of a class/trait/object in the corresponding Java type.<br>
    *
-   * @return if overriden - a predicate which determines whether to exclude a [[scala.meta.Init]]
-   *         otherwise - the default predicate which doesn't exclude anything
+   * @return if overriden - a predicate which determines whether to exclude a [[scala.meta.Init]]<br>
+   *         otherwise - the default predicate which doesn't exclude anything<br>
    */
   def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = TemplateInitExcludedPredicate.None
 
@@ -71,15 +72,15 @@ trait Scala2JavaExtension {
    * [[scala.meta.Decl.Var]] (`var` declaration).<br>
    * @see [[DefnValToDeclVarTransformer]] for a usage example.
    *
-   * @return if overriden - a transformer which transforms a [[scala.meta.Defn.Val]] into a [[scala.meta.Decl.Var]] where applicable
-   *         otherwise - the default transformer which never transforms (returns `None`)
+   * @return if overriden - a transformer which transforms a [[scala.meta.Defn.Val]] into a [[scala.meta.Decl.Var]] where applicable<br>
+   *         otherwise - the default transformer which never transforms (returns `None`)<br>
    */
   def defnValToDeclVarTransformer(): DefnValToDeclVarTransformer = DefnValToDeclVarTransformer.Empty
 
   /** Override this method if you need to modify a [[scala.meta.Defn.Def]] (method definition)
    *
-   * @return if overriden - a transformer which modifies a given [[scala.meta.Defn.Def]]
-   *         otherwise - the default transformer which doesn't modify anything
+   * @return if overriden - a transformer which modifies a given [[scala.meta.Defn.Def]]<br>
+   *         otherwise - the default transformer which doesn't modify anything<br>
    */
   def defnDefTransformer(): DefnDefTransformer = DefnDefTransformer.Identity
 
@@ -94,8 +95,8 @@ trait Scala2JavaExtension {
 
   /** Override this method if you need to modify a [[scala.meta.Term.Apply]] (method invocation)
    *
-   * @return if overriden - a transformer which modifies a given [[scala.meta.Term.Apply]]
-   *         otherwise - the default transformer which doesn't modify anything
+   * @return if overriden - a transformer which modifies a given [[scala.meta.Term.Apply]]<br>
+   *         otherwise - the default transformer which doesn't modify anything<br>
    */
   def termApplyTransformer(): TermApplyTransformer = TermApplyTransformer.Identity
 
@@ -106,8 +107,8 @@ trait Scala2JavaExtension {
    *   - inner member selections
    *   - others...
    *
-   * @return if overriden - a transformer which modifies a given [[scala.meta.Term.Select]]
-   *         otherwise - the default transformer which doesn't modify anything
+   * @return if overriden - a transformer which modifies a given [[scala.meta.Term.Select]]<br>
+   *         otherwise - the default transformer which doesn't modify anything<br>
    */
   def termSelectTransformer(): TermSelectTransformer = TermSelectTransformer.Identity
 }

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/predicates/ImporterExcludedPredicate.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/predicates/ImporterExcludedPredicate.scala
@@ -2,8 +2,17 @@ package io.github.effiban.scala2java.spi.predicates
 
 import scala.meta.Importer
 
-/** A predicate which determines whether a given [[Importer]]s (individual `import` statement) from the Scala source file,
- * should be excluded from the generated Java source file.
+/** A predicate which determines whether a given [[Importer]] (Scala `import` statement),
+ * should be excluded from the generated Java source file.<br>
+ * '''NOTE''' - a Scala `import` statement might be an aggregation of statements having the same suffix ([[scala.meta.Importee]]).<br>
+ * In such a case, the framework will split the statements into separate ones and invoke the predicate separately for each, to allow
+ * fine-grained exclusion logic.<br>
+ * For example, if the Scala file has the statement:<br>
+ * `import aaa.bbb.{ccc, ddd}`<br>
+ * then the framework will split it into two separate statements:<br>
+ * `import aaa.bbb.ccc`<br>
+ * `import aaa.bbb.ddd`<br>
+ * --> and the predicate will be invoked for each one separately.
  */
 trait ImporterExcludedPredicate extends (Importer => Boolean)
 


### PR DESCRIPTION
When an `Importer` has multiple `Importee`-s, flatten (split) them into multiple `Importer`-s with one `Importee` each before calling any `ImporterExcludedPredicate`-s which can filter out unwanted `import`-s.
For example, giving the following Scala `import` statement:

`import aaa.bbb.{ccc, ddd}`

It will be transformed into the following two `import` statements, before the predicates are called:
```
import aaa.bbb.ccc
import aaa.bbb.ddd
```

This way, if an extension implements `ImporterExcludedPredicate`, it will have the ability to exclude only one of the individual flattened imports as needed (in the example above, an extension might decide to exclude only `aaa.bbb.ccc`)

