### PR TITLE
Split `TermSelectTraverser` into three types

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultTermRefTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultTermRefTraverser.scala
@@ -6,13 +6,11 @@ import io.github.effiban.scala2java.core.writers.JavaWriter
 import scala.meta.Term
 import scala.meta.Term.{Super, This}
 
-trait DefaultTermRefTraverser extends ScalaTreeTraverser[Term.Ref]
-
-private[traversers] class DefaultTermRefTraverserImpl(thisTraverser: => ThisTraverser,
-                                                      superTraverser: => SuperTraverser,
-                                                      termNameRenderer: TermNameRenderer,
-                                                      termSelectTraverser: => TermSelectTraverser)
-                                                     (implicit javaWriter: JavaWriter) extends DefaultTermRefTraverser {
+private[traversers] class DefaultTermRefTraverser(thisTraverser: => ThisTraverser,
+                                                  superTraverser: => SuperTraverser,
+                                                  termNameRenderer: TermNameRenderer,
+                                                  defaultTermSelectTraverser: => DefaultTermSelectTraverser)
+                                                 (implicit javaWriter: JavaWriter) extends TermRefTraverser {
 
   import javaWriter._
 
@@ -20,7 +18,7 @@ private[traversers] class DefaultTermRefTraverserImpl(thisTraverser: => ThisTrav
     case `this`: This => thisTraverser.traverse(`this`)
     case `super`: Super => superTraverser.traverse(`super`)
     case termName: Term.Name => termNameRenderer.render(termName)
-    case termSelect: Term.Select => termSelectTraverser.traverse(termSelect)
+    case termSelect: Term.Select => defaultTermSelectTraverser.traverse(termSelect)
     case _ => writeComment(s"UNSUPPORTED Term.Ref in a Path context: $termRef")
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultTermSelectTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultTermSelectTraverser.scala
@@ -1,0 +1,24 @@
+package io.github.effiban.scala2java.core.traversers
+
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
+import io.github.effiban.scala2java.core.writers.JavaWriter
+
+import scala.meta.Term
+
+trait DefaultTermSelectTraverser {
+  def traverse(termSelect: Term.Select): Unit
+}
+
+private[traversers] class DefaultTermSelectTraverserImpl(qualifierTraverser: => TermTraverser,
+                                                         termNameRenderer: TermNameRenderer)
+                                                        (implicit javaWriter: JavaWriter) extends DefaultTermSelectTraverser {
+
+  import javaWriter._
+
+  // A qualified name in a stable, non-expression and non-function context
+  override def traverse(select: Term.Select): Unit = {
+    qualifierTraverser.traverse(select.qual)
+    writeQualifierSeparator()
+    termNameRenderer.render(select.name)
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultTermTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/DefaultTermTraverser.scala
@@ -6,7 +6,7 @@ import io.github.effiban.scala2java.core.writers.JavaWriter
 import scala.meta.Term.{AnonymousFunction, ApplyType, Ascribe, Assign, Block, Do, Eta, For, ForYield, If, New, NewAnonymous, Return, Throw, Try, TryWithHandler, While}
 import scala.meta.{Lit, Term}
 
-private[traversers] class DefaultTermTraverser(defaultTermRefTraverser: => DefaultTermRefTraverser,
+private[traversers] class DefaultTermTraverser(defaultTermRefTraverser: => TermRefTraverser,
                                                termApplyTraverser: => TermApplyTraverser,
                                                defaultMainApplyTypeTraverser: => MainApplyTypeTraverser,
                                                termApplyInfixTraverser: => TermApplyInfixTraverser,

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermRefTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermRefTraverser.scala
@@ -5,14 +5,12 @@ import io.github.effiban.scala2java.core.writers.JavaWriter
 import scala.meta.Term
 import scala.meta.Term.{ApplyUnary, Super, This}
 
-trait ExpressionTermRefTraverser extends ScalaTreeTraverser[Term.Ref]
-
-private[traversers] class ExpressionTermRefTraverserImpl(thisTraverser: => ThisTraverser,
-                                                         superTraverser: => SuperTraverser,
-                                                         termNameTraverser: => TermNameTraverser,
-                                                         termSelectTraverser: => TermSelectTraverser,
-                                                         applyUnaryTraverser: => ApplyUnaryTraverser)
-                                                        (implicit javaWriter: JavaWriter) extends ExpressionTermRefTraverser {
+private[traversers] class ExpressionTermRefTraverser(thisTraverser: => ThisTraverser,
+                                                     superTraverser: => SuperTraverser,
+                                                     termNameTraverser: => TermNameTraverser,
+                                                     termSelectTraverser: => ExpressionTermSelectTraverser,
+                                                     applyUnaryTraverser: => ApplyUnaryTraverser)
+                                                    (implicit javaWriter: JavaWriter) extends TermRefTraverser {
 
   import javaWriter._
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermSelectTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermSelectTraverser.scala
@@ -10,21 +10,21 @@ import io.github.effiban.scala2java.spi.contexts.TermSelectTransformationContext
 
 import scala.meta.Term
 
-trait TermSelectTraverser {
+trait ExpressionTermSelectTraverser {
   def traverse(termSelect: Term.Select, context: TermSelectContext = TermSelectContext()): Unit
 }
 
-private[traversers] class TermSelectTraverserImpl(qualifierTraverser: => TermTraverser,
-                                                  transformedTermTraverser: => TermTraverser,
-                                                  termNameRenderer: TermNameRenderer,
-                                                  typeListTraverser: => TypeListTraverser,
-                                                  qualifierTypeInferrer: => QualifierTypeInferrer,
-                                                  termSelectTransformer: InternalTermSelectTransformer)
-                                                 (implicit javaWriter: JavaWriter) extends TermSelectTraverser {
+private[traversers] class ExpressionTermSelectTraverserImpl(qualifierTraverser: => TermTraverser,
+                                                            transformedTermTraverser: => TermTraverser,
+                                                            termNameRenderer: TermNameRenderer,
+                                                            typeListTraverser: => TypeListTraverser,
+                                                            qualifierTypeInferrer: => QualifierTypeInferrer,
+                                                            termSelectTransformer: InternalTermSelectTransformer)
+                                                           (implicit javaWriter: JavaWriter) extends ExpressionTermSelectTraverser {
 
   import javaWriter._
 
-  // qualified name
+  // qualified name in the context of an evaluated expression, that might need to be desugared or otherwise transformed into a Java equivalent
   override def traverse(select: Term.Select, context: TermSelectContext = TermSelectContext()): Unit = {
     val maybeQualType = qualifierTypeInferrer.infer(select)
     val transformedTerm = termSelectTransformer.transform(select, TermSelectTransformationContext(maybeQualType))

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermTraverser.scala
@@ -12,7 +12,7 @@ import scala.meta.Term.{Block, If}
 private[traversers] class ExpressionTermTraverser(ifTraverser: => IfTraverser,
                                                   statTraverser: => StatTraverser,
                                                   termApplyTraverser: => TermApplyTraverser,
-                                                  expressionTermRefTraverser: => ExpressionTermRefTraverser,
+                                                  expressionTermRefTraverser: => TermRefTraverser,
                                                   expressionMainApplyTypeTraverser: MainApplyTypeTraverser,
                                                   defaultTermTraverser: => TermTraverser) extends TermTraverser {
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunOverridingTermTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunOverridingTermTraverser.scala
@@ -6,7 +6,7 @@ import scala.meta.Term
  * For such terms we need to either enable or disable the ability to 'desugar' into a method invocation - according to the context.<br>
  * This is because in the wrong context, it could either cause an invalid expression or else an infinite recursion.
  */
-private[traversers] class FunOverridingTermTraverser(termRefTraverser: => ExpressionTermRefTraverser,
+private[traversers] class FunOverridingTermTraverser(termRefTraverser: => TermRefTraverser,
                                                      applyTypeTraverser: => MainApplyTypeTraverser,
                                                      termTraverser: => TermTraverser) extends TermTraverser {
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunStandardApplyTypeTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunStandardApplyTypeTraverser.scala
@@ -6,16 +6,16 @@ import io.github.effiban.scala2java.core.writers.JavaWriter
 import scala.meta.Term
 import scala.meta.Term.ApplyType
 
-private[traversers] class DefaultStandardApplyTypeTraverser(termSelectTraverser: => TermSelectTraverser,
-                                                            typeListTraverser: => TypeListTraverser,
-                                                            unqualifiedTermTraverser: => TermTraverser)
-                                                           (implicit javaWriter: JavaWriter) extends StandardApplyTypeTraverser {
+private[traversers] class FunStandardApplyTypeTraverser(funTermSelectTraverser: => FunTermSelectTraverser,
+                                                        typeListTraverser: => TypeListTraverser,
+                                                        unqualifiedTermTraverser: => TermTraverser)
+                                                       (implicit javaWriter: JavaWriter) extends StandardApplyTypeTraverser {
 
   import javaWriter._
 
-  // parametrized type application which is an implicit method invocation, e.g.: identity[X]
+  // parametrized type application which is the 'fun' of a method invocation (after a possible desugaring and transformation)
   override def traverse(termApplyType: ApplyType): Unit = termApplyType.fun match {
-    case termSelect: Term.Select => termSelectTraverser.traverse(termSelect, TermSelectContext(termApplyType.targs))
+    case termSelect: Term.Select => funTermSelectTraverser.traverse(termSelect, TermSelectContext(termApplyType.targs))
     case term => traverseUnqualified(termApplyType, term)
   }
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunTermRefTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunTermRefTraverser.scala
@@ -1,0 +1,12 @@
+package io.github.effiban.scala2java.core.traversers
+
+import scala.meta.Term
+
+private[traversers] class FunTermRefTraverser(funTermSelectTraverser: => FunTermSelectTraverser,
+                                              defaultTermRefTraverser: => TermRefTraverser) extends TermRefTraverser {
+
+  override def traverse(termRef: Term.Ref): Unit = termRef match {
+    case termSelect: Term.Select => funTermSelectTraverser.traverse(termSelect)
+    case aTermRef => defaultTermRefTraverser.traverse(aTermRef)
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunTermSelectTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/FunTermSelectTraverser.scala
@@ -1,0 +1,49 @@
+package io.github.effiban.scala2java.core.traversers
+
+import io.github.effiban.scala2java.core.contexts.TermSelectContext
+import io.github.effiban.scala2java.core.entities.EnclosingDelimiter.Parentheses
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
+import io.github.effiban.scala2java.core.writers.JavaWriter
+
+import scala.meta.Term
+
+trait FunTermSelectTraverser {
+  def traverse(termSelect: Term.Select, context: TermSelectContext = TermSelectContext()): Unit
+}
+
+private[traversers] class FunTermSelectTraverserImpl(qualifierTraverser: => TermTraverser,
+                                                     termNameRenderer: TermNameRenderer,
+                                                     typeListTraverser: => TypeListTraverser)
+                                                    (implicit javaWriter: JavaWriter) extends FunTermSelectTraverser {
+
+  import javaWriter._
+
+  // qualified name which is part of a method invocation, but after any desugaring/transformation have been performed
+  override def traverse(select: Term.Select, context: TermSelectContext = TermSelectContext()): Unit = {
+    traverseQualifier(select.qual)
+    writeQualifierSeparator(select.qual)
+    typeListTraverser.traverse(context.appliedTypeArgs)
+    termNameRenderer.render(select.name)
+  }
+
+  private def traverseQualifier(qualifier: Term): Unit = {
+    qualifier match {
+      case qual@(_: Term.Function | Term.Ascribe(_: Term.Function, _)) => traverseInsideParens(qual)
+      case qual => qualifierTraverser.traverse(qual)
+    }
+  }
+
+  private def traverseInsideParens(qual: Term): Unit = {
+    writeArgumentsStart(Parentheses)
+    qualifierTraverser.traverse(qual)
+    writeArgumentsEnd(Parentheses)
+  }
+
+  private def writeQualifierSeparator(qualifier: Term): Unit = {
+    qualifier match {
+      case _: Term.Apply => writeLine()
+      case _ =>
+    }
+    javaWriter.writeQualifierSeparator()
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ImporterTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ImporterTraverser.scala
@@ -6,7 +6,7 @@ import scala.meta.Importer
 
 trait ImporterTraverser extends ScalaTreeTraverser[Importer]
 
-private[traversers] class ImporterTraverserImpl(termRefTraverser: => DefaultTermRefTraverser,
+private[traversers] class ImporterTraverserImpl(termRefTraverser: => TermRefTraverser,
                                                 importeeTraverser: => ImporteeTraverser)
                                                (implicit javaWriter: JavaWriter) extends ImporterTraverser {
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/PkgTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/PkgTraverser.scala
@@ -7,7 +7,7 @@ import scala.meta.{Import, Pkg}
 
 trait PkgTraverser extends ScalaTreeTraverser[Pkg]
 
-private[traversers] class PkgTraverserImpl(termRefTraverser: => DefaultTermRefTraverser,
+private[traversers] class PkgTraverserImpl(termRefTraverser: => TermRefTraverser,
                                            pkgStatListTraverser: => PkgStatListTraverser,
                                            additionalImportersProvider: AdditionalImportersProvider)
                                           (implicit javaWriter: JavaWriter) extends PkgTraverser {

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermRefTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermRefTraverser.scala
@@ -1,0 +1,5 @@
+package io.github.effiban.scala2java.core.traversers
+
+import scala.meta.Term
+
+trait TermRefTraverser extends ScalaTreeTraverser[Term.Ref]

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefaultTermRefTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefaultTermRefTraverserTest.scala
@@ -1,7 +1,5 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.contexts.TermSelectContext
-import io.github.effiban.scala2java.core.matchers.TermSelectContextMatcher.eqTermSelectContext
 import io.github.effiban.scala2java.core.renderers.TermNameRenderer
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
@@ -9,18 +7,18 @@ import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import scala.meta.Term.{Super, This}
 import scala.meta.{Name, Term}
 
-class DefaultTermRefTraverserImplTest extends UnitTestSuite {
+class DefaultTermRefTraverserTest extends UnitTestSuite {
 
   private val thisTraverser = mock[ThisTraverser]
   private val superTraverser = mock[SuperTraverser]
   private val termNameRenderer = mock[TermNameRenderer]
-  private val termSelectTraverser = mock[TermSelectTraverser]
+  private val defaultTermSelectTraverser = mock[DefaultTermSelectTraverser]
 
-  private val defaultTermRefTraverser = new DefaultTermRefTraverserImpl(
+  private val defaultTermRefTraverser = new DefaultTermRefTraverser(
     thisTraverser,
     superTraverser,
     termNameRenderer,
-    termSelectTraverser
+    defaultTermSelectTraverser
   )
   
   test("traverse 'this'") {
@@ -52,6 +50,6 @@ class DefaultTermRefTraverserImplTest extends UnitTestSuite {
 
     defaultTermRefTraverser.traverse(termSelect)
 
-    verify(termSelectTraverser).traverse(eqTree(termSelect), eqTermSelectContext(TermSelectContext()))
+    verify(defaultTermSelectTraverser).traverse(eqTree(termSelect))
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefaultTermSelectTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefaultTermSelectTraverserTest.scala
@@ -1,0 +1,32 @@
+package io.github.effiban.scala2java.core.traversers
+
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
+import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+
+import scala.meta.XtensionQuasiquoteTerm
+
+class DefaultTermSelectTraverserTest extends UnitTestSuite {
+  private val qualifier = q"myObj"
+  private val name = q"myMember"
+
+  private val qualifierTraverser = mock[TermTraverser]
+  private val termNameRenderer = mock[TermNameRenderer]
+
+  private val termSelectTraverser = new DefaultTermSelectTraverserImpl(
+    qualifierTraverser,
+    termNameRenderer
+  )
+
+  test("traverse()") {
+    val termSelect = q"myObj.myMember"
+
+    doWrite("myObj").when(qualifierTraverser).traverse(eqTree(qualifier))
+    doWrite("myMember").when(termNameRenderer).render(eqTree(name))
+
+    termSelectTraverser.traverse(termSelect)
+
+    outputWriter.toString shouldBe "myObj.myMember"
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermRefTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermRefTraverserImplTest.scala
@@ -13,10 +13,10 @@ class ExpressionTermRefTraverserImplTest extends UnitTestSuite {
   private val thisTraverser = mock[ThisTraverser]
   private val superTraverser = mock[SuperTraverser]
   private val termNameTraverser = mock[TermNameTraverser]
-  private val termSelectTraverser = mock[TermSelectTraverser]
+  private val termSelectTraverser = mock[ExpressionTermSelectTraverser]
   private val applyUnaryTraverser = mock[ApplyUnaryTraverser]
 
-  private val termRefTraverser = new ExpressionTermRefTraverserImpl(
+  private val termRefTraverser = new ExpressionTermRefTraverser(
     thisTraverser,
     superTraverser,
     termNameTraverser,

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermSelectTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ExpressionTermSelectTraverserImplTest.scala
@@ -14,7 +14,7 @@ import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Lit, Term, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
 
-class TermSelectTraverserImplTest extends UnitTestSuite {
+class ExpressionTermSelectTraverserImplTest extends UnitTestSuite {
 
   private val MyInstance = Term.Name("MyObject")
   private val MyType = t"MyType"
@@ -33,7 +33,7 @@ class TermSelectTraverserImplTest extends UnitTestSuite {
   private val qualifierTypeInferrer = mock[QualifierTypeInferrer]
   private val termSelectTransformer = mock[InternalTermSelectTransformer]
 
-  private val termSelectTraverser = new TermSelectTraverserImpl(
+  private val termSelectTraverser = new ExpressionTermSelectTraverserImpl(
     qualifierTraverser,
     transformedTermTraverser,
     termNameRenderer,

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunOverridingTermTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunOverridingTermTraverserTest.scala
@@ -7,7 +7,7 @@ import scala.meta.XtensionQuasiquoteTerm
 
 class FunOverridingTermTraverserTest extends UnitTestSuite {
 
-  private val termRefTraverser = mock[ExpressionTermRefTraverser]
+  private val termRefTraverser = mock[TermRefTraverser]
   private val mainApplyTypeTraverser = mock[MainApplyTypeTraverser]
   private val termTraverser = mock[TermTraverser]
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunStandardApplyTypeTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunStandardApplyTypeTraverserTest.scala
@@ -9,15 +9,15 @@ import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 
 import scala.meta.{Term, Type}
 
-class DefaultStandardApplyTypeTraverserTest extends UnitTestSuite {
+class FunStandardApplyTypeTraverserTest extends UnitTestSuite {
 
-  private val termSelectTraverser = mock[TermSelectTraverser]
+  private val funTermSelectTraverser = mock[FunTermSelectTraverser]
   private val typeListTraverser = mock[TypeListTraverser]
   private val unqualifiedTermTraverser = mock[TermTraverser]
   private val termApplyTraverser = mock[TermApplyTraverser]
 
-  private val defaultStandardApplyTypeTraverser = new DefaultStandardApplyTypeTraverser(
-    termSelectTraverser,
+  private val defaultStandardApplyTypeTraverser = new FunStandardApplyTypeTraverser(
+    funTermSelectTraverser,
     typeListTraverser,
     unqualifiedTermTraverser
   )
@@ -27,7 +27,7 @@ class DefaultStandardApplyTypeTraverserTest extends UnitTestSuite {
     val typeArgs = List(Type.Name("T1"), Type.Name("T2"))
 
     doWrite("myObj<T1, T2>.myFunc")
-      .when(termSelectTraverser).traverse(eqTree(fun), eqTermSelectContext(TermSelectContext(typeArgs)))
+      .when(funTermSelectTraverser).traverse(eqTree(fun), eqTermSelectContext(TermSelectContext(typeArgs)))
     defaultStandardApplyTypeTraverser.traverse(Term.ApplyType(fun = fun, targs = typeArgs))
 
     outputWriter.toString shouldBe "myObj<T1, T2>.myFunc"
@@ -46,6 +46,6 @@ class DefaultStandardApplyTypeTraverserTest extends UnitTestSuite {
 
     outputWriter.toString shouldBe "/* this? */.<T1, T2>myFunc"
 
-    verifyNoMoreInteractions(termSelectTraverser, termApplyTraverser)
+    verifyNoMoreInteractions(funTermSelectTraverser, termApplyTraverser)
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunTermRefTraverserTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunTermRefTraverserTest.scala
@@ -1,0 +1,33 @@
+package io.github.effiban.scala2java.core.traversers
+
+import io.github.effiban.scala2java.core.contexts.TermSelectContext
+import io.github.effiban.scala2java.core.matchers.TermSelectContextMatcher.eqTermSelectContext
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+
+import scala.meta.{XtensionQuasiquoteTerm, XtensionQuasiquoteType}
+
+class FunTermRefTraverserTest extends UnitTestSuite {
+
+  private val funTermSelectTraverser = mock[FunTermSelectTraverser]
+  private val defaultTermRefTraverser = mock[TermRefTraverser]
+
+  private val funTermRefTraverser = new FunTermRefTraverser(funTermSelectTraverser, defaultTermRefTraverser)
+
+  test("traverse() for a Term.Select") {
+    val termSelect = q"a.b"
+    val context = TermSelectContext(List(t"T"))
+
+    funTermRefTraverser.traverse(termSelect)
+
+    verify(funTermSelectTraverser).traverse(eqTree(termSelect), eqTermSelectContext(TermSelectContext()))
+  }
+
+  test("traverse() for a Term.Name") {
+    val termName = q"a"
+
+    funTermRefTraverser.traverse(termName)
+
+    verify(defaultTermRefTraverser).traverse(eqTree(termName))
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunTermSelectTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/FunTermSelectTraverserImplTest.scala
@@ -1,0 +1,90 @@
+package io.github.effiban.scala2java.core.traversers
+
+import io.github.effiban.scala2java.core.contexts.TermSelectContext
+import io.github.effiban.scala2java.core.renderers.TermNameRenderer
+import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.core.testtrees.TypeNames
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+
+import scala.meta.{Lit, Term, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
+
+class FunTermSelectTraverserImplTest extends UnitTestSuite {
+
+  private val MyInstance = q"MyObject"
+  private val MyMethod = q"myMethod"
+  private val MyMethod2 = q"myMethod"
+  private val SelectWithTermName = Term.Select(qual = MyInstance, name = MyMethod)
+
+  private val qualifierTraverser = mock[TermTraverser]
+  private val termNameRenderer = mock[TermNameRenderer]
+  private val typeListTraverser = mock[TypeListTraverser]
+
+  private val funTermSelectTraverser = new FunTermSelectTraverserImpl(
+    qualifierTraverser,
+    termNameRenderer,
+    typeListTraverser,
+  )
+
+  test("traverse() when qualifier is a Term.Name, and has type args") {
+    val typeArgs = List(TypeNames.Int)
+    val context = TermSelectContext(appliedTypeArgs = typeArgs)
+
+    doWrite("MyObject").when(qualifierTraverser).traverse(eqTree(MyInstance))
+    doWrite("myMethod").when(termNameRenderer).render(eqTree(MyMethod))
+    doWrite("<Integer>").when(typeListTraverser).traverse(eqTreeList(typeArgs))
+
+    funTermSelectTraverser.traverse(SelectWithTermName, context)
+
+    outputWriter.toString shouldBe "MyObject.<Integer>myMethod"
+  }
+
+  test("traverse() when qualifier is a Term.Name and has no type args") {
+
+    doWrite("MyObject").when(qualifierTraverser).traverse(eqTree(MyInstance))
+    doWrite("myMethod").when(termNameRenderer).render(eqTree(MyMethod))
+    funTermSelectTraverser.traverse(SelectWithTermName)
+
+    outputWriter.toString shouldBe "MyObject.myMethod"
+  }
+
+  test("traverse() when qualifier is a Term.Function should wrap in parentheses") {
+    val termFunction = Term.Function(Nil, Lit.Int(1))
+    val scalaSelect = Term.Select(termFunction, MyMethod)
+
+    doWrite("() -> 1").when(qualifierTraverser).traverse(eqTree(termFunction))
+    doWrite("get").when(termNameRenderer).render(eqTree(MyMethod))
+    funTermSelectTraverser.traverse(scalaSelect)
+
+    outputWriter.toString shouldBe "(() -> 1).get"
+  }
+
+  test("traverse() when qualifier is a Term.Ascribe applied to a Term.Function, should wrap in parentheses") {
+    val termFunction = Term.Function(Nil, Lit.Int(1))
+    val ascribedTermFunction = Term.Ascribe(termFunction, t"Supplier[Int]")
+    val termSelect = Term.Select(ascribedTermFunction, MyMethod)
+
+    doWrite("(Supplier<Integer>)() -> 1").when(qualifierTraverser).traverse(eqTree(ascribedTermFunction))
+    doWrite("get").when(termNameRenderer).render(eqTree(MyMethod))
+
+    funTermSelectTraverser.traverse(termSelect)
+
+    outputWriter.toString shouldBe "((Supplier<Integer>)() -> 1).get"
+  }
+
+  test("traverse() when qualifier is a Term.Apply should break the line") {
+    val arg = List(Term.Name("arg1"))
+
+    val qual = Term.Apply(SelectWithTermName, arg)
+    val select = Term.Select(qual, MyMethod2)
+
+    doWrite("MyObject.myMethod(arg1)").when(qualifierTraverser).traverse(eqTree(qual))
+    doWrite("myMethod2").when(termNameRenderer).render(eqTree(MyMethod2))
+    funTermSelectTraverser.traverse(select)
+
+    outputWriter.toString shouldBe
+      """MyObject.myMethod(arg1)
+        |.myMethod2""".stripMargin
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporterTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporterTraverserImplTest.scala
@@ -8,10 +8,10 @@ import scala.meta.{Importee, Importer, Name, Term}
 
 class ImporterTraverserImplTest extends UnitTestSuite {
 
-  private val termRefTraverser = mock[DefaultTermRefTraverser]
+  private val defaultTermRefTraverser = mock[TermRefTraverser]
   private val importeeTraverser = mock[ImporteeTraverser]
 
-  private val importerTraverser = new ImporterTraverserImpl(termRefTraverser, importeeTraverser)
+  private val importerTraverser = new ImporterTraverserImpl(defaultTermRefTraverser, importeeTraverser)
 
 
   test("traverse when there is one importee") {
@@ -23,7 +23,7 @@ class ImporterTraverserImplTest extends UnitTestSuite {
       importees = List(importee)
     )
 
-    doWrite("mypackage").when(termRefTraverser).traverse(eqTree(termRef))
+    doWrite("mypackage").when(defaultTermRefTraverser).traverse(eqTree(termRef))
     doWrite("myclass").when(importeeTraverser).traverse(eqTree(importee))
 
     importerTraverser.traverse(importer)
@@ -43,7 +43,7 @@ class ImporterTraverserImplTest extends UnitTestSuite {
       importees = List(importee1, importee2)
     )
 
-    doWrite("mypackage").when(termRefTraverser).traverse(eqTree(termRef))
+    doWrite("mypackage").when(defaultTermRefTraverser).traverse(eqTree(termRef))
     doWrite("myclass1").when(importeeTraverser).traverse(eqTree(importee1))
     doWrite("myclass2").when(importeeTraverser).traverse(eqTree(importee2))
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/PkgTraverserImplTest.scala
@@ -40,12 +40,12 @@ class PkgTraverserImplTest extends UnitTestSuite {
     )
   )
 
-  private val termRefTraverser = mock[DefaultTermRefTraverser]
+  private val defaultTermRefTraverser = mock[TermRefTraverser]
   private val pkgStatListTraverser = mock[PkgStatListTraverser]
   private val additionalImportersProvider = mock[AdditionalImportersProvider]
 
   private val pkgTraverser = new PkgTraverserImpl(
-    termRefTraverser,
+    defaultTermRefTraverser,
     pkgStatListTraverser,
     additionalImportersProvider
   )
@@ -57,7 +57,7 @@ class PkgTraverserImplTest extends UnitTestSuite {
     val stats = List(ArbitraryImport, TheClass)
     val expectedEnrichedStats = Import(CoreImporters) +: stats
 
-    doWrite("mypkg.myinnerpkg").when(termRefTraverser).traverse(eqTree(pkgRef))
+    doWrite("mypkg.myinnerpkg").when(defaultTermRefTraverser).traverse(eqTree(pkgRef))
     when(additionalImportersProvider.provide()).thenReturn(CoreImporters)
     doWrite(
       """/*


### PR DESCRIPTION
Splitting according to the different logical contexts, which now have distinct dependencies and logic:
- `DefaultTermSelectTraverser` for handling the stable paths that do not need any transformations (e.g. type qualifiers, imports, packages)
- `FunTermSelectTraverser` for handling function names **after** all transformations 
- `ExpressionTermSelectTraverser` for handling expressions that might require desugaring/transformation

As a consequence, in addition:
- Added `FunTermRefTraverser` and applied to the correct logical contexts
- Renamed a traverser for Term.ApplyType for consistency
