### PR TITLE
Move method invocation transformations from the `Term.Select` to the `Term.Apply` level

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformer.scala
@@ -16,6 +16,11 @@ private[transformers] class CoreTermApplyTransformer(termNameClassifier: TermNam
           .map(transformedSelect => Term.Apply(transformedSelect, args))
           .getOrElse(termApply)
 
+      case Term.Apply(Term.ApplyType(termSelect: Term.Select, targs), args) =>
+        transformQualifiedMethodName(termSelect)
+          .map(transformedSelect => Term.Apply(Term.ApplyType(transformedSelect, targs), args))
+          .getOrElse(termApply)
+
       case _ => termApply
     }
   }
@@ -42,7 +47,7 @@ private[transformers] class CoreTermApplyTransformer(termNameClassifier: TermNam
       case (Term.Name(Future), Term.Name(ScalaSuccessful)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaCompletedFuture)))
       case (Term.Name(Future), Term.Name(ScalaFailed)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaFailedFuture)))
 
-      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaStreamLike(nm) => Some(Term.Select(Term.Name(Stream), Term.Name(JavaOf)))
+      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaStreamLike(nm) => Some(Term.Select(Term.Name(Stream), Term.Name(JavaOf)))
       case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaListLike(nm) => Some(Term.Select(Term.Name(List), Term.Name(JavaOf)))
       case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaSetLike(nm) => Some(Term.Select(Term.Name(Set), Term.Name(JavaOf)))
       case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaMapLike(nm) => Some(Term.Select(Term.Name(Map), Term.Name(JavaOfEntries)))

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformer.scala
@@ -1,15 +1,11 @@
 package io.github.effiban.scala2java.core.transformers
 
-import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
-import io.github.effiban.scala2java.core.entities.TermNameValues._
 import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
 import io.github.effiban.scala2java.spi.transformers.TermSelectTransformer
 
 import scala.meta.Term
 
-private[transformers] class CoreTermSelectTransformer(termNameClassifier: TermNameClassifier,
-                                                      termSelectTermFunctionTransformer: => TermSelectTermFunctionTransformer)
-  extends TermSelectTransformer {
+object CoreTermSelectTransformer extends TermSelectTransformer {
 
   private final val TupleElementRegex = "_(\\d)".r
 
@@ -17,34 +13,7 @@ private[transformers] class CoreTermSelectTransformer(termNameClassifier: TermNa
   // Either and Try use the syntax of the VAVR framework (Maven: io.vavr:vavr)
   override def transform(termSelect: Term.Select, context: TermSelectTransformationContext = TermSelectTransformationContext()): Option[Term] = {
     (termSelect.qual, termSelect.name) match {
-      case (Term.Name(ScalaRange), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaIntStream), Term.Name(JavaRange)))
-      case (Term.Name(ScalaRange), Term.Name(ScalaInclusive)) => Some(Term.Select(Term.Name(JavaIntStream), Term.Name(JavaRangeClosed)))
-
-      case (Term.Name(ScalaOption), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaOptional), Term.Name(JavaOfNullable)))
-      case (Term.Name(ScalaOption), Term.Name(Empty)) => Some(Term.Select(Term.Name(JavaOptional), Term.Name(JavaAbsent)))
-      case (Term.Name(ScalaSome), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaOptional), Term.Name(JavaOf)))
-
-      case (Term.Name(ScalaRight), Term.Name(Apply)) => Some(Term.Select(Term.Name(Either), Term.Name(LowercaseRight)))
-      case (Term.Name(ScalaLeft), Term.Name(Apply)) => Some(Term.Select(Term.Name(Either), Term.Name(LowercaseLeft)))
-
-      case (Term.Name(Try), Term.Name(Apply)) => Some(Term.Select(Term.Name(Try), Term.Name(JavaOfSupplier)))
-      case (Term.Name(ScalaSuccess), Term.Name(Apply)) => Some(Term.Select(Term.Name(Try), Term.Name(JavaSuccess)))
-      case (Term.Name(ScalaFailure), Term.Name(Apply)) => Some(Term.Select(Term.Name(Try), Term.Name(JavaFailure)))
-
-      case (Term.Name(Future), Term.Name(Apply)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaSupplyAsync)))
-      case (Term.Name(Future), Term.Name(ScalaSuccessful)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaCompletedFuture)))
-      case (Term.Name(Future), Term.Name(ScalaFailed)) => Some(Term.Select(Term.Name(JavaCompletableFuture), Term.Name(JavaFailedFuture)))
-
       case(qual, Term.Name(TupleElementRegex(index))) => Some(Term.Select(qual, Term.Name(s"v$index")))
-
-      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaStreamLike(nm) => Some(Term.Select(Term.Name(Stream), Term.Name(JavaOf)))
-      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaListLike(nm) => Some(Term.Select(Term.Name(List), Term.Name(JavaOf)))
-      case (nm: Term.Name, Term.Name(Apply) | Term.Name(Empty)) if termNameClassifier.isJavaSetLike(nm) => Some(Term.Select(Term.Name(Set), Term.Name(JavaOf)))
-      case (nm: Term.Name, Term.Name(Apply)) if termNameClassifier.isJavaMapLike(nm) => Some(Term.Select(Term.Name(Map), Term.Name(JavaOfEntries)))
-      case (nm: Term.Name, Term.Name(Empty)) if termNameClassifier.isJavaMapLike(nm) => Some(Term.Select(Term.Name(Map), Term.Name(JavaOf)))
-
-      case (termFunction: Term.Function, methodName: Term.Name) => Some(termSelectTermFunctionTransformer.transform(termFunction, methodName))
-
       case _ => None
     }
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/Transformers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/Transformers.scala
@@ -4,7 +4,7 @@ import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
 import io.github.effiban.scala2java.core.extensions.ExtensionRegistry
 import io.github.effiban.scala2java.core.predicates.Predicates
 import io.github.effiban.scala2java.core.typeinference.TypeInferrers
-import io.github.effiban.scala2java.spi.transformers.{TermApplyTransformer, TermSelectTransformer}
+import io.github.effiban.scala2java.spi.transformers.TermApplyTransformer
 
 class Transformers(typeInferrers: => TypeInferrers,
                    predicates: => Predicates)
@@ -15,17 +15,12 @@ class Transformers(typeInferrers: => TypeInferrers,
     termSelectTermFunctionTransformer
   )
 
-  private lazy val coreTermSelectTransformer: TermSelectTransformer = new CoreTermSelectTransformer(
-    TermNameClassifier,
-    termSelectTermFunctionTransformer
-  )
-
   lazy val defaultInternalTermNameTransformer: InternalTermNameTransformer = new DefaultInternalTermNameTransformer(
     new CompositeTermNameTransformer(CoreTermNameTransformer)
   )
 
   lazy val defaultInternalTermSelectTransformer: InternalTermSelectTransformer = new DefaultInternalTermSelectTransformer(
-    new CompositeTermSelectTransformer(coreTermSelectTransformer)
+    new CompositeTermSelectTransformer(CoreTermSelectTransformer)
   )
 
   lazy val evaluatedInternalTermNameTransformer: EvaluatedInternalTermNameTransformer = new EvaluatedInternalTermNameTransformer(
@@ -33,14 +28,14 @@ class Transformers(typeInferrers: => TypeInferrers,
     predicates.compositeTermNameSupportsNoArgInvocation
   )
 
-  lazy val internalTermApplyTransformer: InternalTermApplyTransformer = new InternalTermApplyTransformerImpl(
-    new CompositeTermApplyTransformer(coreTermApplyTransformer),
-    TermNameClassifier
-  )
-
   lazy val evaluatedInternalTermSelectTransformer: EvaluatedInternalTermSelectTransformer = new EvaluatedInternalTermSelectTransformer(
     defaultInternalTermSelectTransformer,
     predicates.compositeTermSelectSupportsNoArgInvocation
+  )
+
+  lazy val internalTermApplyTransformer: InternalTermApplyTransformer = new InternalTermApplyTransformerImpl(
+    new CompositeTermApplyTransformer(coreTermApplyTransformer),
+    TermNameClassifier
   )
 
   private lazy val termSelectTermFunctionTransformer: TermSelectTermFunctionTransformer = new TermSelectTermFunctionTransformerImpl(

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/testtrees/TypeNames.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/testtrees/TypeNames.scala
@@ -27,6 +27,8 @@ object TypeNames {
 
   val Function: Type.Name = t"Function"
 
+  val Throwable: Type.Name = t"Throwable"
+
   val ScalaArray: Type.Name = Type.Name("Array")
   val ScalaOption: Type.Name = Type.Name("Option")
   val ScalaAny: Type.Name = Type.Name("Any")

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
@@ -2,8 +2,8 @@ package io.github.effiban.scala2java.core.transformers
 
 import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
-import io.github.effiban.scala2java.core.testtrees.TermNames
 import io.github.effiban.scala2java.core.testtrees.TermNames.{Apply, Empty, Future, JavaAbsent, JavaCompletableFuture, JavaCompletedFuture, JavaFailedFuture, JavaFailure, JavaIntStream, JavaOf, JavaOfNullable, JavaOfSupplier, JavaOptional, JavaRange, JavaRangeClosed, JavaSuccess, JavaSupplyAsync, LowercaseLeft, LowercaseRight, ScalaFailed, ScalaFailure, ScalaInclusive, ScalaLeft, ScalaOption, ScalaRange, ScalaRight, ScalaSome, ScalaSuccess, ScalaSuccessful, Try}
+import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, XtensionQuasiquoteTerm}
@@ -16,7 +16,7 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
 
   private val termApplyTransformer = new CoreTermApplyTransformer(termNameClassifier, termSelectTermFunctionTransformer)
 
-  test("transform 'Range.apply' should return 'IntStream.range'") {
+  test("transform 'Range.apply(1, 10)' should return 'IntStream.range(1, 10)'") {
     val args = List(q"1", q"10")
     val scalaTermApply = Term.Apply(Term.Select(ScalaRange, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaIntStream, JavaRange), args)
@@ -24,7 +24,7 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Range.inclusive' should return 'IntStream.rangeClosed'") {
+  test("transform 'Range.inclusive(1, 10)' should return 'IntStream.rangeClosed(1, 10)'") {
     val args = List(q"1", q"10")
     val scalaTermApply = Term.Apply(Term.Select(ScalaRange, ScalaInclusive), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaIntStream, JavaRangeClosed), args)
@@ -32,7 +32,7 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Option.apply' should return 'Optional.ofNullable'") {
+  test("transform 'Option.apply(1)' should return 'Optional.ofNullable(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(ScalaOption, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaOptional, JavaOfNullable), args)
@@ -40,14 +40,35 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Option.empty' should return 'Optional.absent'") {
+  test("transform 'Option.apply[Int](1)' should return 'Optional.ofNullable[Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(
+      Term.ApplyType(Term.Select(ScalaOption, Apply), typeArgs),
+      args)
+    val expectedJavaTermApply = Term.Apply(
+      Term.ApplyType(Term.Select(JavaOptional, JavaOfNullable), typeArgs),
+      args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Option.empty()' should return 'Optional.absent()'") {
     val scalaTermApply = Term.Apply(Term.Select(ScalaOption, Empty), Nil)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaOptional, JavaAbsent), Nil)
 
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Some.apply' should return 'Optional.of'") {
+  test("transform 'Option.empty[Int]()' should return 'Optional.absent[Int]()'") {
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(ScalaOption, Empty), typeArgs), Nil)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(JavaOptional, JavaAbsent), typeArgs), Nil)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Some.apply(1)' should return 'Optional.of(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(ScalaSome, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaOptional, JavaOf), args)
@@ -55,7 +76,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Right.apply' should return 'Either.right'") {
+  test("transform 'Some.apply[Int](1)' should return 'Optional.of[Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(ScalaSome, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(JavaOptional, JavaOf), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Right.apply(1)' should return 'Either.right(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(ScalaRight, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Either, LowercaseRight), args)
@@ -63,7 +93,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Left.apply' should return 'Either.left'") {
+  test("transform 'Right.apply[Throwable, Int](1)' should return 'Either.right[Throwable, Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Throwable, TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(ScalaRight, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Either, LowercaseRight), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("""transform 'Left.apply("error")' should return 'Either.left("error")'""") {
     val args = List(q"error")
     val scalaTermApply = Term.Apply(Term.Select(ScalaLeft, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Either, LowercaseLeft), args)
@@ -71,7 +110,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Try.apply' should return 'Try.ofSupplier'") {
+  test("""transform 'Left.apply[String, Int]("error")' should return 'Either.left[String, Int]("error")'""") {
+    val args = List(q"error")
+    val typeArgs = List(TypeNames.Throwable, TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(ScalaLeft, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Either, LowercaseLeft), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Try.apply(1)' should return 'Try.ofSupplier(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(Try, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(Try, JavaOfSupplier), args)
@@ -79,7 +127,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Success.apply' should return 'Try.success'") {
+  test("transform 'Try.apply[Int](1)' should return 'Try.ofSupplier[Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(Try, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(Try, JavaOfSupplier), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Success.apply(1)' should return 'Try.success(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(ScalaSuccess, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(Try, JavaSuccess), args)
@@ -87,15 +144,33 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Failure.apply' should return 'Try.failure'") {
-    val args = List(q"error")
+  test("transform 'Success.apply[Int](1)' should return 'Try.success[Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(ScalaSuccess, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply( Term.ApplyType(Term.Select(Try, JavaSuccess), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Failure.apply(new RuntimeException())' should return 'Try.failure(new RuntimeException())'") {
+    val args = List(q"new RuntimeException()")
     val scalaTermApply = Term.Apply(Term.Select(ScalaFailure, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(Try, JavaFailure), args)
 
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Future.apply' should return 'CompletableFuture.supplyAsync'") {
+  test("transform 'Failure.apply[Int](new RuntimeException())' should return 'Try.failure[Int](new RuntimeException())'") {
+    val args = List(q"new RuntimeException()")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(ScalaFailure, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(Try, JavaFailure), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Future.apply(1)' should return 'CompletableFuture.supplyAsync(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Future, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaCompletableFuture, JavaSupplyAsync), args)
@@ -103,7 +178,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Future.successful' should return 'CompletableFuture.completedFuture'") {
+  test("transform 'Future.apply[Int](1)' should return 'CompletableFuture.supplyAsync[Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Future, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(JavaCompletableFuture, JavaSupplyAsync), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Future.successful(1)' should return 'CompletableFuture.completedFuture(1)'") {
     val args = List(q"1")
     val scalaTermApply = Term.Apply(Term.Select(Future, ScalaSuccessful), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaCompletableFuture, JavaCompletedFuture), args)
@@ -111,7 +195,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Future.failed' should return 'CompletableFuture.failedFuture'") {
+  test("transform 'Future.successful[Int](1)' should return 'CompletableFuture.completedFuture[Int](1)'") {
+    val args = List(q"1")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(Future, ScalaSuccessful), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(JavaCompletableFuture, JavaCompletedFuture), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("""transform 'Future.failed("error")' should return 'CompletableFuture.failedFuture("error")'""") {
     val args = List(q"error")
     val scalaTermApply = Term.Apply(Term.Select(Future, ScalaFailed), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(JavaCompletableFuture, JavaFailedFuture), args)
@@ -119,7 +212,16 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Stream.apply' should return 'Stream.of'") {
+  test("""transform 'Future.failed[Int]("error")' should return 'CompletableFuture.failedFuture[Int]("error")'""") {
+    val args = List(q"error")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(Future, ScalaFailed), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(JavaCompletableFuture, JavaFailedFuture), typeArgs), args)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Stream.apply(1, 2)' should return 'Stream.of(1, 2)'") {
     val args = List(q"1", q"2")
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Stream, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Stream, JavaOf), args)
@@ -129,7 +231,37 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Seq.apply' should return 'List.of'") {
+  test("transform 'Stream.apply[Int](1, 2)' should return 'Stream.of[Int](1, 2)'") {
+    val args = List(q"1", q"2")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Stream, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Stream, JavaOf), typeArgs), args)
+
+    when(termNameClassifier.isJavaStreamLike(eqTree(TermNames.Stream))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Stream.empty()' should return 'Stream.of()'") {
+    val scalaTermApply = Term.Apply(Term.Select(TermNames.Stream, Empty), Nil)
+    val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Stream, JavaOf), Nil)
+
+    when(termNameClassifier.isJavaStreamLike(eqTree(TermNames.Stream))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Stream.empty[Int]()' should return 'Stream.of[Int]()'") {
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Stream, Empty), typeArgs), Nil)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Stream, JavaOf), typeArgs), Nil)
+
+    when(termNameClassifier.isJavaStreamLike(eqTree(TermNames.Stream))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Seq.apply(1, 2)' should return 'List.of(1, 2)'") {
     val args = List(q"1", q"2")
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Seq, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.List, JavaOf), args)
@@ -139,7 +271,18 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Seq.empty' should return 'List.of'") {
+  test("transform 'Seq.apply[Int](1, 2)' should return 'List.of[Int](1, 2)'") {
+    val args = List(q"1", q"2")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Seq, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.List, JavaOf), typeArgs), args)
+
+    when(termNameClassifier.isJavaListLike(eqTree(TermNames.Seq))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Seq.empty()' should return 'List.of()'") {
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Seq, Empty), Nil)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.List, JavaOf), Nil)
 
@@ -148,7 +291,17 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Set.apply' should return 'Set.of'") {
+  test("transform 'Seq.empty[Int]()' should return 'List.of[Int]()'") {
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Seq, Empty), typeArgs), Nil)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.List, JavaOf), typeArgs), Nil)
+
+    when(termNameClassifier.isJavaListLike(eqTree(TermNames.Seq))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Set.apply(1, 2)' should return 'Set.of(1, 2)'") {
     val args = List(q"1", q"2")
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Set, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Set, JavaOf), args)
@@ -158,7 +311,18 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Set.empty' should return 'Set.of'") {
+  test("transform 'Set.apply[Int](1, 2)' should return 'Set.of[Int](1, 2)'") {
+    val args = List(q"1", q"2")
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Set, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Set, JavaOf), typeArgs), args)
+
+    when(termNameClassifier.isJavaSetLike(eqTree(TermNames.Set))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Set.empty()' should return 'Set.of()'") {
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Set, Empty), Nil)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Set, JavaOf), Nil)
 
@@ -167,7 +331,17 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Map.apply' should return 'Map.ofEntries'") {
+  test("transform 'Set.empty[Int]()' should return 'Set.of[Int]()'") {
+    val typeArgs = List(TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Set, Empty), typeArgs), Nil)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Set, JavaOf), typeArgs), Nil)
+
+    when(termNameClassifier.isJavaSetLike(eqTree(TermNames.Set))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("""transform 'Map.apply(("a", 1), ("b", 2))' should return 'Map.ofEntries(("a", 1), ("b", 2))'""") {
     val args = List(q"""("a", 1)""", q"""("b", 2)""")
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Map, Apply), args)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Map, TermNames.JavaOfEntries), args)
@@ -177,9 +351,30 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
   }
 
-  test("transform 'Map.empty' should return 'Map.of'") {
+  test("""transform 'Map.apply[String, Int](("a", 1), ("b", 2))' should return 'Map.ofEntries[String, Int](("a", 1), ("b", 2))'""") {
+    val args = List(q"""("a", 1)""", q"""("b", 2)""")
+    val typeArgs = List(TypeNames.String, TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Map, Apply), typeArgs), args)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Map, TermNames.JavaOfEntries), typeArgs), args)
+
+    when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Map.empty()' should return 'Map.of()'") {
     val scalaTermApply = Term.Apply(Term.Select(TermNames.Map, Empty), Nil)
     val expectedJavaTermApply = Term.Apply(Term.Select(TermNames.Map, TermNames.JavaOf), Nil)
+
+    when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
+
+    termApplyTransformer.transform(scalaTermApply).structure shouldBe expectedJavaTermApply.structure
+  }
+
+  test("transform 'Map.empty[String, Int]()' should return 'Map.of[String, Int]()'") {
+    val typeArgs = List(TypeNames.String, TypeNames.Int)
+    val scalaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Map, Empty), typeArgs), Nil)
+    val expectedJavaTermApply = Term.Apply(Term.ApplyType(Term.Select(TermNames.Map, TermNames.JavaOf), typeArgs), Nil)
 
     when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
 
@@ -197,8 +392,8 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(termApply).structure shouldBe expectedTransformedTermApply.structure
   }
 
-  test("transform 'Dummy.dummy' should return same") {
-    val termApply = Term.Apply(Term.Select(Term.Name("Dummy"), Term.Name("dummy")), Nil)
+  test("transform 'Dummy.dummy(1)' should return same") {
+    val termApply = q"Dummy.dummy(1)"
 
     termApplyTransformer.transform(termApply).structure shouldBe termApply.structure
   }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermSelectTransformerTest.scala
@@ -1,194 +1,22 @@
 package io.github.effiban.scala2java.core.transformers
 
-import io.github.effiban.scala2java.core.classifiers.TermNameClassifier
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
-import io.github.effiban.scala2java.core.testtrees.TermNames
-import io.github.effiban.scala2java.core.testtrees.TermNames._
-import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import io.github.effiban.scala2java.core.transformers.CoreTermSelectTransformer.transform
 
-import scala.meta.{Term, XtensionQuasiquoteTerm}
+import scala.meta.Term
 
 class CoreTermSelectTransformerTest extends UnitTestSuite {
-
-  private val termNameClassifier = mock[TermNameClassifier]
-  private val termSelectTermFunctionTransformer = mock[TermSelectTermFunctionTransformer]
-
-  private val termSelectTransformer = new CoreTermSelectTransformer(termNameClassifier, termSelectTermFunctionTransformer)
-
-
-  test("transform 'Range.apply' should return 'IntStream.range'") {
-    val scalaTermSelect = Term.Select(ScalaRange, Apply)
-    val expectedJavaTermSelect = Term.Select(JavaIntStream, JavaRange)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Range.inclusive' should return 'IntStream.rangeClosed'") {
-    val scalaTermSelect = Term.Select(ScalaRange, ScalaInclusive)
-    val expectedJavaTermSelect = Term.Select(JavaIntStream, JavaRangeClosed)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Option.apply' should return 'Optional.ofNullable'") {
-    val scalaTermSelect = Term.Select(ScalaOption, Apply)
-    val expectedJavaTermSelect = Term.Select(JavaOptional, JavaOfNullable)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Option.empty' should return 'Optional.absent'") {
-    val scalaTermSelect = Term.Select(ScalaOption, Empty)
-    val expectedJavaTermSelect = Term.Select(JavaOptional, JavaAbsent)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Some.apply' should return 'Optional.of'") {
-    val scalaTermSelect = Term.Select(ScalaSome, Apply)
-    val expectedJavaTermSelect = Term.Select(JavaOptional, JavaOf)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Right.apply' should return 'Either.right'") {
-    val scalaTermSelect = Term.Select(ScalaRight, Apply)
-    val expectedJavaTermSelect = Term.Select(TermNames.Either, LowercaseRight)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Left.apply' should return 'Either.left'") {
-    val scalaTermSelect = Term.Select(ScalaLeft, Apply)
-    val expectedJavaTermSelect = Term.Select(TermNames.Either, LowercaseLeft)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Try.apply' should return 'Try.ofSupplier'") {
-    val scalaTermSelect = Term.Select(Try, Apply)
-    val expectedJavaTermSelect = Term.Select(Try, JavaOfSupplier)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Success.apply' should return 'Try.success'") {
-    val scalaTermSelect = Term.Select(ScalaSuccess, Apply)
-    val expectedJavaTermSelect = Term.Select(Try, JavaSuccess)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Failure.apply' should return 'Try.failure'") {
-    val scalaTermSelect = Term.Select(ScalaFailure, Apply)
-    val expectedJavaTermSelect = Term.Select(Try, JavaFailure)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Future.apply' should return 'CompletableFuture.supplyAsync'") {
-    val scalaTermSelect = Term.Select(TermNames.Future, Apply)
-    val expectedJavaTermSelect = Term.Select(JavaCompletableFuture, JavaSupplyAsync)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Future.successful' should return 'CompletableFuture.completedFuture'") {
-    val scalaTermSelect = Term.Select(Future, ScalaSuccessful)
-    val expectedJavaTermSelect = Term.Select(JavaCompletableFuture, JavaCompletedFuture)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Future.failed' should return 'CompletableFuture.failedFuture'") {
-    val scalaTermSelect = Term.Select(Future, ScalaFailed)
-    val expectedJavaTermSelect = Term.Select(JavaCompletableFuture, JavaFailedFuture)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
 
   test("transform 'myTuple._1' should return 'myTuple.v1'") {
     val scalaTermSelect = Term.Select(Term.Name("myTuple"), Term.Name("_1"))
     val expectedJavaTermSelect = Term.Select(Term.Name("myTuple"), Term.Name("v1"))
 
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Stream.apply' should return 'Stream.of'") {
-    val scalaTermSelect = Term.Select(TermNames.Stream, Apply)
-    val expectedJavaTermSelect = Term.Select(TermNames.Stream, JavaOf)
-
-    when(termNameClassifier.isJavaStreamLike(eqTree(TermNames.Stream))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Seq.apply' should return 'List.of'") {
-    val scalaTermSelect = Term.Select(TermNames.Seq, Apply)
-    val expectedJavaTermSelect = Term.Select(TermNames.List, JavaOf)
-
-    when(termNameClassifier.isJavaListLike(eqTree(TermNames.Seq))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Seq.empty' should return 'List.of'") {
-    val scalaTermSelect = Term.Select(TermNames.Seq, Empty)
-    val expectedJavaTermSelect = Term.Select(TermNames.List, JavaOf)
-
-    when(termNameClassifier.isJavaListLike(eqTree(TermNames.Seq))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Set.apply' should return 'Set.of'") {
-    val scalaTermSelect = Term.Select(TermNames.Set, Apply)
-    val expectedJavaTermSelect = Term.Select(TermNames.Set, JavaOf)
-
-    when(termNameClassifier.isJavaSetLike(eqTree(TermNames.Set))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Set.empty' should return 'Set.of'") {
-    val scalaTermSelect = Term.Select(TermNames.Set, Empty)
-    val expectedJavaTermSelect = Term.Select(TermNames.Set, JavaOf)
-
-    when(termNameClassifier.isJavaSetLike(eqTree(TermNames.Set))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Map.apply' should return 'Map.ofEntries'") {
-    val scalaTermSelect = Term.Select(TermNames.Map, Apply)
-    val expectedJavaTermSelect = Term.Select(TermNames.Map, TermNames.JavaOfEntries)
-
-    when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform 'Map.empty' should return 'Map.of'") {
-    val scalaTermSelect = Term.Select(TermNames.Map, Empty)
-    val expectedJavaTermSelect = Term.Select(TermNames.Map, TermNames.JavaOf)
-
-    when(termNameClassifier.isJavaMapLike(eqTree(TermNames.Map))).thenReturn(true)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
-  }
-
-  test("transform a 'Term.Function' (lambda) with a method name, should return result of 'TermSelectTermFunctionTransformer'") {
-    val scalaTermSelect = q"((x: Int) => print(x)).apply"
-    val expectedTransformedTermSelect = q"(((x: Int) => print(x)): Consumer[Int]).accept"
-
-    when(termSelectTermFunctionTransformer.transform(eqTree(q"(x: Int) => print(x)"), eqTree(Apply))).thenReturn(expectedTransformedTermSelect)
-
-    termSelectTransformer.transform(scalaTermSelect).value.structure shouldBe expectedTransformedTermSelect.structure
+    transform(scalaTermSelect).value.structure shouldBe expectedJavaTermSelect.structure
   }
 
   test("transform 'Dummy.dummy' should return None") {
     val termSelect = Term.Select(Term.Name("Dummy"), Term.Name("dummy"))
 
-    termSelectTransformer.transform(termSelect) shouldBe None
+    transform(termSelect) shouldBe None
   }
 }


### PR DESCRIPTION
Since desugaring is now properly supported for all cases, all transformations that were done for methods in `CoreTermSelectTransfomer` level can be moved to `CoreTermApplyTransformer`.
We also need to modify that transformer to handle the case of a typed qualified method name (`Term.ApplyType` wrapping a `Term.Select`).