### PR TITLE
Support forcing an extension to be applied even when condition doesn't match

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionApplicablePredicate.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ExtensionApplicablePredicate.scala
@@ -1,0 +1,22 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.spi.Scala2JavaExtension
+
+import scala.meta.Term
+
+private[extensions] trait ExtensionApplicablePredicate {
+  def apply(extension: Scala2JavaExtension,
+            forcedExtensionNames: Iterable[String] = Nil,
+            termSelects: Iterable[Term.Select] = Nil): Boolean
+}
+
+private[extensions] object ExtensionApplicablePredicate extends ExtensionApplicablePredicate {
+
+  override def apply(extension: Scala2JavaExtension,
+                     forcedExtensionNames: Iterable[String] = Nil,
+                     termSelects: Iterable[Term.Select] = Nil): Boolean = {
+    forcedExtensionNames.exists(extension.getClass.getCanonicalName.contains) ||
+      termSelects.exists(extension.shouldBeAppliedIfContains)
+  }
+
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ForcedExtensionNamesResolver.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/extensions/ForcedExtensionNamesResolver.scala
@@ -1,0 +1,19 @@
+package io.github.effiban.scala2java.core.extensions
+
+private[extensions] trait ForcedExtensionNamesResolver {
+
+  def resolve(): Set[String]
+}
+
+private[extensions] object ForcedExtensionNamesResolver extends ForcedExtensionNamesResolver {
+
+  private final val ForcedExtensionsPropertyName = "Scala2JavaForcedExtensions"
+
+  override def resolve(): Set[String] = {
+    Option(System.getProperty(ForcedExtensionsPropertyName))
+      .map(_.split(","))
+      .map(extNames => extNames.map(_.trim).filterNot(_.isEmpty))
+      .map(_.toSet)
+      .getOrElse(Set.empty)
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionApplicablePredicateTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionApplicablePredicateTest.scala
@@ -1,0 +1,58 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.spi.Scala2JavaExtension
+
+import scala.meta.{Term, XtensionQuasiquoteTerm}
+
+class ExtensionApplicablePredicateTest extends UnitTestSuite {
+
+  test("apply() when forced extension names provided and extension fully matches one, should return true") {
+    val result = ExtensionApplicablePredicate.apply(
+      TestExtension(),
+      forcedExtensionNames = List(
+        "io.github.effiban.scala2java.core.extensions.ExtensionApplicablePredicateTest.TestExtension",
+        "io.github.effiban.scala2java.core.extensions.ExtensionApplicablePredicateTest.BlaBla"
+      )
+    )
+    result shouldBe true
+  }
+
+  test("apply() when forced extension names provided and extension partially matches one, should return true") {
+    ExtensionApplicablePredicate.apply(TestExtension(), forcedExtensionNames = List("TestExtension", "blabla")) shouldBe true
+  }
+
+  test("apply() when selects provided and extension matches one of them, should return true") {
+    val extension = TestExtension(Set(q"aaa.bbb"))
+    ExtensionApplicablePredicate.apply(extension, termSelects = Set(q"aaa.bbb", q"ccc.ddd")) shouldBe true
+  }
+
+  test("apply() when forced extension names and term selects provided and extension matches one of each, should return true") {
+    val extension = TestExtension(Set(q"aaa.bbb"))
+    val result = ExtensionApplicablePredicate.apply(
+      extension,
+      forcedExtensionNames = List("TestExtension", "blabla"),
+      termSelects = Set(q"aaa.bbb", q"ccc.ddd")
+    )
+    result shouldBe true
+  }
+
+  test("apply() when forced extension names provided and extension does not match any, should return false") {
+    ExtensionApplicablePredicate.apply(TestExtension(), forcedExtensionNames = List("blabla", "gaga")) shouldBe false
+  }
+
+  test("apply() when selects provided and extension does not match any, should return false") {
+    val extension = TestExtension(Set(q"aaa.bbb"))
+    ExtensionApplicablePredicate.apply(extension, termSelects = List(q"ccc.ddd", q"eee.fff")) shouldBe false
+  }
+
+  test("apply() when no forced extension names or selects provided, should return false") {
+    val extension = TestExtension(Set(q"aaa.bbb"))
+    ExtensionApplicablePredicate.apply(extension) shouldBe false
+  }
+
+  private case class TestExtension(termSelects: Iterable[Term.Select] = Nil) extends Scala2JavaExtension {
+    override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean =
+      termSelects.exists(_.structure == termSelect.structure)
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilderTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ExtensionRegistryBuilderTest.scala
@@ -2,66 +2,80 @@ package io.github.effiban.scala2java.core.extensions
 
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
-import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import java.util.ServiceLoader.Provider
-import scala.meta.{Import, Importer, Source, Term, XtensionQuasiquoteImportee, XtensionQuasiquoteTerm}
+import scala.meta.{Import, Importer, Source, XtensionQuasiquoteImportee, XtensionQuasiquoteTerm}
 
 class ExtensionRegistryBuilderTest extends UnitTestSuite {
 
-  private val TheTermSelect1 = q"a.b"
-  private val TheTermSelect2 = q"e.f"
+  private final val ForcedExtensionNames = Set("Extension1", "Extension2")
+
+  private val TermSelect1 = q"a.b"
+  private val TermSelect2 = q"d.e"
+  private val TermSelects = List(TermSelect1, TermSelect2)
   private val TheSource = Source(
     List(
       Import(
         List(
-          Importer(TheTermSelect1, List(importee"c1")),
-          Importer(TheTermSelect1, List(importee"c2")),
-          Importer(TheTermSelect2, List(importee"g"))
+          Importer(TermSelect1, List(importee"c")),
+          Importer(TermSelect2, List(importee"f"))
         )
       )
     )
   )
 
-  test("build() when there are two extensions and both should be applied, should return a registry with both") {
-    val extensions = List(TestExtensionThatShouldBeApplied, TestExtensionThatShouldBeApplied)
+  private val forcedExtensionNamesResolver = mock[ForcedExtensionNamesResolver]
+  private val extensionApplicablePredicate = mock[ExtensionApplicablePredicate]
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(forcedExtensionNamesResolver.resolve()).thenReturn(ForcedExtensionNames)
+  }
+
+  test("build() when there are two extensions and both should be applied - should return a registry with both") {
+    val extensions = List(mock[Scala2JavaExtension], mock[Scala2JavaExtension])
+
+    whenApplyPredicate(extensions.head).thenReturn(true)
+    whenApplyPredicate(extensions(1)).thenReturn(true)
 
     registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(extensions)
   }
 
-  test("build() when there is are two extensions and only second should be applied, should return a registry with second only") {
-    val extensions = List(TestExtensionThatShouldNotBeApplied, TestExtensionThatShouldBeApplied)
+  test("build() when there are two extensions and only second should be applied, should return a registry with second only") {
+    val extensions = List(mock[Scala2JavaExtension], mock[Scala2JavaExtension])
 
-    registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(List(TestExtensionThatShouldBeApplied))
+    whenApplyPredicate(extensions.head).thenReturn(false)
+    whenApplyPredicate(extensions(1)).thenReturn(true)
+
+    registryBuilderFrom(extensions).buildFor(TheSource) shouldBe ExtensionRegistry(List(extensions(1)))
   }
 
-  test("build() when there is one extension that should be applied should return a registry with it") {
-    registryBuilderFrom(List(TestExtensionThatShouldBeApplied)).buildFor(TheSource) shouldBe ExtensionRegistry(List(TestExtensionThatShouldBeApplied))
+  test("build() when there is one extension that should be applied, should return a registry with it") {
+    val extension = mock[Scala2JavaExtension]
+
+    whenApplyPredicate(extension).thenReturn(true)
+
+    registryBuilderFrom(List(extension)).buildFor(TheSource) shouldBe ExtensionRegistry(List(extension))
   }
 
   test("build() when there is one extension that should not be applied, should return an empty registry") {
-    registryBuilderFrom(List(TestExtensionThatShouldNotBeApplied)).buildFor(TheSource) shouldBe ExtensionRegistry()
+    val extension = mock[Scala2JavaExtension]
+
+    whenApplyPredicate(extension).thenReturn(false)
+
+    registryBuilderFrom(List(extension)).buildFor(TheSource) shouldBe ExtensionRegistry()
   }
 
   test("build() when there no extensions should return an empty registry") {
     emptyRegistryBuilder().buildFor(TheSource) shouldBe ExtensionRegistry()
   }
 
-  test("build() when there is one extension that should be applied and a qualified name appears twice - should invoke the extension only once") {
-    val extension = spy(TestExtensionThatShouldBeApplied)
-    registryBuilderFrom(List(extension)).buildFor(TheSource)
-    verify(extension).shouldBeAppliedIfContains(eqTree(TheTermSelect1))
-  }
-
-  test("build() when there is one extension that should not be applied and a qualified name appears twice - should invoke the extension only once") {
-    val extension = spy(TestExtensionThatShouldNotBeApplied)
-    registryBuilderFrom(List(extension)).buildFor(TheSource)
-    verify(extension).shouldBeAppliedIfContains(eqTree(TheTermSelect1))
-  }
-
   private def emptyRegistryBuilder() = registryBuilderFrom(Nil)
 
-  private def registryBuilderFrom(extensions: List[Scala2JavaExtension]) = new ExtensionRegistryBuilder() {
+  private def registryBuilderFrom(extensions: List[Scala2JavaExtension]) =
+    new ExtensionRegistryBuilder(forcedExtensionNamesResolver, extensionApplicablePredicate) {
 
     override private[extensions] def loadExtensions() = {
       val extensionProviders = extensions.map(extension => new Provider[Scala2JavaExtension] {
@@ -73,12 +87,12 @@ class ExtensionRegistryBuilderTest extends UnitTestSuite {
     }
   }
 
-  private object TestExtensionThatShouldBeApplied extends Scala2JavaExtension {
-    override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean = termSelect.structure == TheTermSelect1.structure
+  private def whenApplyPredicate(extension: Scala2JavaExtension) = {
+    when(extensionApplicablePredicate.apply(
+      eqTo(extension),
+      eqTo(ForcedExtensionNames),
+      eqTreeList(TermSelects)
+    ))
   }
 
-  private object TestExtensionThatShouldNotBeApplied extends Scala2JavaExtension {
-    override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean =
-      !Set(TheTermSelect1, TheTermSelect2).exists(_.structure == termSelect.structure)
-  }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ForcedExtensionNamesResolverTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/extensions/ForcedExtensionNamesResolverTest.scala
@@ -1,0 +1,56 @@
+package io.github.effiban.scala2java.core.extensions
+
+import io.github.effiban.scala2java.core.extensions.ForcedExtensionNamesResolver.resolve
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+
+class ForcedExtensionNamesResolverTest extends UnitTestSuite {
+
+  private final val ForcedExtensionsPropertyName = "Scala2JavaForcedExtensions"
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    clearProperty()
+  }
+
+  test("resolve() when there are two distinct names in the property without spaces should return them") {
+    setProperty("Ext1,Ext2")
+    resolve() shouldBe Set("Ext1", "Ext2")
+  }
+
+  test("resolve() when there are two distinct names in the property with spaces should return them without spaces") {
+    setProperty(" Ext1 , Ext2 ")
+    resolve() shouldBe Set("Ext1", "Ext2")
+  }
+
+  test("resolve() when there are two distinct names in the property and one empty name should skip the empty one") {
+    setProperty("Ext1, ,Ext2")
+    resolve() shouldBe Set("Ext1", "Ext2")
+  }
+
+  test("resolve() when there are two identical names in the property should return just one") {
+    setProperty("Ext,Ext")
+    resolve() shouldBe Set("Ext")
+  }
+
+  test("resolve() when there is one name in the property should return it") {
+    setProperty("Ext")
+    resolve() shouldBe Set("Ext")
+  }
+
+  test("resolve() when the property is empty should return empty") {
+    setProperty("")
+    resolve() shouldBe Set.empty
+  }
+
+  test("resolve() when the property doesn't exist should return empty") {
+    resolve() shouldBe Set.empty
+  }
+
+  private def setProperty(forcedExtensionNamesStr: String): Unit = {
+    System.setProperty(ForcedExtensionsPropertyName, forcedExtensionNamesStr)
+  }
+
+  private def clearProperty(): Unit = {
+    System.clearProperty(ForcedExtensionsPropertyName)
+  }
+}


### PR DESCRIPTION
Sometimes the user will wish to apply an extension, even though the condition defined for the extension doesn't match the source file.
This could happen for example if a class extends a trait, defined separately - which encapsulates all of the imports / qualified names that the extension recognizes. In that case, there would be nothing left in the class itself to be recognized as erlevant to the extension.
Since the tool does not support semantic data yet, it would not possible to obtain this information from the trait - so instead, adding a 'force' mechanism by which the user can set a system property specifying which extensions should be applied, regardless of whether their conditions are met.