### PR TITLE
Revert "Refactor `ArgumentListRenderer` to support a different `ArgumentRenderer` for each index"

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/ArgumentListRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/ArgumentListRenderer.scala
@@ -7,7 +7,7 @@ import scala.meta.Tree
 
 trait ArgumentListRenderer {
   def render[T <: Tree](args: List[T],
-                        argRendererProvider: Int => ArgumentRenderer[T],
+                        argRenderer: => ArgumentRenderer[T],
                         context: ArgumentListContext = ArgumentListContext()): Unit
 }
 
@@ -16,7 +16,7 @@ class ArgumentListRendererImpl(implicit javaWriter: JavaWriter) extends Argument
   import javaWriter._
 
   override def render[T <: Tree](args: List[T],
-                                 argRendererProvider: Int => ArgumentRenderer[T],
+                                 argRenderer: => ArgumentRenderer[T],
                                  context: ArgumentListContext = ArgumentListContext()): Unit = {
     if (args.nonEmpty || context.options.traverseEmpty) {
 
@@ -27,7 +27,7 @@ class ArgumentListRendererImpl(implicit javaWriter: JavaWriter) extends Argument
         val argContext = ArgumentContext(
           argNameAsComment = context.argNameAsComment
         )
-        val argRenderer = argRendererProvider(idx)
+
         argRenderer.render(tree, argContext)
         if (idx < args.size - 1) {
           writeListSeparator()

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/ArrayInitializerRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/ArrayInitializerRenderer.scala
@@ -32,7 +32,7 @@ private[renderers] class ArrayInitializerRendererImpl(typeRenderer: => TypeRende
     val options = ListTraversalOptions(maybeEnclosingDelimiter = Some(CurlyBrace), traverseEmpty = true)
     argumentListRenderer.render(
       args = values,
-      argRendererProvider = _ => argumentRenderer,
+      argRenderer = argumentRenderer,
       context = ArgumentListContext(options = options))
   }
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/InitRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/InitRenderer.scala
@@ -23,7 +23,7 @@ private[renderers] class InitRendererImpl(typeRenderer: => TypeRenderer,
       val argListContext = ArgumentListContext(options = options, argNameAsComment = context.argNameAsComment)
       argumentListRenderer.render(
         args = init.argss.flatten,
-        argRendererProvider = _ => invocationArgRenderer,
+        argRenderer = invocationArgRenderer,
         context = argListContext)
     }
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/PatListRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/PatListRenderer.scala
@@ -15,7 +15,7 @@ private[renderers] class PatListRendererImpl(argumentListRenderer: => ArgumentLi
   override def render(pats: List[Pat]): Unit = {
     argumentListRenderer.render(
       args = pats,
-      argRendererProvider = _ => patArgRenderer,
+      argRenderer = patArgRenderer,
       context = ArgumentListContext(options = ListTraversalOptions(onSameLine = true))
     )
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TermApplyRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TermApplyRenderer.scala
@@ -29,7 +29,7 @@ private[renderers] class TermApplyRendererImpl(expressionTermRenderer: => Expres
     val argListContext = ArgumentListContext(options = options, argNameAsComment = true)
     argumentListRenderer.render(
       args = termApply.args,
-      argRendererProvider = _ => invocationArgRenderer,
+      argRenderer = invocationArgRenderer,
       context = argListContext
     )
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TypeListRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TypeListRenderer.scala
@@ -16,7 +16,7 @@ private[renderers] class TypeListRendererImpl(argumentListRenderer: => ArgumentL
   override def render(types: List[Type]): Unit = {
     argumentListRenderer.render(args = types,
       // TODO - call the renderer with an argument indicating that Java primitives should be boxed
-      argRendererProvider = _ => typeArgRenderer,
+      argRenderer = typeArgRenderer,
       context = ArgumentListContext(options = ListTraversalOptions(maybeEnclosingDelimiter = Some(AngleBracket), onSameLine = true))
     )
   }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/ArgumentListRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/ArgumentListRendererImplTest.scala
@@ -16,44 +16,36 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   private val arg2 = Term.Name("arg2")
   private val arg3 = Term.Name("arg3")
 
-  private val argumentRenderer1 = mock[ArgumentRenderer[Term]]
-  private val argumentRenderer2 = mock[ArgumentRenderer[Term]]
-  private val argumentRenderer3 = mock[ArgumentRenderer[Term]]
-
-  private val argRendererProvider = (idx: Int) => idx match {
-    case 0 => argumentRenderer1
-    case 1 => argumentRenderer2
-    case _ => argumentRenderer3
-  }
+  private val argumentRenderer = mock[ArgumentRenderer[Term]]
 
   private val argumentListRenderer = new ArgumentListRendererImpl()
 
 
   test("render() when one arg, multi-line and no wrapping delimiter") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
 
-    argumentListRenderer.render(args = List(arg1), argRendererProvider = argRendererProvider)
+    argumentListRenderer.render(args = List(arg1), argRenderer = argumentRenderer)
 
     outputWriter.toString shouldBe "arg1"
   }
 
   test("render() when two args, multi-line and no wrapping delimiter") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
-    doWrite("arg2").when(argumentRenderer2).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg2").when(argumentRenderer).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
 
-    argumentListRenderer.render(args = List(arg1, arg2), argRendererProvider = argRendererProvider)
+    argumentListRenderer.render(args = List(arg1, arg2), argRenderer = argumentRenderer)
 
     outputWriter.toString shouldBe "arg1, arg2"
   }
 
   test("render() when three args, multi-line and no wrapping delimiter") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
-    doWrite("arg2").when(argumentRenderer2).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
-    doWrite("arg3").when(argumentRenderer3).render(eqTree(arg3), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg2").when(argumentRenderer).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
+    doWrite("arg3").when(argumentRenderer).render(eqTree(arg3), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1, arg2, arg3),
-      argRendererProvider = argRendererProvider
+      argRenderer = argumentRenderer
     )
 
     outputWriter.toString shouldBe
@@ -63,11 +55,11 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   }
 
   test("render() when one arg, single-line and no wrapping delimiter") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true))
     )
 
@@ -75,12 +67,12 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   }
 
   test("render() when two args, single-line and no wrapping delimiter") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
-    doWrite("arg2").when(argumentRenderer2).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg2").when(argumentRenderer).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1, arg2),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true))
     )
 
@@ -88,13 +80,13 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   }
 
   test("render() when three args, single-line and no wrapping delimiter") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
-    doWrite("arg2").when(argumentRenderer2).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
-    doWrite("arg3").when(argumentRenderer3).render(eqTree(arg3), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg2").when(argumentRenderer).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
+    doWrite("arg3").when(argumentRenderer).render(eqTree(arg3), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1, arg2, arg3),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true))
     )
 
@@ -104,19 +96,19 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   test("render() when no args, traverseEmpty=false, single-line and parentheses") {
     argumentListRenderer.render(
       args = List.empty,
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true, maybeEnclosingDelimiter = Some(Parentheses)))
     )
 
     outputWriter.toString shouldBe ""
 
-    verifyNoMoreInteractions(argumentRenderer1)
+    verifyNoMoreInteractions(argumentRenderer)
   }
 
   test("render() when no args, traverseEmpty=true, single-line and parentheses") {
     argumentListRenderer.render(
       args = List.empty,
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(
         onSameLine = true,
         maybeEnclosingDelimiter = Some(Parentheses),
@@ -126,15 +118,15 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
 
     outputWriter.toString shouldBe "()"
 
-    verifyNoMoreInteractions(argumentRenderer1)
+    verifyNoMoreInteractions(argumentRenderer)
   }
 
   test("render() when one arg, single-line and parentheses") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true, maybeEnclosingDelimiter = Some(Parentheses)))
     )
 
@@ -142,12 +134,12 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   }
 
   test("render() when two args, single-line and parentheses") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
-    doWrite("arg2").when(argumentRenderer2).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg2").when(argumentRenderer).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1, arg2),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true, maybeEnclosingDelimiter = Some(Parentheses)))
     )
 
@@ -155,13 +147,13 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
   }
 
   test("render() when three args, single-line and parentheses") {
-    doWrite("arg1").when(argumentRenderer1).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
-    doWrite("arg2").when(argumentRenderer2).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
-    doWrite("arg3").when(argumentRenderer3).render(eqTree(arg3), eqArgumentContext(ArgumentContext()))
+    doWrite("arg1").when(argumentRenderer).render(eqTree(arg1), eqArgumentContext(ArgumentContext()))
+    doWrite("arg2").when(argumentRenderer).render(eqTree(arg2), eqArgumentContext(ArgumentContext()))
+    doWrite("arg3").when(argumentRenderer).render(eqTree(arg3), eqArgumentContext(ArgumentContext()))
 
     argumentListRenderer.render(
       args = List(arg1, arg2, arg3),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(options = ListTraversalOptions(onSameLine = true, maybeEnclosingDelimiter = Some(Parentheses)))
     )
 
@@ -172,14 +164,14 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
     val methodInvocation = q"myMethod(arg1)"
 
     doWrite("arg1")
-      .when(argumentRenderer1).render(
+      .when(argumentRenderer).render(
       eqTree(arg1),
       eqArgumentContext(ArgumentContext())
     )
 
     argumentListRenderer.render(
       args = List(arg1),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(
         options = ListTraversalOptions(onSameLine = true, maybeEnclosingDelimiter = Some(Parentheses))
       )
@@ -190,14 +182,14 @@ class ArgumentListRendererImplTest extends UnitTestSuite {
 
   test("render() when one arg and argNameAsComment=true") {
     doWrite("arg1")
-      .when(argumentRenderer1).render(
+      .when(argumentRenderer).render(
       eqTree(arg1),
       eqArgumentContext(ArgumentContext(argNameAsComment = true))
     )
 
     argumentListRenderer.render(
       args = List(arg1),
-      argRendererProvider = argRendererProvider,
+      argRenderer = argumentRenderer,
       ArgumentListContext(
         options = ListTraversalOptions(onSameLine = true, maybeEnclosingDelimiter = Some(Parentheses)),
         argNameAsComment = true

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/ArrayInitializerRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/ArrayInitializerRendererImplTest.scala
@@ -9,8 +9,7 @@ import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames.JavaObject
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
-import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.captor.ArgCaptor
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.{Term, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
 
@@ -22,8 +21,6 @@ class ArrayInitializerRendererImplTest extends UnitTestSuite {
   private val expressionTermRenderer = mock[ExpressionTermRenderer]
   private val termArgumentRenderer = mock[ArgumentRenderer[Term]]
   private val argumentListRenderer = mock[ArgumentListRenderer]
-
-  private val argRendererProviderCaptor = ArgCaptor[Int => ArgumentRenderer[Term]]
 
   private val arrayInitializerRenderer = new ArrayInitializerRendererImpl(
     typeRenderer,
@@ -40,21 +37,13 @@ class ArrayInitializerRendererImplTest extends UnitTestSuite {
     doWrite("T").when(typeRenderer).render(eqTree(tpe))
     doWrite("{ val1, val2 }").when(argumentListRenderer).render(
       eqTreeList(values),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(termArgumentRenderer),
       eqArgumentListContext(ExpectedArgListContext)
     )
 
     arrayInitializerRenderer.renderWithValues(context)
 
     outputWriter.toString shouldBe "new T[] { val1, val2 }"
-
-    verify(argumentListRenderer).render(
-      eqTreeList(values),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(ExpectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe termArgumentRenderer
   }
 
   test("renderWithValues() when has type and no values") {
@@ -64,21 +53,13 @@ class ArrayInitializerRendererImplTest extends UnitTestSuite {
     doWrite("T").when(typeRenderer).render(eqTree(tpe))
     doWrite("""{}""").when(argumentListRenderer).render(
       eqTo(Nil),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(termArgumentRenderer),
       eqArgumentListContext(ExpectedArgListContext)
     )
 
     arrayInitializerRenderer.renderWithValues(context)
 
     outputWriter.toString shouldBe "new T[] {}"
-
-    verify(argumentListRenderer).render(
-      eqTo(Nil),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(ExpectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe termArgumentRenderer
   }
 
   test("renderWithValues() when has no type but has values should use the Java type 'Object'") {
@@ -88,42 +69,26 @@ class ArrayInitializerRendererImplTest extends UnitTestSuite {
     doWrite("Object").when(typeRenderer).render(eqTree(JavaObject))
     doWrite("{ val1, val2 }").when(argumentListRenderer).render(
       eqTreeList(values),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(termArgumentRenderer),
       eqArgumentListContext(ExpectedArgListContext)
     )
 
     arrayInitializerRenderer.renderWithValues(context)
 
     outputWriter.toString shouldBe "new Object[] { val1, val2 }"
-
-    verify(argumentListRenderer).render(
-      eqTreeList(values),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(ExpectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe termArgumentRenderer
   }
 
   test("renderWithValues() when has an empty context should use the Java type 'Object'") {
     doWrite("Object").when(typeRenderer).render(eqTree(JavaObject))
     doWrite("""{}""").when(argumentListRenderer).render(
       eqTreeList(Nil),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(termArgumentRenderer),
       eqArgumentListContext(ExpectedArgListContext)
     )
 
     arrayInitializerRenderer.renderWithValues(ArrayInitializerValuesRenderContext())
 
     outputWriter.toString shouldBe "new Object[] {}"
-
-    verify(argumentListRenderer).render(
-      eqTreeList(Nil),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(ExpectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe termArgumentRenderer
   }
 
   test("renderWithSize() when has non-default type and non-default size") {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/InitRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/InitRendererImplTest.scala
@@ -8,8 +8,7 @@ import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
-import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.captor.ArgCaptor
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.{Init, Name, Term, XtensionQuasiquoteType}
 
@@ -22,8 +21,6 @@ class InitRendererImplTest extends UnitTestSuite {
   private val typeRenderer = mock[TypeRenderer]
   private val argumentListRenderer = mock[ArgumentListRenderer]
   private val invocationArgRenderer = mock[ArgumentRenderer[Term]]
-
-  private val argRendererProviderCaptor = ArgCaptor[Int => ArgumentRenderer[Term]]
 
   private val initRenderer = new InitRendererImpl(
     typeRenderer,
@@ -45,11 +42,9 @@ class InitRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       eqTo(Nil),
-      argRendererProviderCaptor.capture,
+      eqTo(invocationArgRenderer),
       eqArgumentListContext(expectedArgListContext)
     )
-
-    argRendererProviderCaptor.value(0) shouldBe invocationArgRenderer
   }
 
   test("render() with no arguments, traverseEmpty = true and the rest default") {
@@ -69,11 +64,9 @@ class InitRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       eqTo(Nil),
-      argRendererProviderCaptor.capture,
+      eqTo(invocationArgRenderer),
       eqArgumentListContext(expectedArgListContext)
     )
-
-    argRendererProviderCaptor.value(0) shouldBe invocationArgRenderer
   }
 
   test("render() for no arguments when ignored") {
@@ -100,7 +93,7 @@ class InitRendererImplTest extends UnitTestSuite {
         |arg2)""".stripMargin)
       .when(argumentListRenderer).render(
       eqTreeList(ArgList1),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(invocationArgRenderer),
       eqArgumentListContext(expectedArgListContext)
     )
 
@@ -109,14 +102,6 @@ class InitRendererImplTest extends UnitTestSuite {
     outputWriter.toString shouldBe
       """MyType(arg1,
         |arg2)""".stripMargin
-
-    verify(argumentListRenderer).render(
-      eqTreeList(ArgList1),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(expectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe invocationArgRenderer
   }
 
   test("render() for one argument list when argNameAsComment=true and the rest default") {
@@ -131,7 +116,7 @@ class InitRendererImplTest extends UnitTestSuite {
         |/*arg2Name = */arg2)""".stripMargin)
       .when(argumentListRenderer).render(
       eqTreeList(ArgList1),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(invocationArgRenderer),
       eqArgumentListContext(expectedArgListContext)
     )
 
@@ -140,14 +125,6 @@ class InitRendererImplTest extends UnitTestSuite {
     outputWriter.toString shouldBe
       """MyType(/*arg1Name = */arg1,
         |/*arg2Name = */arg2)""".stripMargin
-
-    verify(argumentListRenderer).render(
-      eqTreeList(ArgList1),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(expectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe invocationArgRenderer
   }
 
   test("render() for one argument list when ignored") {
@@ -181,7 +158,7 @@ class InitRendererImplTest extends UnitTestSuite {
         |arg4)""".stripMargin)
       .when(argumentListRenderer).render(
       eqTreeList(ArgList1 ++ ArgList2),
-      any[Int => ArgumentRenderer[Term]],
+      eqTo(invocationArgRenderer),
       eqArgumentListContext(expectedArgListContext)
     )
 
@@ -192,13 +169,5 @@ class InitRendererImplTest extends UnitTestSuite {
         |arg2,
         |arg3,
         |arg4)""".stripMargin
-
-    verify(argumentListRenderer).render(
-      eqTreeList(ArgList1 ++ ArgList2),
-      argRendererProviderCaptor.capture,
-      eqArgumentListContext(expectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe invocationArgRenderer
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/PatListRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/PatListRendererImplTest.scala
@@ -6,7 +6,6 @@ import io.github.effiban.scala2java.core.matchers.ArgumentListContextMatcher.eqA
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.captor.ArgCaptor
 
 import scala.meta.{Pat, XtensionQuasiquoteCaseOrPattern}
 
@@ -17,8 +16,6 @@ class PatListRendererImplTest extends UnitTestSuite {
   private val argumentListRenderer = mock[ArgumentListRenderer]
   private val patArgRenderer = mock[ArgumentRenderer[Pat]]
 
-  private val argRendererProviderCaptor = ArgCaptor[Int => ArgumentRenderer[Pat]]
-
   private val patListRenderer = new PatListRendererImpl(argumentListRenderer, patArgRenderer)
 
 
@@ -27,11 +24,9 @@ class PatListRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       args = eqTo(Nil),
-      argRendererProvider = argRendererProviderCaptor.capture,
+      argRenderer = eqTo(patArgRenderer),
       context = eqArgumentListContext(ExpectedArgListContext)
     )
-
-    argRendererProviderCaptor.value(0) shouldBe patArgRenderer
   }
 
   test("render() when one pat") {
@@ -42,11 +37,9 @@ class PatListRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       args = eqTreeList(List(pat)),
-      argRendererProvider = argRendererProviderCaptor.capture,
+      argRenderer = eqTo(patArgRenderer),
       context = eqArgumentListContext(ExpectedArgListContext)
     )
-
-    argRendererProviderCaptor.value(0) shouldBe patArgRenderer
   }
 
   test("render() when two pats") {
@@ -57,10 +50,8 @@ class PatListRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       args = eqTreeList(List(pat1, pat2)),
-      argRendererProvider = argRendererProviderCaptor.capture,
+      argRenderer = eqTo(patArgRenderer),
       context = eqArgumentListContext(ExpectedArgListContext)
     )
-
-    argRendererProviderCaptor.value(0) shouldBe patArgRenderer
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TermApplyRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TermApplyRendererImplTest.scala
@@ -11,8 +11,7 @@ import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.{TermNames, TypeNames}
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
-import org.mockito.ArgumentMatchersSugar.any
-import org.mockito.captor.ArgCaptor
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.{Lit, Term}
 
@@ -22,8 +21,6 @@ class TermApplyRendererImplTest extends UnitTestSuite {
   private val argListRenderer = mock[ArgumentListRenderer]
   private val invocationArgRenderer = mock[InvocationArgRenderer[Term]]
   private val arrayInitializerRenderContextResolver = mock[ArrayInitializerRenderContextResolver]
-
-  private val argRendererProviderCaptor = ArgCaptor[Int => ArgumentRenderer[Term]]
 
   private val termApplyRenderer = new TermApplyRendererImpl(
     expressionTermRenderer,
@@ -49,7 +46,7 @@ class TermApplyRendererImplTest extends UnitTestSuite {
     doWrite("myMethod").when(expressionTermRenderer).render(eqTree(termApply.fun))
     doWrite("(arg1, arg2)").when(argListRenderer).render(
       args = eqTreeList(termApply.args),
-      any[Int => ArgumentRenderer[Term]],
+      argRenderer = eqTo(invocationArgRenderer),
       context = eqArgumentListContext(expectedArgListContext)
     )
 
@@ -57,13 +54,6 @@ class TermApplyRendererImplTest extends UnitTestSuite {
 
     outputWriter.toString shouldBe "myMethod(arg1, arg2)"
 
-    verify(argListRenderer).render(
-      args = eqTreeList(termApply.args),
-      argRendererProviderCaptor.capture,
-      context = eqArgumentListContext(expectedArgListContext)
-    )
-
-    argRendererProviderCaptor.value(0) shouldBe invocationArgRenderer
   }
 
   test("render() an Array initializer") {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TypeListRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TypeListRendererImplTest.scala
@@ -7,7 +7,6 @@ import io.github.effiban.scala2java.core.matchers.ArgumentListContextMatcher.eqA
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
 import org.mockito.ArgumentMatchersSugar.eqTo
-import org.mockito.captor.ArgCaptor
 
 import scala.meta.{Type, XtensionQuasiquoteType}
 
@@ -21,8 +20,6 @@ class TypeListRendererImplTest extends UnitTestSuite {
   private val argumentListRenderer = mock[ArgumentListRenderer]
   private val typeArgRenderer = mock[ArgumentRenderer[Type]]
 
-  private val argRendererProviderCaptor = ArgCaptor[Int => ArgumentRenderer[Type]]
-
   private val typeListRenderer = new TypeListRendererImpl(
     argumentListRenderer,
     typeArgRenderer
@@ -34,11 +31,9 @@ class TypeListRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       args = eqTo(Nil),
-      argRendererProvider = argRendererProviderCaptor.capture,
+      argRenderer = eqTo(typeArgRenderer),
       context = eqArgumentListContext(ArgumentListContext(options = ExpectedTraversalOptions))
     )
-
-    argRendererProviderCaptor.value(0) shouldBe typeArgRenderer
   }
 
   test("traverse() when one type") {
@@ -48,11 +43,9 @@ class TypeListRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       args = eqTreeList(List(tpe)),
-      argRendererProvider = argRendererProviderCaptor.capture,
+      argRenderer = eqTo(typeArgRenderer),
       context = eqArgumentListContext(ArgumentListContext(options = ExpectedTraversalOptions))
     )
-
-    argRendererProviderCaptor.value(0) shouldBe typeArgRenderer
   }
 
   test("traverse() when two types") {
@@ -63,10 +56,9 @@ class TypeListRendererImplTest extends UnitTestSuite {
 
     verify(argumentListRenderer).render(
       args = eqTreeList(List(type1, type2)),
-      argRendererProvider = argRendererProviderCaptor.capture,
+      argRenderer = eqTo(typeArgRenderer),
       context = eqArgumentListContext(ArgumentListContext(options = ExpectedTraversalOptions))
     )
-
-    argRendererProviderCaptor.value(0) shouldBe typeArgRenderer
   }
+
 }


### PR DESCRIPTION
Reverts effiban/scala2java#649