### PR TITLE
Refactor `InvocationArgClassifier`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/classifiers/InvocationArgClassifier.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/classifiers/InvocationArgClassifier.scala
@@ -1,14 +1,13 @@
 package io.github.effiban.scala2java.core.classifiers
 
-import io.github.effiban.scala2java.core.contexts.ArgumentContext
-import io.github.effiban.scala2java.core.entities.TermNameValues
 import io.github.effiban.scala2java.core.entities.TermNameValues.Apply
+import io.github.effiban.scala2java.core.entities.{ArgumentCoordinates, TermNameValues}
 
 import scala.meta.Term
 
 trait InvocationArgClassifier {
 
-  def isPassedByName(argContext: ArgumentContext): Boolean
+  def isPassedByName(argCoords: ArgumentCoordinates): Boolean
 }
 
 object InvocationArgClassifier extends InvocationArgClassifier {
@@ -19,10 +18,10 @@ object InvocationArgClassifier extends InvocationArgClassifier {
   )
 
 
-  override def isPassedByName(argContext: ArgumentContext): Boolean = {
-    argContext match {
-      case ArgumentContext(Some(Term.Apply(method, _)), _, 0, _) if isFirstArgPassedByName(method) => true
-      case ArgumentContext(Some(Term.Apply(Term.ApplyType(method, _), _)), _, 0, _) if isFirstArgPassedByName(method) => true
+  override def isPassedByName(argCoords: ArgumentCoordinates): Boolean = {
+    argCoords match {
+      case ArgumentCoordinates(Term.Apply(method, _), _, 0) if isFirstArgPassedByName(method) => true
+      case ArgumentCoordinates(Term.Apply(Term.ApplyType(method, _), _), _, 0) if isFirstArgPassedByName(method) => true
       case _ => false
     }
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/ArgumentContext.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/ArgumentContext.scala
@@ -6,3 +6,4 @@ case class ArgumentContext(maybeParent: Option[Tree] = None,
                            maybeName: Option[Term.Name] = None,
                            index: Int,
                            argNameAsComment: Boolean = false)
+

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/entities/ArgumentCoordinates.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/entities/ArgumentCoordinates.scala
@@ -1,0 +1,7 @@
+package io.github.effiban.scala2java.core.entities
+
+import scala.meta.{Term, Tree}
+
+case class ArgumentCoordinates(parent: Tree,
+                               maybeName: Option[Term.Name] = None,
+                               index: Int)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultInvocationArgTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultInvocationArgTraverser.scala
@@ -2,6 +2,7 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.classifiers.InvocationArgClassifier
 import io.github.effiban.scala2java.core.contexts.ArgumentContext
+import io.github.effiban.scala2java.core.entities.ArgumentCoordinates
 
 import scala.meta.Term
 
@@ -9,7 +10,12 @@ private[traversers] class DefaultInvocationArgTraverser(expressionTraverser: => 
                                                         invocationArgClassifier: InvocationArgClassifier) extends InvocationArgTraverser[Term] {
 
   override def traverse(arg: Term, context: ArgumentContext): Unit = {
-    val adjustedArg = if (invocationArgClassifier.isPassedByName(context)) Term.Function(Nil, arg) else arg
+    import context._
+    val maybeCoords = maybeParent.map(parent => ArgumentCoordinates(parent, maybeName, index))
+    val adjustedArg = maybeCoords match {
+      case Some(coords) if invocationArgClassifier.isPassedByName(coords) => Term.Function(Nil, arg)
+      case _ => arg
+    }
     expressionTraverser.traverse(adjustedArg)
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/classifiers/InvocationArgClassifierTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/classifiers/InvocationArgClassifierTest.scala
@@ -1,6 +1,6 @@
 package io.github.effiban.scala2java.core.classifiers
 
-import io.github.effiban.scala2java.core.contexts.ArgumentContext
+import io.github.effiban.scala2java.core.entities.ArgumentCoordinates
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 
 import scala.meta.XtensionQuasiquoteTerm
@@ -8,20 +8,21 @@ import scala.meta.XtensionQuasiquoteTerm
 class InvocationArgClassifierTest extends UnitTestSuite {
 
   private val ArgumentContextClassifications = Table(
-    ("ArgumentContext", "ExpectedPassedByName"),
-    (ArgumentContext(maybeParent = Some(q"Try.apply(x)"), index = 0), true),
-    (ArgumentContext(maybeParent = Some(q"Try.apply[Int](x)"), index = 0), true),
-    (ArgumentContext(maybeParent = Some(q"Future.apply(x)"), index = 0), true),
-    (ArgumentContext(maybeParent = Some(q"Future.apply[Int](x)"), index = 0), true),
-    (ArgumentContext(maybeParent = Some(q"Some(x)"), index = 0), false),
-    (ArgumentContext(maybeParent = Some(q"Right(x)"), index = 0), false),
-    (ArgumentContext(index = 0), false),
-    (ArgumentContext(index = 1), false)
+    ("ArgumentCoordinates", "ExpectedPassedByName"),
+    (ArgumentCoordinates(parent = q"Try.apply(x)", index = 0), true),
+    (ArgumentCoordinates(parent = q"Try.apply[Int](x)", index = 0), true),
+    (ArgumentCoordinates(parent = q"Future.apply(x)", index = 0), true),
+    (ArgumentCoordinates(parent = q"Future.apply[Int](x)", index = 0), true),
+    (ArgumentCoordinates(parent = q"Some(x)", maybeName = Some(q"value"), index = 0), false),
+    (ArgumentCoordinates(parent = q"Some(x)", index = 0), false),
+    (ArgumentCoordinates(parent = q"Right(x)", index = 0), false),
+    (ArgumentCoordinates(parent = q"foo(x)", index = 0), false),
+    (ArgumentCoordinates(parent = q"foo(x)", index = 1), false)
   )
 
-  forAll(ArgumentContextClassifications) { case (argContext: ArgumentContext, expectedPassedByName: Boolean) =>
-    test(s"$argContext should be considered as passed by ${if (expectedPassedByName) "name" else "value"}") {
-      InvocationArgClassifier.isPassedByName(argContext)
+  forAll(ArgumentContextClassifications) { case (argCoords: ArgumentCoordinates, expectedPassedByName: Boolean) =>
+    test(s"The argument at: $argCoords is passed by ${if (expectedPassedByName) "name" else "value"}") {
+      InvocationArgClassifier.isPassedByName(argCoords)
     }
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArgumentContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArgumentContextMatcher.scala
@@ -5,19 +5,28 @@ import io.github.effiban.scala2java.test.utils.matchers.{OptionMatcher, TreeMatc
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
 
-import scala.meta.Tree
+import scala.meta.{Term, Tree}
 
 class ArgumentContextMatcher(expectedContext: ArgumentContext) extends ArgumentMatcher[ArgumentContext] {
 
   override def matches(actualContext: ArgumentContext): Boolean = {
-    maybeParentsMatch(actualContext) && indexesMatch(actualContext)
+    maybeParentsMatch(actualContext) &&
+      maybeNamesMatch(actualContext) &&
+      indexesMatch(actualContext) &&
+      argNameAsCommentFlagsMatch(actualContext)
   }
 
   private def maybeParentsMatch(actualContext: ArgumentContext) = {
     new OptionMatcher[Tree](expectedContext.maybeParent, new TreeMatcher[Tree](_)).matches(actualContext.maybeParent)
   }
 
+  private def maybeNamesMatch(actualContext: ArgumentContext) = {
+    new OptionMatcher[Term.Name](expectedContext.maybeName, new TreeMatcher[Term.Name](_)).matches(actualContext.maybeName)
+  }
+
   private def indexesMatch(actualContext: ArgumentContext): Boolean = actualContext.index == expectedContext.index
+
+  private def argNameAsCommentFlagsMatch(actualContext: ArgumentContext): Boolean = actualContext.argNameAsComment == expectedContext.argNameAsComment
 
   override def toString: String = s"Matcher for: $expectedContext"
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArgumentCoordinatesMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/ArgumentCoordinatesMatcher.scala
@@ -1,0 +1,35 @@
+package io.github.effiban.scala2java.core.matchers
+
+import io.github.effiban.scala2java.core.entities.ArgumentCoordinates
+import io.github.effiban.scala2java.test.utils.matchers.{OptionMatcher, TreeMatcher}
+import org.mockito.ArgumentMatcher
+import org.mockito.ArgumentMatchers.argThat
+
+import scala.meta.{Term, Tree}
+
+class ArgumentCoordinatesMatcher(expectedCoords: ArgumentCoordinates) extends ArgumentMatcher[ArgumentCoordinates] {
+
+  override def matches(actualCoords: ArgumentCoordinates): Boolean = {
+    parentsMatch(actualCoords) &&
+      maybeNamesMatch(actualCoords) &&
+      indexesMatch(actualCoords)
+  }
+
+  private def parentsMatch(actualCoords: ArgumentCoordinates) = {
+    new TreeMatcher[Tree](expectedCoords.parent).matches(actualCoords.parent)
+  }
+
+  private def maybeNamesMatch(actualCoords: ArgumentCoordinates) = {
+    new OptionMatcher[Term.Name](expectedCoords.maybeName, new TreeMatcher[Term.Name](_)).matches(actualCoords.maybeName)
+  }
+
+  private def indexesMatch(actualCoords: ArgumentCoordinates): Boolean = actualCoords.index == expectedCoords.index
+
+  override def toString: String = s"Matcher for: $expectedCoords"
+}
+
+object ArgumentCoordinatesMatcher {
+  def eqArgumentCoordinates(expectedCoords: ArgumentCoordinates): ArgumentCoordinates =
+    argThat(new ArgumentCoordinatesMatcher(expectedCoords))
+}
+

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AssignInvocationArgTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/AssignInvocationArgTraverserTest.scala
@@ -39,7 +39,7 @@ class AssignInvocationArgTraverserTest extends UnitTestSuite {
     val rhs = Lit.Int(1)
     val assign = Term.Assign(lhs, rhs)
     val initialContext = ArgumentContext(index = 0, argNameAsComment = true)
-    val expectedAdjustedContext = ArgumentContext(maybeName = Some(lhs), index = 0)
+    val expectedAdjustedContext = ArgumentContext(maybeName = Some(lhs), index = 0, argNameAsComment = true)
 
     doWrite("/* x = */").when(assignLHSTraverser).traverse(eqTree(lhs), asComment = eqTo(true))
     doWrite("1").when(defaultInvocationArgTraverser).traverse(eqTree(rhs), eqArgumentContext(expectedAdjustedContext))

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefaultInvocationArgTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefaultInvocationArgTraverserTest.scala
@@ -2,7 +2,8 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.classifiers.InvocationArgClassifier
 import io.github.effiban.scala2java.core.contexts.ArgumentContext
-import io.github.effiban.scala2java.core.matchers.ArgumentContextMatcher.eqArgumentContext
+import io.github.effiban.scala2java.core.entities.ArgumentCoordinates
+import io.github.effiban.scala2java.core.matchers.ArgumentCoordinatesMatcher.eqArgumentCoordinates
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
@@ -18,49 +19,82 @@ class DefaultInvocationArgTraverserTest extends UnitTestSuite {
     invocationArgClassifier
   )
 
-  test("traverse when arg is a Lit and passed by value") {
+  test("traverse when has a parent, has a name, and is a Lit passed by value") {
+    val parent = q"foo(x)"
+    val name = q"arg1"
     val arg = q"1"
-    val context = ArgumentContext(index = 0)
+    val context = ArgumentContext(maybeParent = Some(parent), maybeName = Some(name), index = 0)
+    val coords = ArgumentCoordinates(parent = parent, maybeName = Some(name), index = 0)
 
-    when(invocationArgClassifier.isPassedByName(eqArgumentContext(context))).thenReturn(false)
+    when(invocationArgClassifier.isPassedByName(eqArgumentCoordinates(coords))).thenReturn(false)
 
     invocationArgTraverser.traverse(arg, context)
 
     verify(expressionTraverser).traverse(eqTree(arg))
   }
 
-  test("traverse when arg is a Lit and passed by name") {
+  test("traverse when has a parent, has no name, and is a Lit passed by value") {
+    val parent = q"foo(x)"
     val arg = q"1"
-    val context = ArgumentContext(index = 0)
+    val context = ArgumentContext(maybeParent = Some(parent), index = 0)
+    val coords = ArgumentCoordinates(parent = parent, index = 0)
+
+    when(invocationArgClassifier.isPassedByName(eqArgumentCoordinates(coords))).thenReturn(false)
+
+    invocationArgTraverser.traverse(arg, context)
+
+    verify(expressionTraverser).traverse(eqTree(arg))
+  }
+
+  test("traverse when has a parent, and is a Lit passed by name") {
+    val parent = q"foo(x)"
+    val arg = q"1"
     val expectedArg = q"() => 1"
+    val context = ArgumentContext(maybeParent = Some(parent),index = 0)
+    val coords = ArgumentCoordinates(parent = parent, index = 0)
 
-    when(invocationArgClassifier.isPassedByName(eqArgumentContext(context))).thenReturn(true)
+    when(invocationArgClassifier.isPassedByName(eqArgumentCoordinates(coords))).thenReturn(true)
 
     invocationArgTraverser.traverse(arg, context)
 
     verify(expressionTraverser).traverse(eqTree(expectedArg))
   }
 
-  test("traverse when arg is a Term.Apply and passed by value") {
-    val arg = q"execute(x)"
-    val context = ArgumentContext(index = 0)
+  test("traverse when has a parent, and is a Term.Apply passed by value") {
+    val parent = q"doCallback(x)"
+    val arg = q"foo(y)"
+    val context = ArgumentContext(maybeParent = Some(parent), index = 0)
+    val coords = ArgumentCoordinates(parent = parent, index = 0)
 
-    when(invocationArgClassifier.isPassedByName(eqArgumentContext(context))).thenReturn(false)
+    when(invocationArgClassifier.isPassedByName(eqArgumentCoordinates(coords))).thenReturn(false)
 
     invocationArgTraverser.traverse(arg, context)
 
     verify(expressionTraverser).traverse(eqTree(arg))
   }
 
-  test("traverse when arg is a Term.Apply and passed by name") {
-    val arg = q"execute(x)"
-    val context = ArgumentContext(index = 0)
-    val expectedArg = q"() => execute(x)"
+  test("traverse when has a parent, and is a Term.Apply passed by name") {
+    val parent = q"doCallback(x)"
+    val arg = q"foo(y)"
+    val expectedArg = q"() => foo(y)"
+    val context = ArgumentContext(maybeParent = Some(parent), index = 0)
+    val coords = ArgumentCoordinates(parent = parent, index = 0)
 
-    when(invocationArgClassifier.isPassedByName(eqArgumentContext(context))).thenReturn(true)
+    when(invocationArgClassifier.isPassedByName(eqArgumentCoordinates(coords))).thenReturn(true)
 
     invocationArgTraverser.traverse(arg, context)
 
     verify(expressionTraverser).traverse(eqTree(expectedArg))
+  }
+
+  test("traverse when has no parent") {
+    val arg = q"xyz"
+    val context = ArgumentContext(index = 0)
+
+    invocationArgTraverser.traverse(arg, context)
+
+    verify(expressionTraverser).traverse(eqTree(arg))
+
+    verifyNoMoreInteractions(invocationArgClassifier)
   }
 }


### PR DESCRIPTION
Refactoring the classifier to receive a more accurate `ArgumentCoordinates` object in which the `parent` is mandatory - so that it will not even be called if there is no parent present, as the argument cannot be uniquely identified anyway in that case.