### PR TITLE
Generalize transformation of `Term.Select` to any `Term`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeTermSelectTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CompositeTermSelectTransformer.scala
@@ -8,7 +8,7 @@ import scala.meta.Term
 
 class CompositeTermSelectTransformer(override val coreTransformer: TermSelectTransformer)
                                     (implicit extensionRegistry: ExtensionRegistry)
-  extends CompositeSameTypeTransformer1[Term.Select, TermSelectTransformationContext]
+  extends CompositeDifferentTypeTransformer1[Term.Select, TermSelectTransformationContext, Term]
     with ExtensionAndCoreTransformers[TermSelectTransformer]
     with TermSelectTransformer {
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformer.scala
@@ -8,43 +8,44 @@ import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
 import scala.meta.Term
 
 private[transformers] class CoreTermSelectTransformer(termNameClassifier: TermNameClassifier,
-                                                      termSelectTermFunctionTransformer: => TermSelectTermFunctionTransformer) extends TermSelectTransformer {
+                                                      termSelectTermFunctionTransformer: => TermSelectTermFunctionTransformer)
+  extends TermSelectTransformer {
 
   private final val TupleElementRegex = "_(\\d)".r
 
   // Transform a Scala-specific qualified name into an equivalent in Java
   // Either and Try use the syntax of the VAVR framework (Maven: io.vavr:vavr)
-  override def transform(termSelect: Term.Select, context: TermSelectTransformationContext = TermSelectTransformationContext()): Term.Select = {
+  override def transform(termSelect: Term.Select, context: TermSelectTransformationContext = TermSelectTransformationContext()): Option[Term] = {
     (termSelect.qual, termSelect.name) match {
-      case (Term.Name(ScalaRange), Term.Name(Apply)) => Term.Select(Term.Name(JavaIntStream), Term.Name(JavaRange))
-      case (Term.Name(ScalaRange), Term.Name(ScalaInclusive)) => Term.Select(Term.Name(JavaIntStream), Term.Name(JavaRangeClosed))
+      case (Term.Name(ScalaRange), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaIntStream), Term.Name(JavaRange)))
+      case (Term.Name(ScalaRange), Term.Name(ScalaInclusive)) => Some(Term.Select(Term.Name(JavaIntStream), Term.Name(JavaRangeClosed)))
 
-      case (Term.Name(ScalaOption), Term.Name(Apply)) => Term.Select(Term.Name(JavaOptional), Term.Name(JavaOfNullable))
-      case (Term.Name(ScalaOption), Term.Name(Empty)) => Term.Select(Term.Name(JavaOptional), Term.Name(JavaAbsent))
-      case (Term.Name(ScalaSome), Term.Name(Apply)) => Term.Select(Term.Name(JavaOptional), Term.Name(JavaOf))
+      case (Term.Name(ScalaOption), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaOptional), Term.Name(JavaOfNullable)))
+      case (Term.Name(ScalaOption), Term.Name(Empty)) => Some(Term.Select(Term.Name(JavaOptional), Term.Name(JavaAbsent)))
+      case (Term.Name(ScalaSome), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaOptional), Term.Name(JavaOf)))
 
-      case (Term.Name(ScalaRight), Term.Name(Apply)) => Term.Select(Term.Name(Either), Term.Name(LowercaseRight))
-      case (Term.Name(ScalaLeft), Term.Name(Apply)) => Term.Select(Term.Name(Either), Term.Name(LowercaseLeft))
+      case (Term.Name(ScalaRight), Term.Name(Apply)) => Some(Term.Select(Term.Name(Either), Term.Name(LowercaseRight)))
+      case (Term.Name(ScalaLeft), Term.Name(Apply)) => Some(Term.Select(Term.Name(Either), Term.Name(LowercaseLeft)))
 
-      case (Term.Name(Try), Term.Name(Apply)) => Term.Select(Term.Name(Try), Term.Name(JavaOfSupplier))
-      case (Term.Name(ScalaSuccess), Term.Name(Apply)) => Term.Select(Term.Name(Try), Term.Name(JavaSuccess))
-      case (Term.Name(ScalaFailure), Term.Name(Apply)) => Term.Select(Term.Name(Try), Term.Name(JavaFailure))
+      case (Term.Name(Try), Term.Name(Apply)) => Some(Term.Select(Term.Name(Try), Term.Name(JavaOfSupplier)))
+      case (Term.Name(ScalaSuccess), Term.Name(Apply)) => Some(Term.Select(Term.Name(Try), Term.Name(JavaSuccess)))
+      case (Term.Name(ScalaFailure), Term.Name(Apply)) => Some(Term.Select(Term.Name(Try), Term.Name(JavaFailure)))
 
-      case (Term.Name(Future), Term.Name(Apply)) => Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaSupplyAsync))
-      case (Term.Name(Future), Term.Name(ScalaSuccessful)) => Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaCompletedFuture))
-      case (Term.Name(Future), Term.Name(ScalaFailed)) => Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaFailedFuture))
+      case (Term.Name(Future), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaSupplyAsync)))
+      case (Term.Name(Future), Term.Name(ScalaSuccessful)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaCompletedFuture)))
+      case (Term.Name(Future), Term.Name(ScalaFailed)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaFailedFuture)))
 
-      case(qual, Term.Name(TupleElementRegex(index))) => Term.Select(qual, Term.Name(s"v$index"))
+      case(qual, Term.Name(TupleElementRegex(index))) => Some(Term.Select(qual, Term.Name(s"v$index")))
 
-      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaStreamLike(nm) => Term.Select(Term.Name(Stream), Term.Name(JavaOf))
-      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaListLike(nm) => Term.Select(Term.Name(List), Term.Name(JavaOf))
-      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaSetLike(nm) => Term.Select(Term.Name(Set), Term.Name(JavaOf))
-      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaMapLike(nm) => Term.Select(Term.Name(Map), Term.Name(JavaOfEntries))
-      case (nm: Term.Name, Term.Name(Empty)) if termNameClassifier.isJavaMapLike(nm) => Term.Select(Term.Name(Map), Term.Name(JavaOf))
+      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaStreamLike(nm) => Some(Term.Select(Term.Name(Stream), Term.Name(JavaOf)))
+      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaListLike(nm) => Some(Term.Select(Term.Name(List), Term.Name(JavaOf)))
+      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaSetLike(nm) => Some(Term.Select(Term.Name(Set), Term.Name(JavaOf)))
+      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaMapLike(nm) => Some(Term.Select(Term.Name(Map), Term.Name(JavaOfEntries)))
+      case (nm: Term.Name, Term.Name(Empty)) if termNameClassifier.isJavaMapLike(nm) => Some(Term.Select(Term.Name(Map), Term.Name(JavaOf)))
 
-      case (termFunction: Term.Function, methodName: Term.Name) => termSelectTermFunctionTransformer.transform(termFunction, methodName)
+      case (termFunction: Term.Function, methodName: Term.Name) => Some(termSelectTermFunctionTransformer.transform(termFunction, methodName))
 
-      case _ => termSelect
+      case _ => None
     }
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/DefaultInternalTermSelectTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/DefaultInternalTermSelectTransformer.scala
@@ -1,0 +1,13 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
+import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
+
+import scala.meta.Term
+
+private[transformers] class DefaultInternalTermSelectTransformer(termSelectTransformer: => TermSelectTransformer)
+  extends InternalTermSelectTransformer {
+
+  override def transform(termSelect: Term.Select, context: TermSelectTransformationContext = TermSelectTransformationContext()): Term =
+    termSelectTransformer.transform(termSelect, context).getOrElse(termSelect)
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/InternalTermSelectTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/InternalTermSelectTransformer.scala
@@ -1,0 +1,9 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
+
+import scala.meta.Term
+
+trait InternalTermSelectTransformer {
+  def transform(termSelect: Term.Select, context: TermSelectTransformationContext = TermSelectTransformationContext()): Term
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/Transformers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/Transformers.scala
@@ -4,22 +4,23 @@ import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
 import io.github.effiban.scala2java.core.predicates.Predicates
 import io.github.effiban.scala2java.core.typeinference.TypeInferrers
-import io.github.effiban.scala2java.spi.transformers.{TermNameTransformer, TermSelectTransformer}
+import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
 
 class Transformers(typeInferrers: => TypeInferrers,
                    predicates: => Predicates)
                   (implicit extensionRegistry: ExtensionRegistry) {
 
-  private lazy val compositeTermNameTransformer: TermNameTransformer =
-    new CompositeTermNameTransformer(CoreTermNameTransformer)
-
-  lazy val coreTermSelectTransformer: TermSelectTransformer = new CoreTermSelectTransformer(
+  private lazy val coreTermSelectTransformer: TermSelectTransformer = new CoreTermSelectTransformer(
     TermNameClassifier,
     termSelectTermFunctionTransformer
   )
 
   lazy val defaultInternalTermNameTransformer: InternalTermNameTransformer = new DefaultInternalTermNameTransformer(
-    compositeTermNameTransformer
+    new CompositeTermNameTransformer(CoreTermNameTransformer)
+  )
+
+  lazy val defaultInternalTermSelectTransformer: InternalTermSelectTransformer = new DefaultInternalTermSelectTransformer(
+    new CompositeTermSelectTransformer(coreTermSelectTransformer)
   )
 
   lazy val evaluatedInternalTermNameTransformer: EvaluatedInternalTermNameTransformer = new EvaluatedInternalTermNameTransformer(

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -502,11 +502,12 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
   private lazy val termRepeatedTraverser: TermRepeatedTraverser = new TermRepeatedTraverserImpl(expressionTermTraverser)
 
   private lazy val termSelectTraverser: TermSelectTraverser = new TermSelectTraverserImpl(
-    expressionTermTraverser,
+    qualifierTraverser = expressionTermTraverser,
+    transformedTermTraverser = defaultTermTraverser,
     defaultTermNameTraverser,
     typeListTraverser,
     qualifierTypeInferrer,
-    new CompositeTermSelectTransformer(coreTermSelectTransformer)
+    defaultInternalTermSelectTransformer
   )
 
   private lazy val termTupleTraverser: TermTupleTraverser = new TermTupleTraverserImpl(

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermSelectTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermSelectTraverser.scala
@@ -2,10 +2,10 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.contexts.TermSelectContext
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.Parentheses
+import io.github.effiban.scala2java.core.transformers.InternalTermSelectTransformer
 import io.github.effiban.scala2java.core.typeinference.QualifierTypeInferrer
 import io.github.effiban.scala2java.core.writers.JavaWriter
 import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
-import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
 
 import scala.meta.Term
 
@@ -13,11 +13,12 @@ trait TermSelectTraverser {
   def traverse(termSelect: Term.Select, context: TermSelectContext = TermSelectContext()): Unit
 }
 
-private[traversers] class TermSelectTraverserImpl(expressionTermTraverser: => TermTraverser,
+private[traversers] class TermSelectTraverserImpl(qualifierTraverser: => TermTraverser,
+                                                  transformedTermTraverser: => TermTraverser,
                                                   defaultTermNameTraverser: => TermNameTraverser,
                                                   typeListTraverser: => TypeListTraverser,
                                                   qualifierTypeInferrer: => QualifierTypeInferrer,
-                                                  termSelectTransformer: TermSelectTransformer)
+                                                  termSelectTransformer: InternalTermSelectTransformer)
                                                  (implicit javaWriter: JavaWriter) extends TermSelectTraverser {
 
   import javaWriter._
@@ -25,23 +26,30 @@ private[traversers] class TermSelectTraverserImpl(expressionTermTraverser: => Te
   // qualified name
   override def traverse(select: Term.Select, context: TermSelectContext = TermSelectContext()): Unit = {
     val maybeQualType = qualifierTypeInferrer.infer(select)
-    val javaSelect = termSelectTransformer.transform(select, TermSelectTransformationContext(maybeQualType))
-    traverseQualifier(javaSelect.qual)
-    writeQualifierSeparator(javaSelect.qual)
+    val transformedTerm = termSelectTransformer.transform(select, TermSelectTransformationContext(maybeQualType))
+    transformedTerm match {
+        case transformedSelect: Term.Select => traverseAsSelect(transformedSelect, context)
+        case term => transformedTermTraverser.traverse(term)
+    }
+  }
+
+  private def traverseAsSelect(transformedSelect: Term.Select, context: TermSelectContext): Unit = {
+    traverseQualifier(transformedSelect.qual)
+    writeQualifierSeparator(transformedSelect.qual)
     typeListTraverser.traverse(context.appliedTypeArgs)
-    defaultTermNameTraverser.traverse(javaSelect.name)
+    defaultTermNameTraverser.traverse(transformedSelect.name)
   }
 
   private def traverseQualifier(qualifier: Term): Unit = {
     qualifier match {
       case qual@(_: Term.Function | Term.Ascribe(_: Term.Function,_)) => traverseInsideParens(qual)
-      case qual => expressionTermTraverser.traverse(qual)
+      case qual => qualifierTraverser.traverse(qual)
     }
   }
 
   private def traverseInsideParens(qual: Term): Unit = {
     writeArgumentsStart(Parentheses)
-    expressionTermTraverser.traverse(qual)
+    qualifierTraverser.traverse(qual)
     writeArgumentsEnd(Parentheses)
   }
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformerTest.scala
@@ -20,98 +20,98 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
     val scalaTermSelect = Term.Select(ScalaRange, Apply)
     val expectedJavaTermSelect = Term.Select(JavaIntStream, JavaRange)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Range.inclusive' should return 'IntStream.rangeClosed'") {
     val scalaTermSelect = Term.Select(ScalaRange, ScalaInclusive)
     val expectedJavaTermSelect = Term.Select(JavaIntStream, JavaRangeClosed)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Option.apply' should return 'Optional.ofNullable'") {
     val scalaTermSelect = Term.Select(ScalaOption, Apply)
     val expectedJavaTermSelect = Term.Select(JavaOptional, JavaOfNullable)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Option.empty' should return 'Optional.absent'") {
     val scalaTermSelect = Term.Select(ScalaOption, Empty)
     val expectedJavaTermSelect = Term.Select(JavaOptional, JavaAbsent)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Some.apply' should return 'Optional.of'") {
     val scalaTermSelect = Term.Select(ScalaSome, Apply)
     val expectedJavaTermSelect = Term.Select(JavaOptional, JavaOf)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Right.apply' should return 'Either.right'") {
     val scalaTermSelect = Term.Select(ScalaRight, Apply)
     val expectedJavaTermSelect = Term.Select(TermNames.Either, LowercaseRight)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Left.apply' should return 'Either.left'") {
     val scalaTermSelect = Term.Select(ScalaLeft, Apply)
     val expectedJavaTermSelect = Term.Select(TermNames.Either, LowercaseLeft)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Try.apply' should return 'Try.ofSupplier'") {
     val scalaTermSelect = Term.Select(Try, Apply)
     val expectedJavaTermSelect = Term.Select(Try, JavaOfSupplier)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Success.apply' should return 'Try.success'") {
     val scalaTermSelect = Term.Select(ScalaSuccess, Apply)
     val expectedJavaTermSelect = Term.Select(Try, JavaSuccess)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Failure.apply' should return 'Try.failure'") {
     val scalaTermSelect = Term.Select(ScalaFailure, Apply)
     val expectedJavaTermSelect = Term.Select(Try, JavaFailure)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Future.apply' should return 'CompletableFuture.supplyAsync'") {
     val scalaTermSelect = Term.Select(TermNames.Future, Apply)
     val expectedJavaTermSelect = Term.Select(JavaCompletableFuture, JavaSupplyAsync)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Future.successful' should return 'CompletableFuture.completedFuture'") {
     val scalaTermSelect = Term.Select(Future, ScalaSuccessful)
     val expectedJavaTermSelect = Term.Select(JavaCompletableFuture, JavaCompletedFuture)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Future.failed' should return 'CompletableFuture.failedFuture'") {
     val scalaTermSelect = Term.Select(Future, ScalaFailed)
     val expectedJavaTermSelect = Term.Select(JavaCompletableFuture, JavaFailedFuture)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'myTuple._1' should return 'myTuple.v1'") {
     val scalaTermSelect = Term.Select(Term.Name("myTuple"), Term.Name("_1"))
     val expectedJavaTermSelect = Term.Select(Term.Name("myTuple"), Term.Name("v1"))
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Stream.apply' should return 'Stream.of'") {
@@ -120,7 +120,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaStreamLike(eqTree(TermNames.Stream))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Seq.apply' should return 'List.of'") {
@@ -129,7 +129,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaListLike(eqTree(TermNames.Seq))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Seq.empty' should return 'List.of'") {
@@ -138,7 +138,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaListLike(eqTree(TermNames.Seq))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Set.apply' should return 'Set.of'") {
@@ -147,7 +147,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaSetLike(eqTree(TermNames.Set))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Set.empty' should return 'Set.of'") {
@@ -156,7 +156,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaSetLike(eqTree(TermNames.Set))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Map.apply' should return 'Map.ofEntries'") {
@@ -165,7 +165,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Map.empty' should return 'Map.of'") {
@@ -174,7 +174,7 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedJavaTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform a 'Term.Function' (lambda) with a method name, should return result of 'TermSelectTermFunctionTransformer'") {
@@ -183,12 +183,12 @@ class CoreTermSelectTransformerTest extends UnitTestSuite {
 
     when(termSelectTermFunctionTransformer.transform(eqTree(q"(x: Int) => print(x)"), eqTree(Apply))).thenReturn(expectedTransformedTermSelect)
 
-    termSelectTransformer.transform(scalaTermSelect).structure shouldBe expectedTransformedTermSelect.structure
+    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedTransformedTermSelect.structure
   }
 
-  test("transform 'Dummy.dummy' should return the same") {
+  test("transform 'Dummy.dummy' should return None") {
     val termSelect = Term.Select(Term.Name("Dummy"), Term.Name("dummy"))
 
-    termSelectTransformer.transform(termSelect).structure shouldBe termSelect.structure
+    termSelectTransformer.transform(termSelect) shouldBe None
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/DefaultInternalTermSelectTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/DefaultInternalTermSelectTransformerTest.scala
@@ -1,0 +1,37 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.matchers.TermSelectTransformationContextMatcher.eqTermSelectTransformationContext
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
+import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+
+import scala.meta.XtensionQuasiquoteTerm
+
+class DefaultInternalTermSelectTransformerTest extends UnitTestSuite {
+
+  private val termSelectTransformer = mock[TermSelectTransformer]
+
+  private val defaultInternalTermNameTransformer = new DefaultInternalTermSelectTransformer(termSelectTransformer)
+
+  test("transform() when inner transformer returns a result should return it") {
+    val termSelect = q"a.b"
+    val context = TermSelectTransformationContext(Some(TypeNames.Int))
+    val expectedTerm = q"x(123)"
+
+    when(termSelectTransformer.transform(eqTree(termSelect), eqTermSelectTransformationContext(context))).thenReturn(Some(expectedTerm))
+
+    defaultInternalTermNameTransformer.transform(termSelect, context).structure shouldBe expectedTerm.structure
+  }
+
+  test("transform() when inner transformer returns None should return input") {
+    val termSelect = q"a.b"
+    val context = TermSelectTransformationContext(Some(TypeNames.Int))
+
+    when(termSelectTransformer.transform(eqTree(termSelect), eqTermSelectTransformationContext(context))).thenReturn(None)
+
+    defaultInternalTermNameTransformer.transform(termSelect, context).structure shouldBe termSelect.structure
+  }
+
+}

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/ExtendedTransformers.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/ExtendedTransformers.scala
@@ -116,7 +116,7 @@ trait ExtendedTransformers {
    * @return if overriden - a transformer which modifies a given [[scala.meta.Term.Select]]<br>
    *         otherwise - the default transformer which doesn't modify anything<br>
    */
-  def termSelectTransformer(): TermSelectTransformer = TermSelectTransformer.Identity
+  def termSelectTransformer(): TermSelectTransformer = TermSelectTransformer.Empty
 
   /** Override this method if you need to modify a [[scala.meta.Term.Name]] (identifier) appearing by itself.<br>
    *

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/TermSelectTransformer.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/TermSelectTransformer.scala
@@ -4,16 +4,16 @@ import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
 
 import scala.meta.Term
 
-/** A transformer which can modify a given Scala [[Term.Select]] (qualified name).<br>
+/** A transformer which can convert a given Scala [[Term.Select]] (qualified name) into any [[Term]].<br>
+ * Usually the output will also be a [[Term.Select]], but there are cases where the Java equivalent is a different tree type.<br>
  * The transformer also receives a context object with extra information needed for a precise transformation,
  * such as the inferred type of the qualifier.<br>
- * This is useful for cases where the Java equivalent has a different qualifier+name combination.
  */
-trait TermSelectTransformer extends SameTypeTransformer1[Term.Select, TermSelectTransformationContext]
+trait TermSelectTransformer extends DifferentTypeTransformer1[Term.Select, TermSelectTransformationContext, Term]
 
 
 object TermSelectTransformer {
-  /** The default transformer which returns the input [[Term.Select]] unchanged, indicating that no transformation is needed. */
-  val Identity: TermSelectTransformer = (select, _) => select
+  /** The default transformer which returns the None, indicating that no transformation is needed. */
+  val Empty: TermSelectTransformer = (_, _) => None
 }
 


### PR DESCRIPTION
- Generalize the transformer which can be overiden by extensions
- Wrapping it with another inner transformer, as a preparation for supporting desugaring