### PR TITLE
Fix `ApplyTypeTypeInferrer`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/entities/TermNameValues.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/entities/TermNameValues.scala
@@ -59,6 +59,7 @@ object TermNameValues {
   final val ScalaTo = "to"
   final val ScalaUntil = "until"
   final val ScalaAssociate = "->"
+  final val ScalaClassOf = "classOf"
 
   final val Java = "java"
   final val JavaIntStream = "IntStream"

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/entities/TypeNameValues.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/entities/TypeNameValues.scala
@@ -15,6 +15,7 @@ object TypeNameValues {
   final val Set = "Set"
   final val Stream = "Stream"
   final val Try = "Try"
+  final val Class = "Class"
 
   final val ScalaAny = "Any"
   final val ScalaArray = "Array"

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/MainApplyTypeTraverserImpl.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/MainApplyTypeTraverserImpl.scala
@@ -1,5 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.entities.TermNameValues.ScalaClassOf
+
 import scala.meta.Term
 import scala.meta.Term.ApplyType
 
@@ -11,7 +13,7 @@ private[traversers] class MainApplyTypeTraverserImpl(classOfTraverser: => ClassO
 
   // parametrized type application, e.g.: classOf[X], identity[X]
   override def traverse(termApplyType: ApplyType): Unit = termApplyType.fun match {
-    case Term.Name("classOf") => classOfTraverser.traverse(termApplyType.targs)
+    case Term.Name(ScalaClassOf) => classOfTraverser.traverse(termApplyType.targs)
     case _ => standardApplyTypeTraverser.traverse(termApplyType)
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeTypeInferrer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeTypeInferrer.scala
@@ -1,7 +1,7 @@
 package io.github.effiban.scala2java.core.typeinference
 
-import io.github.effiban.scala2java.core.entities.TermNameValues.Apply
-import io.github.effiban.scala2java.spi.predicates.TermNameHasApplyMethod
+import io.github.effiban.scala2java.core.entities.TermNameValues.ScalaClassOf
+import io.github.effiban.scala2java.core.entities.TypeNameValues
 
 import scala.meta.{Term, Type}
 
@@ -9,16 +9,12 @@ trait ApplyTypeTypeInferrer {
   def infer(termApplyType: Term.ApplyType): Option[Type]
 }
 
-private[typeinference] class ApplyTypeTypeInferrerImpl(applyReturnTypeInferrer: => ApplyReturnTypeInferrer,
-                                                       termNameHasApplyMethod: TermNameHasApplyMethod)
+private[typeinference] class ApplyTypeTypeInferrerImpl(applyReturnTypeInferrer: => ApplyReturnTypeInferrer)
   extends ApplyTypeTypeInferrer {
 
   override def infer(termApplyType: Term.ApplyType): Option[Type] = {
     termApplyType match {
-      case Term.ApplyType(termName: Term.Name, targs) if termNameHasApplyMethod(termName) =>
-        applyReturnTypeInferrer.infer(Term.Apply(
-          Term.ApplyType(Term.Select(termName, Term.Name(Apply)), targs),
-          Nil))
+      case Term.ApplyType(Term.Name(ScalaClassOf), List(tpe)) => Some(Type.Apply(Type.Name(TypeNameValues.Class), List(tpe)))
       case aTermApplyType => applyReturnTypeInferrer.infer(Term.Apply(aTermApplyType, Nil))
     }
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/TypeInferrers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/TypeInferrers.scala
@@ -20,10 +20,7 @@ class TypeInferrers(factories: => Factories,
     internalApplyDeclDefInferrer
   )
 
-  private[typeinference] lazy val applyTypeTypeInferrer = new ApplyTypeTypeInferrerImpl(
-    applyReturnTypeInferrer,
-    compositeTermNameHasApplyMethod
-  )
+  private[typeinference] lazy val applyTypeTypeInferrer = new ApplyTypeTypeInferrerImpl(applyReturnTypeInferrer)
 
   private[typeinference] lazy val blockTypeInferrer = new BlockTypeInferrerImpl(termTypeInferrer)
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/testtrees/TermNames.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/testtrees/TermNames.scala
@@ -57,6 +57,7 @@ object TermNames {
   val ScalaFailed: Term.Name = Term.Name("failed")
   val ScalaVector: Term.Name = Term.Name("Vector")
   val ScalaNil: Term.Name = Term.Name("Nil")
+  val ScalaClassOf: Term.Name = Term.Name("classOf")
 
   val Java: Term.Name = Term.Name("java")
   val JavaIntStream: Term.Name = Term.Name("IntStream")

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/testtrees/TypeNames.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/testtrees/TypeNames.scala
@@ -29,6 +29,8 @@ object TypeNames {
 
   val Throwable: Type.Name = t"Throwable"
 
+  val Class: Type.Name = t"Class"
+
   val ScalaArray: Type.Name = Type.Name("Array")
   val ScalaOption: Type.Name = Type.Name("Option")
   val ScalaAny: Type.Name = Type.Name("Any")

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/MainApplyTypeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/MainApplyTypeTraverserImplTest.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.core.testtrees.TermNames.ScalaClassOf
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
@@ -19,7 +20,7 @@ class MainApplyTypeTraverserImplTest extends UnitTestSuite {
 
   test("traverse() when function is 'classOf' should call the dedicated traverser") {
     val typeName = t"T"
-    val termApplyType = Term.ApplyType(fun = Term.Name("classOf"), targs = List(typeName))
+    val termApplyType = Term.ApplyType(fun = ScalaClassOf, targs = List(typeName))
 
     mainApplyTypeTraverser.traverse(termApplyType)
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeTypeInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/ApplyTypeTypeInferrerImplTest.scala
@@ -1,35 +1,31 @@
 package io.github.effiban.scala2java.core.typeinference
 
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
-import io.github.effiban.scala2java.spi.predicates.TermNameHasApplyMethod
+import io.github.effiban.scala2java.core.testtrees.TermNames.ScalaClassOf
+import io.github.effiban.scala2java.core.testtrees.TypeNames
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
-import scala.meta.{XtensionQuasiquoteTerm, XtensionQuasiquoteType}
+import scala.meta.{Term, Type, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
 
 class ApplyTypeTypeInferrerImplTest extends UnitTestSuite {
 
   private val applyReturnTypeInferrer = mock[ApplyReturnTypeInferrer]
-  private val termNameHasApplyMethod = mock[TermNameHasApplyMethod]
 
-  private val applyTypeTypeInferrer = new ApplyTypeTypeInferrerImpl(applyReturnTypeInferrer, termNameHasApplyMethod)
+  private val applyTypeTypeInferrer = new ApplyTypeTypeInferrerImpl(applyReturnTypeInferrer)
 
-  test("infer() when term has an apply() method") {
-    val termApplyType = q"List[Int]"
-    val expectedTermApply = q"List.apply[Int]()"
-    val expectedType = t"List[Int]"
-
-    when(termNameHasApplyMethod(eqTree(q"List"))).thenReturn(true)
-    when(applyReturnTypeInferrer.infer(eqTree(expectedTermApply))).thenReturn(Some(expectedType))
+  test("infer() when term is 'classOf[Foo]' should return 'Class[Foo]'") {
+    val innerType = t"Foo"
+    val termApplyType = Term.ApplyType(ScalaClassOf, List(innerType))
+    val expectedType = Type.Apply(TypeNames.Class, List(innerType))
 
     applyTypeTypeInferrer.infer(termApplyType).value.structure shouldBe expectedType.structure
   }
 
-  test("infer() when term does not have an apply() method") {
+  test("infer() for arbitrary typed term should return an equivalent Term.Apply with no params") {
     val termApplyType = q"Foo[Int]"
     val expectedTermApply = q"Foo[Int]()"
     val expectedType = t"String"
 
-    when(termNameHasApplyMethod(eqTree(q"Foo"))).thenReturn(false)
     when(applyReturnTypeInferrer.infer(eqTree(expectedTermApply))).thenReturn(Some(expectedType))
 
     applyTypeTypeInferrer.infer(termApplyType).value.structure shouldBe expectedType.structure


### PR DESCRIPTION
- Handle 'classOf'
- Skip redundant check for implicit 'apply' method