### PR TITLE
In `ImporteeTraverser` use `NameIndeterminateRenderer` instead of `NameTraverser`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/Renderers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/Renderers.scala
@@ -8,7 +8,7 @@ class Renderers(implicit javaWriter: JavaWriter) {
 
   val litRenderer: LitRenderer = new LitRendererImpl()
 
-  private val nameIndeterminateRenderer: NameIndeterminateRenderer = new NameIndeterminateRendererImpl()
+  val nameIndeterminateRenderer: NameIndeterminateRenderer = new NameIndeterminateRendererImpl()
 
   val nameRenderer: NameRenderer = new NameRendererImpl(
     nameIndeterminateRenderer,

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ImporteeTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ImporteeTraverser.scala
@@ -1,12 +1,13 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.renderers.NameIndeterminateRenderer
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
-import scala.meta.Importee
+import scala.meta.{Importee, Name}
 
 trait ImporteeTraverser extends ScalaTreeTraverser[Importee]
 
-private[traversers] class ImporteeTraverserImpl(nameTraverser: => NameTraverser)
+private[traversers] class ImporteeTraverserImpl(nameIndeterminateRenderer: NameIndeterminateRenderer)
                                                (implicit javaWriter: JavaWriter) extends ImporteeTraverser {
 
   import javaWriter._
@@ -14,16 +15,28 @@ private[traversers] class ImporteeTraverserImpl(nameTraverser: => NameTraverser)
   // A single imported element within an Importer (can be one name, wildcard etc. see below)
   override def traverse(importee: Importee): Unit = {
     importee match {
-      case Importee.Name(name) => nameTraverser.traverse(name)
+      case Importee.Name(name: Name.Indeterminate) =>
+        nameIndeterminateRenderer.render(name)
+      case Importee.Name(name) => handleIllegalName(name)
       case Importee.Wildcard() => write("*")
-      case Importee.Rename(name, rename) =>
-        nameTraverser.traverse(name)
+      case Importee.Rename(name: Name.Indeterminate, rename: Name.Indeterminate) =>
+        nameIndeterminateRenderer.render(name)
         write(" ")
         writeComment(s"Renamed in Scala to '${rename.toString}'")
-      case Importee.Unimport(name) =>
-        nameTraverser.traverse(name)
+      case Importee.Rename(name: Name, rename: Name) => handleIllegalNamePair(name, rename)
+      case Importee.Unimport(name: Name.Indeterminate) =>
+        nameIndeterminateRenderer.render(name)
         write(" ")
         writeComment(s"Hidden (unimported) in Scala")
+      case Importee.Unimport(name) => handleIllegalName(name)
     }
   }
+
+  private def handleIllegalName(name: Name) =
+    throw new IllegalStateException(s"Invalid importee name '$name' - must be a Name.Indeterminate")
+
+  private def handleIllegalNamePair(name: Name, rename: Name) =
+    throw new IllegalStateException(
+      s"Invalid importee name+rename pair ('$name', '$rename') - both must be a Name.Indeterminate but at least one isn't"
+    )
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -298,7 +298,7 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
 
   private lazy val ifTraverser: IfTraverser = new IfTraverserImpl(expressionTermTraverser, blockTraverser)
 
-  private lazy val importeeTraverser: ImporteeTraverser = new ImporteeTraverserImpl(nameTraverser)
+  private lazy val importeeTraverser: ImporteeTraverser = new ImporteeTraverserImpl(nameIndeterminateRenderer)
 
   private lazy val importerTraverser: ImporterTraverser = new ImporterTraverserImpl(defaultTermRefTraverser, importeeTraverser)
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporteeTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/ImporteeTraverserImplTest.scala
@@ -1,5 +1,6 @@
 package io.github.effiban.scala2java.core.traversers
 
+import io.github.effiban.scala2java.core.renderers.NameIndeterminateRenderer
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
@@ -8,15 +9,15 @@ import scala.meta.{Importee, Name}
 
 class ImporteeTraverserImplTest extends UnitTestSuite {
 
-  private val nameTraverser = mock[NameTraverser]
+  private val nameIndeterminateRenderer = mock[NameIndeterminateRenderer]
 
-  private val importeeTraverser = new ImporteeTraverserImpl(nameTraverser)
+  private val importeeTraverser = new ImporteeTraverserImpl(nameIndeterminateRenderer)
 
 
   test("traverse name") {
     val name = Name.Indeterminate("myName")
 
-    doWrite("myName").when(nameTraverser).traverse(eqTree(name))
+    doWrite("myName").when(nameIndeterminateRenderer).render(eqTree(name))
 
     importeeTraverser.traverse(Importee.Name(name))
 
@@ -33,8 +34,8 @@ class ImporteeTraverserImplTest extends UnitTestSuite {
     val origName = Name.Indeterminate("origName")
     val newName = Name.Indeterminate("newName")
 
-    doWrite("origName").when(nameTraverser).traverse(eqTree(origName))
-    doWrite("newName").when(nameTraverser).traverse(eqTree(newName))
+    doWrite("origName").when(nameIndeterminateRenderer).render(eqTree(origName))
+    doWrite("newName").when(nameIndeterminateRenderer).render(eqTree(newName))
 
     importeeTraverser.traverse(Importee.Rename(name = origName, rename = newName))
 
@@ -44,7 +45,7 @@ class ImporteeTraverserImplTest extends UnitTestSuite {
   test("traverse unimported") {
     val name = Name.Indeterminate("myName")
 
-    doWrite("myName").when(nameTraverser).traverse(eqTree(name))
+    doWrite("myName").when(nameIndeterminateRenderer).render(eqTree(name))
 
     importeeTraverser.traverse(Importee.Unimport(name))
 


### PR DESCRIPTION
Despite using the supertype `Name`, the only type actually supported for importees is a `Name.Indeterminate` (or a quasi which is completely unsupported by this tool)