### PR TITLE
Migrate `DefnDefTraverser` to use the separated block traverser+renderer

### DIFF
--- a/scala2java-core/src/integrationTest/resources/testfiles/Fors/For/OneEnumerator/WithRangeInRHS/Exclusive/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/Fors/For/OneEnumerator/WithRangeInRHS/Exclusive/Sample.java
@@ -10,6 +10,7 @@ import java.util.stream.*;
 public class Sample {
 
     public void foo() {
-        IntStream.range(0, 4).forEach(i -> doSomething(i));
+        IntStream.range(0, 4)
+                .forEach(i -> doSomething(i));
     }
 }

--- a/scala2java-core/src/integrationTest/resources/testfiles/Fors/For/OneEnumerator/WithRangeInRHS/Inclusive/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/Fors/For/OneEnumerator/WithRangeInRHS/Inclusive/Sample.java
@@ -10,6 +10,7 @@ import java.util.stream.*;
 public class Sample {
 
     public void foo() {
-        IntStream.rangeClosed(1, 4).forEach(i -> doSomething(i));
+        IntStream.rangeClosed(1, 4)
+                .forEach(i -> doSomething(i));
     }
 }

--- a/scala2java-core/src/integrationTest/resources/testfiles/Ifs/IfElse/InRHS/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/Ifs/IfElse/InRHS/Sample.java
@@ -10,6 +10,6 @@ import java.util.stream.*;
 public class Sample {
 
     public void foo() {
-        final var parity = (x % 2 == 0) ? "even" : "odd";
+        final String parity = (x % 2 == 0) ? "even" : "odd";
     }
 }

--- a/scala2java-core/src/integrationTest/resources/testfiles/TermApplys/WithBlockArg/WithMultipleStatements/ReturningInt/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/TermApplys/WithBlockArg/WithMultipleStatements/ReturningInt/Sample.java
@@ -13,7 +13,7 @@ public class Sample {
         doSomething(((Supplier<int>)() ->  {
             doFirst();
             doSecond();
-            /* return? */3;
+            3;
             }
             ).get());
     }

--- a/scala2java-core/src/integrationTest/resources/testfiles/TermFunctions/SingleParam/WithBlock/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/TermFunctions/SingleParam/WithBlock/Sample.java
@@ -12,7 +12,7 @@ public class Sample {
     public void foo() {
         x ->  {
             doSomething(x);
-            /* return? */doSomethingElse(x);
+            doSomethingElse(x);
         }
     }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/DefnValOrVarTypeRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/DefnValOrVarTypeRenderer.scala
@@ -20,6 +20,7 @@ private[renderers] class DefnValOrVarTypeRendererImpl(typeRenderer: => TypeRende
                       context: ValOrVarRenderContext = ValOrVarRenderContext()): Unit = {
     maybeDeclType match {
       case Some(declType) => typeRenderer.render(declType)
+      // TODO write 'var' also if type is parameterized (Type.Apply)
       case None if context.inBlock => write("var")
       case _ => handleUnknownType()
     }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -26,6 +26,7 @@ class ScalaTreeTraversers(implicit factories: Factories,
   private lazy val renderers = new Renderers()
 
   import factories._
+  import io.github.effiban.scala2java.core.renderers.contextfactories.RenderContextFactories._
   import renderers._
   import resolvers._
   import transformers._
@@ -289,7 +290,9 @@ class ScalaTreeTraversers(implicit factories: Factories,
     typeTraverser,
     typeRenderer,
     deprecatedTermParamListTraverser,
-    deprecatedBlockTraverser,
+    blockWrappingTermTraverser,
+    blockRenderContextFactory,
+    blockRenderer,
     termTypeInferrer,
     new CompositeDefnDefTransformer()
   )

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermFunctionTraverser.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/TermFunctionTraverser.scala
@@ -25,8 +25,13 @@ private[traversers] class TermFunctionTraverserImpl(termParamTraverser: => TermP
       .map(_.tree)
 
     function.body match {
+      // Block of size 2 or more
+      case block@Block(_ :: _ :: _) => traverseBlockBody(shouldBodyReturnValue, traversedParams, block)
+      // Block of size 1 with a Term - treat as a plain term for nicer style, because Java does support a single-term lambda
+      case Block(List(term: Term)) => traverseSingleTermBody(traversedParams, term)
+      // Block of size 1 with a non-Term - must treat as a Block because a Java lambda body must be a Term
       case block: Block => traverseBlockBody(shouldBodyReturnValue, traversedParams, block)
-      case bodyTerm => traverseSingleTermBody(traversedParams, bodyTerm)
+      case term => traverseSingleTermBody(traversedParams, term)
     }
   }
 
@@ -37,8 +42,8 @@ private[traversers] class TermFunctionTraverserImpl(termParamTraverser: => TermP
     BlockTermFunctionTraversalResult(traversedParams, bodyResult)
   }
 
-  private def traverseSingleTermBody(traversedParams: List[Term.Param], bodyTerm: Term) = {
-    val traversedTerm = defaultTermTraverser.traverse(bodyTerm)
+  private def traverseSingleTermBody(traversedParams: List[Term.Param], term: Term) = {
+    val traversedTerm = defaultTermTraverser.traverse(term)
     SingleTermFunctionTraversalResult(Term.Function(traversedParams, traversedTerm))
   }
 }


### PR DESCRIPTION
This is the first PR which migrates a `Stat` subclass traverser to use the new and separated term traverser/renderer hierarchies 🎉 
It has some additional changes due to minor style changes in the Java output that were introduced by the separation (some were done to improve the style, and some just to simplifiy the code without changing the output in a significant way).