### PR TITLE
Optimize extension registry building

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilder.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilder.scala
@@ -9,7 +9,9 @@ import scala.meta.{Source, Term}
 class ExtensionRegistryBuilder {
 
   def buildFor(source: Source): ExtensionRegistry = {
-    val termSelects = source.collect { case termSelect: Term.Select => termSelect }
+    val termSelects = source
+      .collect { case termSelect: Term.Select => termSelect }
+      .distinctBy(_.structure)
 
     val extensions = loadExtensions()
       .map(_.get)

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilderTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilderTest.scala
@@ -2,6 +2,7 @@ package io.github.effiban.scala2java.core.extensions
 
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import java.util.ServiceLoader.Provider
 import scala.meta.{Import, Importer, Source, Term, XtensionQuasiquoteImportee, XtensionQuasiquoteTerm}
@@ -14,7 +15,8 @@ class ExtensionRegistryBuilderTest extends UnitTestSuite {
     List(
       Import(
         List(
-          Importer(TheTermSelect1, List(importee"c")),
+          Importer(TheTermSelect1, List(importee"c1")),
+          Importer(TheTermSelect1, List(importee"c2")),
           Importer(TheTermSelect2, List(importee"g"))
         )
       )
@@ -22,33 +24,39 @@ class ExtensionRegistryBuilderTest extends UnitTestSuite {
   )
 
   test("build() when there are two extensions and both should be applied, should return a registry with both") {
-    val extension1 = extensionThatShouldBeApplied()
-    val extension2 = extensionThatShouldBeApplied()
-    val extensions = List(extension1, extension2)
+    val extensions = List(TestExtensionThatShouldBeApplied, TestExtensionThatShouldBeApplied)
 
     registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(extensions)
   }
 
   test("build() when there is are two extensions and only second should be applied, should return a registry with second only") {
-    val extension1 = extensionThatShouldNotBeApplied()
-    val extension2 = extensionThatShouldBeApplied()
-    val extensions = List(extension1, extension2)
+    val extensions = List(TestExtensionThatShouldNotBeApplied, TestExtensionThatShouldBeApplied)
 
-    registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(List(extension2))
+    registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(List(TestExtensionThatShouldBeApplied))
   }
 
   test("build() when there is one extension that should be applied should return a registry with it") {
-    val extension = extensionThatShouldBeApplied()
-    registryBuilderFrom(List(extension)).buildFor(TheSource) shouldBe ExtensionRegistry(List(extension))
+    registryBuilderFrom(List(TestExtensionThatShouldBeApplied)).buildFor(TheSource) shouldBe ExtensionRegistry(List(TestExtensionThatShouldBeApplied))
   }
 
   test("build() when there is one extension that should not be applied, should return an empty registry") {
-    val extension = extensionThatShouldNotBeApplied()
-    registryBuilderFrom(List(extension)).buildFor(TheSource) shouldBe ExtensionRegistry()
+    registryBuilderFrom(List(TestExtensionThatShouldNotBeApplied)).buildFor(TheSource) shouldBe ExtensionRegistry()
   }
 
   test("build() when there no extensions should return an empty registry") {
     emptyRegistryBuilder().buildFor(TheSource) shouldBe ExtensionRegistry()
+  }
+
+  test("build() when there is one extension that should be applied and a qualified name appears twice - should invoke the extension only once") {
+    val extension = spy(TestExtensionThatShouldBeApplied)
+    registryBuilderFrom(List(extension)).buildFor(TheSource)
+    verify(extension).shouldBeAppliedIfContains(eqTree(TheTermSelect1))
+  }
+
+  test("build() when there is one extension that should not be applied and a qualified name appears twice - should invoke the extension only once") {
+    val extension = spy(TestExtensionThatShouldNotBeApplied)
+    registryBuilderFrom(List(extension)).buildFor(TheSource)
+    verify(extension).shouldBeAppliedIfContains(eqTree(TheTermSelect1))
   }
 
   private def emptyRegistryBuilder() = registryBuilderFrom(Nil)
@@ -65,11 +73,12 @@ class ExtensionRegistryBuilderTest extends UnitTestSuite {
     }
   }
 
-  private def extensionThatShouldBeApplied() = new Scala2JavaExtension() {
+  private object TestExtensionThatShouldBeApplied extends Scala2JavaExtension {
     override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean = termSelect.structure == TheTermSelect1.structure
   }
 
-  private def extensionThatShouldNotBeApplied() = new Scala2JavaExtension() {
-    override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean = !Set(TheTermSelect1, TheTermSelect2).exists(_.structure == termSelect.structure)
+  private object TestExtensionThatShouldNotBeApplied extends Scala2JavaExtension {
+    override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean =
+      !Set(TheTermSelect1, TheTermSelect2).exists(_.structure == termSelect.structure)
   }
 }


### PR DESCRIPTION
When checking if an extension should be applied, call the extension method with each `Term.Select` only once, even if it appears multiple times in the file.