### PR TITLE
Refactor `ApplyUnaryTraverser` to use `TermNameRenderer`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ApplyUnaryTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ApplyUnaryTraverser.scala
@@ -1,14 +1,16 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
+
 import scala.meta.Term.ApplyUnary
 
 trait ApplyUnaryTraverser extends ScalaTreeTraverser[ApplyUnary]
 
-private[traversers] class ApplyUnaryTraverserImpl(defaultTermNameTraverser: => TermNameTraverser,
+private[traversers] class ApplyUnaryTraverserImpl(termNameRenderer: TermNameRenderer,
                                                   expressionTermTraverser: => TermTraverser) extends ApplyUnaryTraverser {
 
   override def traverse(applyUnary: ApplyUnary): Unit = {
-    defaultTermNameTraverser.traverse(applyUnary.op)
+    termNameRenderer.render(applyUnary.op)
     expressionTermTraverser.traverse(applyUnary.arg)
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -40,7 +40,7 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
 
   private lazy val anonymousFunctionTraverser: AnonymousFunctionTraverser = new AnonymousFunctionTraverserImpl(termFunctionTraverser)
 
-  private lazy val applyUnaryTraverser: ApplyUnaryTraverser = new ApplyUnaryTraverserImpl(defaultTermNameTraverser, expressionTermTraverser)
+  private lazy val applyUnaryTraverser: ApplyUnaryTraverser = new ApplyUnaryTraverserImpl(termNameRenderer, expressionTermTraverser)
 
   private lazy val argumentListTraverser: ArgumentListTraverser = new ArgumentListTraverserImpl
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyUnaryTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ApplyUnaryTraverserImplTest.scala
@@ -1,5 +1,6 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
@@ -8,16 +9,16 @@ import scala.meta.Term
 
 class ApplyUnaryTraverserImplTest extends UnitTestSuite {
 
-  private val defaultTermNameTraverser = mock[TermNameTraverser]
+  private val termNameRenderer = mock[TermNameRenderer]
   private val expressionTermTraverser = mock[ExpressionTermTraverser]
 
-  private val applyUnaryTraverser = new ApplyUnaryTraverserImpl(defaultTermNameTraverser, expressionTermTraverser)
+  private val applyUnaryTraverser = new ApplyUnaryTraverserImpl(termNameRenderer, expressionTermTraverser)
 
   test("traverse") {
     val op = Term.Name("!")
     val arg = Term.Name("myFlag")
 
-    doWrite("!").when(defaultTermNameTraverser).traverse(eqTree(op))
+    doWrite("!").when(termNameRenderer).render(eqTree(op))
     doWrite("myFlag").when(expressionTermTraverser).traverse(eqTree(arg))
 
     applyUnaryTraverser.traverse(Term.ApplyUnary(op = op, arg = arg))


### PR DESCRIPTION
A unary operator in Scala is a symbol coming from a fixed list which is the same as in Java, so it can be rendered directly with no additional transformations