### PR TITLE
Invoke 'for comprehension' desugarers

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/desugarers/syntactic/SourceDesugarer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/desugarers/syntactic/SourceDesugarer.scala
@@ -2,11 +2,14 @@ package io.github.effiban.scala2java.core.desugarers.syntactic
 
 import io.github.effiban.scala2java.core.desugarers.SameTypeDesugarer
 
+import scala.meta.Term.{For, ForYield}
 import scala.meta.{Source, Term}
 
 trait SourceDesugarer extends SameTypeDesugarer[Source]
 
-private[syntactic] class SourceDesugarerImpl(termInterpolateDesugarer: TermInterpolateDesugarer) extends SourceDesugarer {
+private[syntactic] class SourceDesugarerImpl(termInterpolateDesugarer: TermInterpolateDesugarer,
+                                             forDesugarer: ForDesugarer,
+                                             forYieldDesugarer: ForYieldDesugarer) extends SourceDesugarer {
 
   override def desugar(source: Source): Source = desugarInner(source) match {
     case desugaredSource: Source => desugaredSource
@@ -15,8 +18,14 @@ private[syntactic] class SourceDesugarerImpl(termInterpolateDesugarer: TermInter
 
   private def desugarInner(source: Source) = source.transform {
     case termInterpolate: Term.Interpolate => termInterpolateDesugarer.desugar(termInterpolate)
+    case `for`: For => forDesugarer.desugar(`for`)
+    case forYield: ForYield => forYieldDesugarer.desugar(forYield)
     case other => other
   }
 }
 
-object SourceDesugarer extends SourceDesugarerImpl(TermInterpolateDesugarer)
+object SourceDesugarer extends SourceDesugarerImpl(
+  TermInterpolateDesugarer,
+  ForDesugarer,
+  ForYieldDesugarer
+)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformer.scala
@@ -78,6 +78,7 @@ private[transformers] class CoreTermApplyTransformer(termNameClassifier: TermNam
         Some(Term.Select(Term.Name(Map), Term.Name(JavaOfEntries)))
       case (nm: Term.Name, Term.Name(Empty)) if termNameClassifier.isJavaMapLike(nm) =>
         Some(Term.Select(Term.Name(Map), Term.Name(JavaOf)))
+      case (qual, q"foreach") => Some(Term.Select(qual, q"forEach"))
 
       case (termFunction: Term.Function, methodName: Term.Name) =>
         Some(termSelectTermFunctionTransformer.transform(termFunction, methodName))

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/transformers/CoreTermApplyTransformerTest.scala
@@ -427,6 +427,14 @@ class CoreTermApplyTransformerTest extends UnitTestSuite {
     termApplyTransformer.transform(scalaTermApply, context).structure shouldBe expectedJavaTermApply.structure
   }
 
+  test("transform 'elems.foreach(print(_))' should return 'elems.forEach(print(_))'") {
+    val scalaTermApply = q"elems.foreach(print(_))"
+    val expectedJavaTermApply = q"elems.forEach(print(_))"
+
+    termApplyTransformer.transform(scalaTermApply, DummyContext).structure shouldBe expectedJavaTermApply.structure
+  }
+
+
   test("transform 'Dummy.dummy(1)' should return same") {
     val termApply = q"Dummy.dummy(1)"
 


### PR DESCRIPTION
Includes additional code in the traversers phase for transforming Scala `foreach` into Java `forEach`.
This is needed now because we are desugaring at the first phase and only transforming to Java later on.