### PR TITLE
Split `TermApplyTransformer`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformer.scala
@@ -1,32 +1,15 @@
 package io.github.effiban.scala2java.core.transformers
 
-import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
-import io.github.effiban.scala2java.core.entities.TermNameValues.Apply
 import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
 
-import scala.annotation.tailrec
 import scala.meta.Term
 
-private[transformers] class CoreTermApplyTransformer(termNameClassifier: TermNameClassifier) extends TermApplyTransformer {
+private[transformers] class CoreTermApplyTransformer extends TermApplyTransformer {
 
-  // Transform any method invocations which have a Scala-specific style into Java equivalents
-  @tailrec
   override final def transform(termApply: Term.Apply): Term.Apply = {
-    termApply match {
-      case Term.Apply(name : Term.Name, args) => Term.Apply(transformName(name), args)
-      case Term.Apply(Term.ApplyType(name: Term.Name, types), args) => Term.Apply(Term.ApplyType(transformName(name), types), args)
-      // Invocation of method with more than one param list
-      case Term.Apply(Term.Apply(fun, args1), args2) => transform(Term.Apply(fun, args1 ++ args2))
-      // Invocation of lambda - must add the implicit apply so it can be further processed by the 'Select' transformer
-      case Term.Apply(termFunction: Term.Function, args) => Term.Apply(Term.Select(termFunction, Term.Name(Apply)), args)
-      case other => other
-    }
-  }
-
-  private def transformName(name: Term.Name): Term = name match {
-    case nm if termNameClassifier.hasApplyMethod(nm) => Term.Select(nm, Term.Name(Apply))
-    case _ => name
+    // TODO - move transformations from CoreTermSelectTransformer here once desugaring is supported
+    termApply
   }
 }
 
-object CoreTermApplyTransformer extends CoreTermApplyTransformer(TermNameClassifier)
+object CoreTermApplyTransformer extends CoreTermApplyTransformer

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/InternalTermApplyTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/InternalTermApplyTransformer.scala
@@ -1,0 +1,36 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
+import io.github.effiban.scala2java.core.entities.TermNameValues.Apply
+import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
+
+import scala.annotation.tailrec
+import scala.meta.Term
+
+trait InternalTermApplyTransformer {
+  def transform(termApply: Term.Apply): Term.Apply
+}
+
+private[transformers] class InternalTermApplyTransformerImpl(termApplyTransformer: TermApplyTransformer,
+                                                             termNameClassifier: TermNameClassifier) extends InternalTermApplyTransformer {
+
+  @tailrec
+  override final def transform(termApply: Term.Apply): Term.Apply = {
+    termApply match {
+      case Term.Apply(name : Term.Name, args) if termNameClassifier.hasApplyMethod(name) => transform(Term.Apply(toQualifiedApply(name), args))
+      case Term.Apply(Term.ApplyType(name: Term.Name, types), args) if termNameClassifier.hasApplyMethod(name) =>
+        transform(Term.Apply(Term.ApplyType(toQualifiedApply(name), types), args))
+      // Invocation of method with more than one param list
+      case Term.Apply(Term.Apply(fun, args1), args2) => transform(Term.Apply(fun, args1 ++ args2))
+      // Invocation of lambda - must add the implicit apply so it can be further processed by the 'Select' transformer
+      case Term.Apply(termFunction: Term.Function, args) => transform(Term.Apply(Term.Select(termFunction, Term.Name(Apply)), args))
+
+      case other => termApplyTransformer.transform(other)
+    }
+  }
+
+  private def toQualifiedApply(name: Term.Name): Term = name match {
+    case nm if termNameClassifier.hasApplyMethod(nm) => Term.Select(nm, Term.Name(Apply))
+    case _ => name
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/Transformers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/Transformers.scala
@@ -28,6 +28,11 @@ class Transformers(typeInferrers: => TypeInferrers,
     predicates.compositeTermNameSupportsNoArgInvocation
   )
 
+  lazy val internalTermApplyTransformer: InternalTermApplyTransformer = new InternalTermApplyTransformerImpl(
+    new CompositeTermApplyTransformer(CoreTermApplyTransformer),
+    TermNameClassifier
+  )
+
   private lazy val termSelectTermFunctionTransformer: TermSelectTermFunctionTransformer = new TermSelectTermFunctionTransformerImpl(
     typeInferrers.functionTypeInferrer,
     FunctionTypeTransformer

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -460,7 +460,7 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
     argumentListTraverser,
     compositeInvocationArgTraverser,
     ArrayInitializerContextResolver,
-    new CompositeTermApplyTransformer(CoreTermApplyTransformer)
+    internalTermApplyTransformer
   )
 
   private lazy val termFunctionTraverser: TermFunctionTraverser = new TermFunctionTraverserImpl(

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermApplyTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermApplyTraverser.scala
@@ -4,7 +4,7 @@ import io.github.effiban.scala2java.core.contexts.ArgumentListContext
 import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.Parentheses
 import io.github.effiban.scala2java.core.entities.ListTraversalOptions
 import io.github.effiban.scala2java.core.resolvers.ArrayInitializerContextResolver
-import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
+import io.github.effiban.scala2java.core.transformers.InternalTermApplyTransformer
 
 import scala.meta.Term
 
@@ -15,7 +15,7 @@ private[traversers] class TermApplyTraverserImpl(funTermTraverser: => TermTraver
                                                  argumentListTraverser: => ArgumentListTraverser,
                                                  invocationArgTraverser: => ArgumentTraverser[Term],
                                                  arrayInitializerContextResolver: ArrayInitializerContextResolver,
-                                                 termApplyTransformer: TermApplyTransformer)
+                                                 termApplyTransformer: InternalTermApplyTransformer)
   extends TermApplyTraverser {
 
   // method invocation

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
@@ -1,99 +1,16 @@
 package io.github.effiban.scala2java.core.transformers
 
-import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
-import io.github.effiban.scala2java.core.entities.TermNameValues
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
-import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
-import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
-import scala.meta.{Lit, Term, XtensionQuasiquoteTerm}
+import scala.meta.XtensionQuasiquoteTerm
 
 class CoreTermApplyTransformerTest extends UnitTestSuite {
 
-  private val fun = Term.Name("foo")
-  private val arg1 = Term.Name("arg1")
-  private val arg2 = Term.Name("arg2")
-  private val arg3 = Term.Name("arg3")
-  private val arg4 = Term.Name("arg4")
-  private val arg5 = Term.Name("arg5")
-  private val arg6 = Term.Name("arg6")
+  private val coreTermApplyTransformer = new CoreTermApplyTransformer
 
-  private val termNameClassifier = mock[TermNameClassifier]
+  test("transform() of an unrecognized Term.Apply should return the same") {
+    val termApply = q"blabla(1)"
 
-  private val termApplyTransformer = new CoreTermApplyTransformer(termNameClassifier)
-
-  test("transform() of a untyped pre-def object initializer, arg by-value, should return same with added 'apply'") {
-    val initialTermApply = Term.Apply(Term.Name("ScalaObject"), List(Lit.Int(1)))
-    val expectedTermApply = Term.Apply(Term.Select(Term.Name("ScalaObject"), TermNames.Apply), List(Lit.Int(1)))
-
-    when(termNameClassifier.hasApplyMethod(eqTree(Term.Name("ScalaObject")))).thenReturn(true)
-
-    termApplyTransformer.transform(initialTermApply).structure shouldBe expectedTermApply.structure
-  }
-
-  test("transform() of a typed pre-def object initializer, arg by-value, should return same with added 'apply'") {
-    val initialTermApply = Term.Apply(Term.ApplyType(Term.Name("ScalaObject"), List(TypeNames.Int)), List(Lit.Int(1)))
-    val expectedTermApply = Term.Apply(Term.ApplyType(Term.Select(Term.Name("ScalaObject"), TermNames.Apply), List(TypeNames.Int)), List(Lit.Int(1)))
-
-    when(termNameClassifier.hasApplyMethod(eqTree(Term.Name("ScalaObject")))).thenReturn(true)
-
-    termApplyTransformer.transform(initialTermApply).structure shouldBe expectedTermApply.structure
-  }
-
-  test("transform() of a regular method invocation with an unqualified name, should return  same invocation") {
-    val termApply = Term.Apply(Term.Name("Foo"), List(Lit.Int(1)))
-
-    when(termNameClassifier.hasApplyMethod(eqTree(Term.Name("Foo")))).thenReturn(false)
-
-    termApplyTransformer.transform(termApply).structure shouldBe termApply.structure
-  }
-
-
-  test("transform() of a regular method invocation with a qualified name, should return same invocation") {
-    val termApply = Term.Apply(Term.Select(Term.Name("a"), Term.Name("b")), List(Lit.Int(1)))
-
-    termApplyTransformer.transform(termApply).structure shouldBe termApply.structure
-
-  }
-
-    // foo(arg1, arg2)(arg3, arg4) ---> foo(arg1, arg2, arg3, arg4)
-  test("transform() of a 2-level nested invocation should return a single invocation with concatenated args") {
-    val scalaStyleTermApply =
-      Term.Apply(
-        Term.Apply(fun, List(arg1, arg2)),
-        List(arg3, arg4)
-    )
-    val expectedJavaStyleTermApply = Term.Apply(fun, List(arg1, arg2, arg3, arg4))
-
-    when(termNameClassifier.hasApplyMethod(eqTree(fun))).thenReturn(false)
-
-    termApplyTransformer.transform(scalaStyleTermApply).structure shouldBe expectedJavaStyleTermApply.structure
-  }
-
-  // foo(arg1, arg2)(arg3, arg4)(arg5, arg6) ---> foo(arg1, arg2, arg3, arg4, arg5, arg6)
-  test("transform() of a 3-level nested invocation should return a single invocation with concatenated args") {
-    val scalaStyleTermApply =
-      Term.Apply(
-        Term.Apply(
-          Term.Apply(fun, List(arg1, arg2)),
-          List(arg3, arg4)),
-        List(arg5, arg6)
-      )
-    val expectedJavaStyleTermApply = Term.Apply(fun, List(arg1, arg2, arg3, arg4, arg5, arg6))
-
-    when(termNameClassifier.hasApplyMethod(eqTree(fun))).thenReturn(false)
-
-    termApplyTransformer.transform(scalaStyleTermApply).structure shouldBe expectedJavaStyleTermApply.structure
-  }
-
-  test("transform() of a Term.Function (lambda) invocation should transform it into a qualified expression with the explicit apply()") {
-    val termFunction = q"((x: Int) => x + 1)"
-    val args = List(Lit.Int(2))
-
-    val termFunctionInvocation = Term.Apply(termFunction, args)
-
-    val expectedTermFunctionInvocation = Term.Apply(Term.Select(termFunction, Term.Name(TermNameValues.Apply)), args)
-
-    termApplyTransformer.transform(termFunctionInvocation).structure shouldBe expectedTermFunctionInvocation.structure
+    coreTermApplyTransformer.transform(termApply).structure shouldBe termApply.structure
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/InternalTermApplyTransformerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/InternalTermApplyTransformerImplTest.scala
@@ -1,0 +1,124 @@
+package io.github.effiban.scala2java.core.transformers
+
+import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+
+import scala.meta.{Term, XtensionQuasiquoteTerm}
+
+class InternalTermApplyTransformerImplTest extends UnitTestSuite {
+
+  private val fun = Term.Name("foo")
+  private val transformedFun = Term.Name("transformedFoo")
+  private val arg1 = Term.Name("arg1")
+  private val arg2 = Term.Name("arg2")
+  private val arg3 = Term.Name("arg3")
+  private val arg4 = Term.Name("arg4")
+  private val arg5 = Term.Name("arg5")
+  private val arg6 = Term.Name("arg6")
+
+  private val termNameClassifier = mock[TermNameClassifier]
+  private val termApplyTransformer = mock[TermApplyTransformer]
+
+  private val internalTermApplyTransformer = new InternalTermApplyTransformerImpl(termApplyTransformer, termNameClassifier)
+
+  test("transform() of an untyped method invocation of an implicit 'apply()', should add the 'apply()' and call inner transformer") {
+    val termName = q"MyObject"
+    val termApply = q"MyObject(1)"
+    val adjustedTermApply = q"MyObject.apply(1)"
+    val expectedTransformedTermApply = q"MyObject.create(1)"
+
+    when(termNameClassifier.hasApplyMethod(eqTree(termName))).thenReturn(true)
+    when(termApplyTransformer.transform(eqTree(adjustedTermApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(termApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  test("transform() of an typed method invocation of an implicit 'apply()', should add the 'apply()' and call inner transformer") {
+    val termName = q"MyObject"
+    val termApply = q"MyObject[Int](1)"
+    val adjustedTermApply = q"MyObject.apply[Int](1)"
+    val expectedTransformedTermApply = q"MyObject.create[Int](1)"
+
+    when(termNameClassifier.hasApplyMethod(eqTree(termName))).thenReturn(true)
+    when(termApplyTransformer.transform(eqTree(adjustedTermApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(termApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  test("transform() of an untyped method invocation with no implicit 'apply()', should call inner transformer directly") {
+    val termName = q"myMethod"
+    val termApply = q"myMethod(1)"
+    val expectedTransformedTermApply = q"myTransformedMethod(1)"
+
+    when(termNameClassifier.hasApplyMethod(eqTree(termName))).thenReturn(false)
+    when(termApplyTransformer.transform(eqTree(termApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(termApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  test("transform() of a typed method invocation with no implicit 'apply()', should call inner transformer directly") {
+    val termName = q"myMethod"
+    val termApply = q"myMethod[Int](1)"
+    val expectedTransformedTermApply = q"myTransformedMethod[Int](1)"
+
+    when(termNameClassifier.hasApplyMethod(eqTree(termName))).thenReturn(false)
+    when(termApplyTransformer.transform(eqTree(termApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(termApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  test("transform() of a method invocation with a qualified name, should call inner transformer directly") {
+    val termApply = q"MyObj.myMethod(1)"
+    val expectedTransformedTermApply = q"MyObj.myTransformedMethod(1)"
+
+    when(termApplyTransformer.transform(eqTree(termApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(termApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  // foo(arg1, arg2)(arg3, arg4) ---> foo(arg1, arg2, arg3, arg4) ---> transformedFoo(arg1, arg2, arg3, arg4)
+  test("transform() of a 2-level nested invocation, should convert to a single invocation with concatenated args and call inner transformer") {
+    val nestedTermApply =
+      Term.Apply(
+        Term.Apply(fun, List(arg1, arg2)),
+        List(arg3, arg4)
+    )
+    val expectedFlattenedTermApply = Term.Apply(fun, List(arg1, arg2, arg3, arg4))
+    val expectedTransformedTermApply = Term.Apply(transformedFun, List(arg1, arg2, arg3, arg4))
+
+    when(termNameClassifier.hasApplyMethod(eqTree(fun))).thenReturn(false)
+    when(termApplyTransformer.transform(eqTree(expectedFlattenedTermApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(nestedTermApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  // foo(arg1, arg2)(arg3, arg4)(arg5, arg6) ---> foo(arg1, arg2, arg3, arg4, arg5, arg6) ---> transformedFoo(arg1, arg2, arg3, arg4, arg5, arg6)
+  test("transform() of a 3-level nested invocation should convert tp a single invocation with concatenated args, and then call inner transformer") {
+    val nestedTermApply =
+      Term.Apply(
+        Term.Apply(
+          Term.Apply(fun, List(arg1, arg2)),
+          List(arg3, arg4)),
+        List(arg5, arg6)
+      )
+    val expectedFlattenedTermApply = Term.Apply(fun, List(arg1, arg2, arg3, arg4, arg5, arg6))
+    val expectedTransformedTermApply = Term.Apply(transformedFun, List(arg1, arg2, arg3, arg4, arg5, arg6))
+
+    when(termNameClassifier.hasApplyMethod(eqTree(fun))).thenReturn(false)
+    when(termApplyTransformer.transform(eqTree(expectedFlattenedTermApply))).thenReturn(expectedTransformedTermApply)
+
+    internalTermApplyTransformer.transform(nestedTermApply).structure shouldBe expectedTransformedTermApply.structure
+  }
+
+  test("transform() of a Term.Function (lambda) invocation should convert it into a qualified expression with apply(), and then call inner transformer") {
+    val lambdaInvocation = q"((x: Int) => x + 1)(2)"
+    val expectedAdjustedLambdaInvocation = q"((x: Int) => x + 1).apply(2)"
+    val expectedTransformedLambdaInvocation = q"((Function<Int, Int>)((x: Int) => x + 1)).apply(2)"
+
+    when(termApplyTransformer.transform(eqTree(expectedAdjustedLambdaInvocation))).thenReturn(expectedTransformedLambdaInvocation)
+
+    internalTermApplyTransformer.transform(lambdaInvocation).structure shouldBe expectedTransformedLambdaInvocation.structure
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermApplyTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TermApplyTraverserImplTest.scala
@@ -9,7 +9,7 @@ import io.github.effiban.scala2java.core.resolvers.ArrayInitializerContextResolv
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
-import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
+import io.github.effiban.scala2java.core.transformers.InternalTermApplyTransformer
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchersSugar.eqTo
@@ -22,7 +22,7 @@ class TermApplyTraverserImplTest extends UnitTestSuite {
   private val argListTraverser = mock[ArgumentListTraverser]
   private val invocationArgTraverser = mock[ArgumentTraverser[Term]]
   private val arrayInitializerContextResolver = mock[ArrayInitializerContextResolver]
-  private val termApplyTransformer = mock[TermApplyTransformer]
+  private val termApplyTransformer = mock[InternalTermApplyTransformer]
 
   private val termApplyTraverser = new TermApplyTraverserImpl(
     funTermTraverser,


### PR DESCRIPTION
- Wrapping `TermApplyTransformer` with an internal transformer, which delegates to the original one (which can be overriden by extensions).
- Moving the generic logic there from `CoreTermApplyTransformer` to the internal transformer. 
**Note** that this means there will be a breaking change for extensions, such that the inputs to their transformed will have some pre-processing applied - but it is deemed to be generic enough and reasonable.
These steps are a preparation for properly supporting desugaring of `Term.Select`