### PR TITLE
Remove duplicate `Importer`s before traversal

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ImportTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ImportTraverser.scala
@@ -34,6 +34,7 @@ private[traversers] class ImportTraverserImpl(importerTraverser: => ImporterTrav
       case importers => importers.flatMap(flattenImportees)
         .filterNot(importerExcludedPredicate)
         .map(importerTransformer.transform)
+        .distinctBy(_.structure)
         .foreach(importerTraverser.traverse)
     }
   }


### PR DESCRIPTION
Since an extension can add and modify `Importer`s, it may cause duplicate `Importer`s to be traversed and output as Java code.
While this is not such a big deal to the user, it is still unnecessary and can produce some unexpected results in tests.
So this PR eliminates the duplicates right before the traversal phase and the Java code generation.