### PR TITLE
Temporarily unsupport the annotation part of `Type.Annotate`

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -599,7 +599,7 @@ class ScalaTreeTraversers(implicit javaWriter: JavaWriter, extensionRegistry: Ex
 
   private lazy val tryWithHandlerTraverser: TryWithHandlerTraverser = new TryWithHandlerTraverserImpl(blockTraverser, finallyTraverser)
 
-  private lazy val typeAnnotateTraverser: TypeAnnotateTraverser = new TypeAnnotateTraverserImpl(annotListTraverser, typeTraverser)
+  private lazy val typeAnnotateTraverser: TypeAnnotateTraverser = new TypeAnnotateTraverserImpl(typeTraverser)
 
   private lazy val typeApplyInfixTraverser: TypeApplyInfixTraverser = new TypeApplyInfixTraverserImpl()
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TypeAnnotateTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TypeAnnotateTraverser.scala
@@ -1,21 +1,16 @@
 package io.github.effiban.scala2java.core.traversers
 
-import io.github.effiban.scala2java.core.writers.JavaWriter
-
 import scala.meta.Type
 
 trait TypeAnnotateTraverser extends ScalaTreeTraverser[Type.Annotate]
 
-private[traversers] class TypeAnnotateTraverserImpl(annotListTraverser: => AnnotListTraverser,
-                                                    typeTraverser: => TypeTraverser)
-                                                   (implicit javaWriter: JavaWriter) extends TypeAnnotateTraverser {
-
-  import javaWriter._
+private[traversers] class TypeAnnotateTraverserImpl(typeTraverser: => TypeTraverser) extends TypeAnnotateTraverser {
 
   // type with annotation, e.g.: T @annot
   override def traverse(annotatedType: Type.Annotate): Unit = {
-    annotListTraverser.traverseAnnotations(annotations = annotatedType.annots, onSameLine = true)
-    write(" ")
+    //TODO - restore after renderers have been extracted
+    /**annotListTraverser.traverseAnnotations(annotations = annotatedType.annots, onSameLine = true)
+    write(" ")*/
     typeTraverser.traverse(annotatedType.tpe)
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeAnnotateTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/TypeAnnotateTraverserImplTest.scala
@@ -2,9 +2,7 @@ package io.github.effiban.scala2java.core.traversers
 
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
-import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
-import org.mockito.ArgumentMatchers
 
 import scala.meta.Mod.Annot
 import scala.meta.{Init, Name, Type}
@@ -17,21 +15,18 @@ class TypeAnnotateTraverserImplTest extends UnitTestSuite {
 
   private val TheType = Type.Name("T")
 
-  private val annotListTraverser = mock[AnnotListTraverser]
   private val typeTraverser = mock[TypeTraverser]
 
-  private val typeAnnotateTraverser = new TypeAnnotateTraverserImpl(annotListTraverser, typeTraverser)
+  private val typeAnnotateTraverser = new TypeAnnotateTraverserImpl(typeTraverser)
 
   test("traverse") {
-    val typeAnnotate = Type.Annotate(tpe = TheType, annots = List(Annot1, Annot2))
+    val typeAnnotate = Type.Annotate(tpe = TheType, annots = Annots)
 
-    doWrite("@MyAnnot1 @MyAnnot2")
-      .when(annotListTraverser).traverseAnnotations(annotations = eqTreeList(Annots), onSameLine = ArgumentMatchers.eq(true))
     doWrite("T").when(typeTraverser).traverse(eqTree(TheType))
 
     typeAnnotateTraverser.traverse(typeAnnotate)
 
-    outputWriter.toString shouldBe "@MyAnnot1 @MyAnnot2 T"
+    outputWriter.toString shouldBe "T"
   }
 
 }


### PR DESCRIPTION
This is done to simplify dealing with the complex circular dependencies, while extracting the type renderers.
It will be added back after the term renderers have also been extracted.