### PR TITLE
In `NameTraverser` use `TermNameRenderer` instead of `TermNameTraverser`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/NameTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/NameTraverser.scala
@@ -1,5 +1,6 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.{Name, Term, Type}
@@ -8,7 +9,7 @@ trait NameTraverser extends ScalaTreeTraverser[Name]
 
 private[traversers] class NameTraverserImpl(nameAnonymousTraverser: => NameAnonymousTraverser,
                                             nameIndeterminateTraverser: => NameIndeterminateTraverser,
-                                            termNameTraverser: => TermNameTraverser,
+                                            termNameRenderer: TermNameRenderer,
                                             typeNameTraverser: => TypeNameTraverser)
                                            (implicit javaWriter: JavaWriter) extends NameTraverser {
 
@@ -17,7 +18,7 @@ private[traversers] class NameTraverserImpl(nameAnonymousTraverser: => NameAnony
   override def traverse(name: Name): Unit = name match {
     case anonName: Name.Anonymous => nameAnonymousTraverser.traverse(anonName)
     case indeterminateName: Name.Indeterminate => nameIndeterminateTraverser.traverse(indeterminateName)
-    case termName: Term.Name => termNameTraverser.traverse(termName)
+    case termName: Term.Name => termNameRenderer.render(termName)
     case typeName: Type.Name => typeNameTraverser.traverse(typeName)
     case other => writeComment(s"UNSUPPORTED: $other")
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -326,7 +326,7 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
   private lazy val nameTraverser: NameTraverser = new NameTraverserImpl(
     NameAnonymousTraverser,
     nameIndeterminateTraverser,
-    defaultTermNameTraverser,
+    termNameRenderer,
     typeNameTraverser
   )
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NameTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/NameTraverserImplTest.scala
@@ -1,5 +1,6 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
@@ -9,13 +10,13 @@ class NameTraverserImplTest extends UnitTestSuite {
 
   private val nameAnonymousTraverser = mock[NameAnonymousTraverser]
   private val nameIndeterminateTraverser = mock[NameIndeterminateTraverser]
-  private val termNameTraverser = mock[TermNameTraverser]
+  private val termNameRenderer = mock[TermNameRenderer]
   private val typeNameTraverser = mock[TypeNameTraverser]
 
 
   private val nameTraverser = new NameTraverserImpl(nameAnonymousTraverser,
     nameIndeterminateTraverser,
-    termNameTraverser,
+    termNameRenderer,
     typeNameTraverser)
 
   test("traverse for Name.Anonymous") {
@@ -37,7 +38,7 @@ class NameTraverserImplTest extends UnitTestSuite {
 
     nameTraverser.traverse(name)
 
-    verify(termNameTraverser).traverse(eqTree(name))
+    verify(termNameRenderer).render(eqTree(name))
   }
 
   test("traverse for Term.Type") {

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/ExtendedTransformers.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/ExtendedTransformers.scala
@@ -108,7 +108,8 @@ trait ExtendedTransformers {
    */
   def termSelectTransformer(): TermSelectTransformer = TermSelectTransformer.Empty
 
-  /** Override this method if you need to modify a [[scala.meta.Term.Name]] (identifier) appearing by itself.<br>
+  /** Override this method if you need to modify a [[scala.meta.Term.Name]] (identifier) appearing in the context
+   * of an evaluated expression (see [[TermApplyTransformer]] for examples).<br>
    * '''NOTE''': This transformer will only be called for identifiers that are __not__ method invocations.<br>
    * If some method invocation is an identifier with no args and no parentheses,
    * it will be automatically 'desugared' into a method invocation and eventually passed to [[termApplyTransformer]].<br>

--- a/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/TermNameTransformer.scala
+++ b/scala2java-spi/src/main/scala/io/github/effiban/scala2java/spi/transformers/TermNameTransformer.scala
@@ -2,7 +2,14 @@ package io.github.effiban.scala2java.spi.transformers
 
 import scala.meta.Term
 
-/** A transformer which can modify a given Scala [[Term.Name]] (identifier) when appearing by itself */
+/** A transformer which can modify a given Scala [[Term.Name]] (identifier) when appearing in the context of
+ * an evaulated expression, for example:
+ * - return value
+ * - method argument
+ * - RHS of an assignment
+ * - RHS of a 'case' clause
+ */
+
 trait TermNameTransformer extends DifferentTypeTransformer0[Term.Name, Term]
 
 object TermNameTransformer {


### PR DESCRIPTION
In the context of a general `Name` (which is a stable element, not part of an expression), it is not likely that a `Term.Name` will need to be modified - therefore the renderer can be called directly.