### PR TITLE
Simplify logic of 'uncertain return' hint

### DIFF
--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/IfElse/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/IfElse/Sample.java
@@ -10,6 +10,12 @@ import java.util.stream.*;
 public class Sample {
 
     public /* UnknownType */ foo() {
-        /* return? */doSomething();
+        doSomething();
+        if (x < 3) {
+            /* return? */doSomething2A();
+        }
+        else {
+            /* return? */doSomething2B();
+        }
     }
 }

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/IfElse/Sample.scala
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/IfElse/Sample.scala
@@ -1,0 +1,12 @@
+package dummy
+
+class Sample {
+  def foo = {
+    doSomething()
+    if (x < 3) {
+      doSomething2A()
+    } else {
+      doSomething2B()
+    }
+  }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermApply/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermApply/Sample.java
@@ -1,0 +1,16 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+public class Sample {
+
+    public /* UnknownType */ foo() {
+        doSomething1();
+        /* return? */doSomething2();
+    }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermApply/Sample.scala
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermApply/Sample.scala
@@ -2,6 +2,7 @@ package dummy
 
 class Sample {
   def foo = {
-    doSomething()
+    doSomething1()
+    doSomething2()
   }
 }

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermName/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermName/Sample.java
@@ -1,0 +1,16 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+public class Sample {
+
+    public /* UnknownType */ foo() {
+        doSomething();
+        /* return? */x;
+    }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermName/Sample.scala
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermName/Sample.scala
@@ -1,0 +1,8 @@
+package dummy
+
+class Sample {
+  def foo = {
+    doSomething()
+    x
+  }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermSelect/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermSelect/Sample.java
@@ -1,0 +1,16 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+public class Sample {
+
+    public /* UnknownType */ foo() {
+        doSomething();
+        /* return? */x.y;
+    }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermSelect/Sample.scala
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/TermSelect/Sample.scala
@@ -1,0 +1,8 @@
+package dummy
+
+class Sample {
+  def foo = {
+    doSomething()
+    x.y
+  }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/Throw/Sample.java
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/Throw/Sample.java
@@ -1,0 +1,16 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+public class Sample {
+
+    public foo() {
+        doSomething();
+        throw new IllegalStateException();
+    }
+}

--- a/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/Throw/Sample.scala
+++ b/scala2java-core/src/integrationTest/resources/testfiles/DefnDefs/WithoutDeclaredType/NonInferrable/WithLastStatementType/Throw/Sample.scala
@@ -1,0 +1,8 @@
+package dummy
+
+class Sample {
+  def foo = {
+    doSomething()
+    throw new IllegalStateException()
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/classifiers/TermTreeClassifier.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/classifiers/TermTreeClassifier.scala
@@ -1,0 +1,36 @@
+package io.github.effiban.scala2java.core.classifiers
+
+import scala.meta.Term.{ApplyType, Ascribe, Eta, ForYield, New, NewAnonymous}
+import scala.meta.{Lit, Term}
+
+trait TermTreeClassifier {
+
+  def isReturnable(term: Term): Boolean
+}
+
+object TermTreeClassifier extends TermTreeClassifier {
+
+  override def isReturnable(term: Term): Boolean = {
+    term match {
+      case _: Term.Apply |
+           _: Term.ApplyInfix |
+           _: ApplyType |
+           _: Ascribe |
+           _: ForYield |
+           _: Term.Function |
+           _: Term.PartialFunction |
+           _: Term.AnonymousFunction |
+           _: Term.Interpolate |
+           _: Lit |
+           _: Term.Name |
+           _: New |
+           _: NewAnonymous |
+           _: Term.Repeated |
+           _: Term.Select |
+           _: Term.Match |
+           _: Term.Tuple |
+           _: Eta => true
+      case _ => false
+    }
+  }
+}

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/BlockRenderContext2.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/BlockRenderContext2.scala
@@ -1,0 +1,3 @@
+package io.github.effiban.scala2java.core.contexts
+
+case class BlockRenderContext2(uncertainReturn: Boolean = false)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/BlockStatRenderContext2.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/BlockStatRenderContext2.scala
@@ -1,0 +1,4 @@
+package io.github.effiban.scala2java.core.contexts
+
+// TODO - when expecting a return value which is a lambda, need another flag for returnability inside the lambda body
+case class BlockStatRenderContext2(uncertainReturn: Boolean = false)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/DefnDefContext.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/DefnDefContext.scala
@@ -3,7 +3,4 @@ package io.github.effiban.scala2java.core.contexts
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
 
-import scala.meta.Init
-
-case class DefnDefContext(override val javaScope: JavaScope = JavaScope.Unknown,
-                          maybeInit: Option[Init] = None) extends JavaScopeAware
+case class DefnDefContext(override val javaScope: JavaScope = JavaScope.Unknown) extends JavaScopeAware

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/IfRenderContext2.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/IfRenderContext2.scala
@@ -1,0 +1,3 @@
+package io.github.effiban.scala2java.core.contexts
+
+case class IfRenderContext2(uncertainReturn: Boolean = false)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/TermFunctionRenderContext2.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/TermFunctionRenderContext2.scala
@@ -1,0 +1,3 @@
+package io.github.effiban.scala2java.core.contexts
+
+case class TermFunctionRenderContext2(uncertainReturn: Boolean = false)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/TryRenderContext2.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/contexts/TryRenderContext2.scala
@@ -1,0 +1,3 @@
+package io.github.effiban.scala2java.core.contexts
+
+case class TryRenderContext2(uncertainReturn: Boolean = false)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/BlockRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/BlockRenderer.scala
@@ -1,6 +1,6 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, BlockStatRenderContext}
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, BlockStatRenderContext2}
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.Stat
@@ -8,7 +8,7 @@ import scala.meta.Term.Block
 
 trait BlockRenderer {
 
-  def render(block: Block, context: BlockRenderContext = BlockRenderContext()): Unit
+  def render(block: Block, context: BlockRenderContext2 = BlockRenderContext2()): Unit
 }
 
 private[renderers] class BlockRendererImpl(blockStatRenderer: => BlockStatRenderer)
@@ -16,16 +16,16 @@ private[renderers] class BlockRendererImpl(blockStatRenderer: => BlockStatRender
 
   import javaWriter._
 
-  override def render(block: Block, context: BlockRenderContext = BlockRenderContext()): Unit = {
+  override def render(block: Block, context: BlockRenderContext2 = BlockRenderContext2()): Unit = {
     writeBlockStart()
-    renderContents(block.stats, context.lastStatContext)
+    renderContents(block.stats, context)
     writeBlockEnd()
   }
 
-  private def renderContents(stats: List[Stat], lastStatContext: BlockStatRenderContext): Unit = {
+  private def renderContents(stats: List[Stat], context: BlockRenderContext2): Unit = {
     if (stats.nonEmpty) {
       stats.slice(0, stats.length - 1).foreach(blockStatRenderer.render)
-      blockStatRenderer.renderLast(stats.last, lastStatContext)
+      blockStatRenderer.renderLast(stats.last, BlockStatRenderContext2(context.uncertainReturn))
     }
   }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/CatchHandlerRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/CatchHandlerRenderer.scala
@@ -1,6 +1,6 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.BlockRenderContext
+import io.github.effiban.scala2java.core.contexts.BlockRenderContext2
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.Term.Block
@@ -8,7 +8,7 @@ import scala.meta.{Case, Term}
 
 trait CatchHandlerRenderer {
   def render(catchCase: Case,
-             context: BlockRenderContext = BlockRenderContext()): Unit
+             context: BlockRenderContext2 = BlockRenderContext2()): Unit
 }
 
 private[renderers] class CatchHandlerRendererImpl(catchArgumentRenderer: => CatchArgumentRenderer,
@@ -18,13 +18,13 @@ private[renderers] class CatchHandlerRendererImpl(catchArgumentRenderer: => Catc
   import javaWriter._
 
   override def render(catchCase: Case,
-                      context: BlockRenderContext = BlockRenderContext()): Unit = {
+                      context: BlockRenderContext2 = BlockRenderContext2()): Unit = {
     write("catch ")
     catchArgumentRenderer.render(catchCase.pat)
     renderBody(catchCase.body, context)
   }
 
-  private def renderBody(body: Term, context: BlockRenderContext): Unit = {
+  private def renderBody(body: Term, context: BlockRenderContext2): Unit = {
     val block = body match {
       case aBlock: Block => aBlock
       case _ => throw new IllegalStateException("The body of a catch clause must be converted to a Block before this point")

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/IfRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/IfRenderer.scala
@@ -1,13 +1,13 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, IfRenderContext}
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, IfRenderContext2}
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.Term.{Block, If}
 import scala.meta.{Lit, Term}
 
 trait IfRenderer {
-  def render(`if`: If, context: IfRenderContext = IfRenderContext()): Unit
+  def render(`if`: If, context: IfRenderContext2 = IfRenderContext2()): Unit
 
   def renderAsTertiaryOp(`if`: If): Unit
 }
@@ -19,17 +19,17 @@ private[renderers] class IfRendererImpl(expressionTermRenderer: => ExpressionTer
 
   import javaWriter._
 
-  override def render(`if`: If, context: IfRenderContext = IfRenderContext()): Unit = {
+  override def render(`if`: If, context: IfRenderContext2 = IfRenderContext2()): Unit = {
     //TODO handle mods (what do they represent in an 'if'?...)
     write("if (")
     expressionTermRenderer.render(`if`.cond)
     write(")")
-    renderNonExpressionClause(`if`.thenp, context.thenContext)
+    renderNonExpressionClause(`if`.thenp, BlockRenderContext2(context.uncertainReturn))
     `if`.elsep match {
       case Lit.Unit() =>
       case elsep =>
         write("else")
-        renderNonExpressionClause(elsep, context.elseContext)
+        renderNonExpressionClause(elsep, BlockRenderContext2(context.uncertainReturn))
     }
   }
 
@@ -45,9 +45,9 @@ private[renderers] class IfRendererImpl(expressionTermRenderer: => ExpressionTer
     }
   }
 
-  private def renderNonExpressionClause(clause: Term, clauseContext: BlockRenderContext): Unit = {
+  private def renderNonExpressionClause(clause: Term, context: BlockRenderContext2): Unit = {
     clause match {
-      case block: Block => blockRenderer.render(block, clauseContext)
+      case block: Block => blockRenderer.render(block, context)
       case term =>
         write(" ")
         defaultTermRenderer.render(term)

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/Renderers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/Renderers.scala
@@ -1,6 +1,6 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.classifiers.JavaStatClassifier
+import io.github.effiban.scala2java.core.classifiers.{JavaStatClassifier, TermTreeClassifier}
 import io.github.effiban.scala2java.core.orderings.JavaModifierOrdering
 import io.github.effiban.scala2java.core.resolvers.ArrayInitializerRenderContextResolver
 import io.github.effiban.scala2java.core.writers.JavaWriter
@@ -53,6 +53,7 @@ class Renderers(implicit javaWriter: JavaWriter) {
     defnValRenderer,
     defnVarRenderer,
     declVarRenderer,
+    TermTreeClassifier,
     JavaStatClassifier
   )
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TermFunctionRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TermFunctionRenderer.scala
@@ -1,13 +1,13 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{TermFunctionRenderContext, TermParamListRenderContext}
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, TermFunctionRenderContext2, TermParamListRenderContext}
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.Term
 import scala.meta.Term.Block
 
 trait TermFunctionRenderer {
-  def render(function: Term.Function, context: TermFunctionRenderContext = TermFunctionRenderContext()): Unit
+  def render(function: Term.Function, context: TermFunctionRenderContext2 = TermFunctionRenderContext2()): Unit
 }
 
 private[renderers] class TermFunctionRendererImpl(termParamRenderer: => TermParamRenderer,
@@ -19,7 +19,7 @@ private[renderers] class TermFunctionRendererImpl(termParamRenderer: => TermPara
   import javaWriter._
 
   // lambda definition
-  override def render(function: Term.Function, context: TermFunctionRenderContext = TermFunctionRenderContext()): Unit = {
+  override def render(function: Term.Function, context: TermFunctionRenderContext2 = TermFunctionRenderContext2()): Unit = {
     function.params match {
       case param :: Nil if param.decltpe.isEmpty => termParamRenderer.render(param)
       case _ =>
@@ -30,7 +30,7 @@ private[renderers] class TermFunctionRendererImpl(termParamRenderer: => TermPara
     }
     writeArrow()
     function.body match {
-      case block: Block => blockRenderer.render(block = block, context = context.bodyContext)
+      case block: Block => blockRenderer.render(block = block, context = BlockRenderContext2(context.uncertainReturn))
       case term => defaultTermRenderer.render(term)
     }
   }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TryRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TryRenderer.scala
@@ -1,13 +1,13 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, TryRenderContext}
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, TryRenderContext2}
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.Term
 import scala.meta.Term.Block
 
 trait TryRenderer {
-  def render(`try`: Term.Try, context: TryRenderContext = TryRenderContext()): Unit
+  def render(`try`: Term.Try, context: TryRenderContext2 = TryRenderContext2()): Unit
 }
 
 private[renderers] class TryRendererImpl(blockRenderer: => BlockRenderer,
@@ -17,33 +17,23 @@ private[renderers] class TryRendererImpl(blockRenderer: => BlockRenderer,
 
   import javaWriter._
 
-  override def render(`try`: Term.Try, context: TryRenderContext = TryRenderContext()): Unit = {
-    validateContext(`try`, context)
+  override def render(`try`: Term.Try, context: TryRenderContext2 = TryRenderContext2()): Unit = {
     write("try")
-    renderBody(`try`.expr, context.exprContext)
-    `try`.catchp.zipWithIndex.foreach { case (catchCase, idx) =>
+    renderBody(`try`.expr, BlockRenderContext2(context.uncertainReturn))
+    `try`.catchp.foreach { catchCase =>
       catchHandlerRenderer.render(
         catchCase = catchCase,
-        context = context.catchContexts(idx)
+        context = BlockRenderContext2(context.uncertainReturn)
       )
     }
     `try`.finallyp.foreach(finallyRenderer.render)
   }
 
-  private def validateContext(`try`: Term.Try, context: TryRenderContext): Unit = {
-    if (`try`.catchp.length != context.catchContexts.length) {
-      throw new IllegalStateException(s"The input 'Try' has ${`try`.catchp.length} 'catch' clauses," +
-        s"while the input context has ${context.catchContexts.length} catch contexts")
-    }
-  }
-
-
-  private def renderBody(tryExpr: Term, context: BlockRenderContext): Unit = {
+  private def renderBody(tryExpr: Term, context: BlockRenderContext2): Unit = {
     val tryBlock = tryExpr match {
       case aBlock: Block => aBlock
       case _ => throw new IllegalStateException("A try expression must be converted to a Block before this point")
     }
     blockRenderer.render(tryBlock, context)
   }
-
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TryWithHandlerRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TryWithHandlerRenderer.scala
@@ -1,13 +1,13 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, TryRenderContext}
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, TryRenderContext2}
 import io.github.effiban.scala2java.core.writers.JavaWriter
 
 import scala.meta.Term
 import scala.meta.Term.{Block, TryWithHandler}
 
 trait TryWithHandlerRenderer {
-  def render(tryWithHandler: TryWithHandler, context: TryRenderContext = TryRenderContext()): Unit
+  def render(tryWithHandler: TryWithHandler, context: TryRenderContext2 = TryRenderContext2()): Unit
 }
 
 private[renderers] class TryWithHandlerRendererImpl(blockRenderer: => BlockRenderer,
@@ -16,9 +16,9 @@ private[renderers] class TryWithHandlerRendererImpl(blockRenderer: => BlockRende
 
   import javaWriter._
 
-  override def render(tryWithHandler: TryWithHandler, context: TryRenderContext = TryRenderContext()): Unit = {
+  override def render(tryWithHandler: TryWithHandler, context: TryRenderContext2 = TryRenderContext2()): Unit = {
     write("try")
-    renderBody(tryWithHandler.expr, context.exprContext)
+    renderBody(tryWithHandler.expr, BlockRenderContext2(context.uncertainReturn))
     // The catch handler is some term which evaluates to a partial function, which we cannot handle (without semantic information)
     writeComment(s"UNPARSEABLE catch handler: ${tryWithHandler.catchp}")
     writeLine()
@@ -26,7 +26,7 @@ private[renderers] class TryWithHandlerRendererImpl(blockRenderer: => BlockRende
     tryWithHandler.finallyp.foreach(finallyRenderer.render)
   }
 
-  private def renderBody(tryExpr: Term, context: BlockRenderContext): Unit = {
+  private def renderBody(tryExpr: Term, context: BlockRenderContext2): Unit = {
     val tryBlock = tryExpr match {
       case aBlock: Block => aBlock
       case _ => throw new IllegalStateException("A try expression must be converted to a Block before this point")

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/traversers/ScalaTreeTraversers.scala
@@ -24,7 +24,6 @@ class ScalaTreeTraversers(implicit factories: Factories,
   private lazy val renderers = new Renderers()
 
   import factories._
-  import io.github.effiban.scala2java.core.renderers.contextfactories.RenderContextFactories._
   import renderers._
   import resolvers._
   import transformers._
@@ -211,7 +210,6 @@ class ScalaTreeTraversers(implicit factories: Factories,
     termParamTraverser,
     termParamListRenderer,
     blockWrappingTermTraverser,
-    blockRenderContextFactory,
     blockRenderer,
     termTypeInferrer,
     new CompositeDefnDefTransformer()

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/classifiers/TermTreeClassifierTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/classifiers/TermTreeClassifierTest.scala
@@ -1,0 +1,40 @@
+package io.github.effiban.scala2java.core.classifiers
+
+import io.github.effiban.scala2java.core.classifiers.TermTreeClassifier.isReturnable
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+
+import scala.meta.Term.AnonymousFunction
+import scala.meta.{Term, XtensionQuasiquoteTerm}
+
+class TermTreeClassifierTest extends UnitTestSuite {
+
+  private val Scenarios = Table(
+    ("Term", "ExpectedReturnable"),
+    (q"foo(1)", true),
+    (q"a + b", true),
+    (q"foo[Int]", true),
+    (q"x: Int", true),
+    (q"for (x <- xs) yield (x)", true),
+    (q"x => foo(x)", true),
+    (q"{case x: X => x }", true),
+    (AnonymousFunction(q"foo"), true),
+    (Term.Interpolate(q"s", List(q""""before-"""", q""""-after""""), List(q"myVal")), true),
+    (q"3", true),
+    (q"x", true),
+    (q"new MyClass()", true),
+    (q"new { foo() }", true),
+    (q"x: _*", true),
+    (q"a.b", true),
+    (q"""x match { case 1 => "one" }""", true),
+    (q"(x, 1)", true),
+    (q"foo _", true),
+    (q"throw new MyException()", false),
+    (q"while (x < 3) do foo(x)", false)
+  )
+
+  forAll(Scenarios) { (term: Term, expectedReturnable: Boolean) =>
+    test(s"isReturnable() for '$term' should return $expectedReturnable") {
+      isReturnable(term) shouldBe expectedReturnable
+    }
+  }
+}

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/DefnDefContextMatcher.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/matchers/DefnDefContextMatcher.scala
@@ -1,20 +1,13 @@
 package io.github.effiban.scala2java.core.matchers
 
 import io.github.effiban.scala2java.core.contexts.DefnDefContext
-import io.github.effiban.scala2java.test.utils.matchers.{OptionMatcher, TreeMatcher}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.argThat
-
-import scala.meta.Init
 
 class DefnDefContextMatcher(expectedContext: DefnDefContext) extends ArgumentMatcher[DefnDefContext] {
 
   override def matches(actualContext: DefnDefContext): Boolean = {
-    actualContext.javaScope == expectedContext.javaScope && maybeInitMatches(actualContext)
-  }
-
-  private def maybeInitMatches(actualContext: DefnDefContext) = {
-    new OptionMatcher[Init](expectedContext.maybeInit, new TreeMatcher[Init](_)).matches(actualContext.maybeInit)
+    actualContext.javaScope == expectedContext.javaScope
   }
 
   override def toString: String = s"Matcher for: $expectedContext"

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/BlockRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/BlockRendererImplTest.scala
@@ -1,6 +1,6 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, IfRenderContext, SimpleBlockStatRenderContext}
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, BlockStatRenderContext2}
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
@@ -34,7 +34,7 @@ class BlockRendererImplTest extends UnitTestSuite {
     doWrite(
       s"""  foo();
          |""".stripMargin)
-      .when(blockStatRenderer).renderLast(eqTree(q"foo()"), eqTo(SimpleBlockStatRenderContext()))
+      .when(blockStatRenderer).renderLast(eqTree(q"foo()"), eqTo(BlockStatRenderContext2()))
 
     blockRenderer.render(block = block)
 
@@ -52,14 +52,14 @@ class BlockRendererImplTest extends UnitTestSuite {
         foo()
       }
       """
-    val lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true)
+    val lastStatContext = BlockStatRenderContext2(uncertainReturn = true)
 
     doWrite(
       s"""  /* return? */foo();
          |""".stripMargin)
       .when(blockStatRenderer).renderLast(eqTree(q"foo()"), eqTo(lastStatContext))
 
-    blockRenderer.render(block = block, context = BlockRenderContext(lastStatContext = lastStatContext))
+    blockRenderer.render(block = block, context = BlockRenderContext2(uncertainReturn = true))
 
     outputWriter.toString shouldBe
       s""" {
@@ -81,9 +81,9 @@ class BlockRendererImplTest extends UnitTestSuite {
     doWrite(
       s"""  func2();
          |""".stripMargin
-    ).when(blockStatRenderer).renderLast(eqTree(q"func2()"), eqTo(SimpleBlockStatRenderContext()))
+    ).when(blockStatRenderer).renderLast(eqTree(q"func2()"), eqTo(BlockStatRenderContext2()))
 
-    blockRenderer.render(block = block, context = BlockRenderContext())
+    blockRenderer.render(block = block, context = BlockRenderContext2())
 
     outputWriter.toString shouldBe
       s""" {
@@ -100,7 +100,7 @@ class BlockRendererImplTest extends UnitTestSuite {
       func2()
       """
 
-    val lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true)
+    val lastStatContext = BlockStatRenderContext2(uncertainReturn = true)
 
     doWrite(
       s"""  func1();
@@ -111,7 +111,7 @@ class BlockRendererImplTest extends UnitTestSuite {
          |""".stripMargin
     ).when(blockStatRenderer).renderLast(eqTree(q"func2()"), eqTo(lastStatContext))
 
-    blockRenderer.render(block = block, context = BlockRenderContext(lastStatContext = lastStatContext))
+    blockRenderer.render(block = block, context = BlockRenderContext2(uncertainReturn = true))
 
     outputWriter.toString shouldBe
       s""" {
@@ -128,8 +128,7 @@ class BlockRendererImplTest extends UnitTestSuite {
       if (x < 3) small() else large()
       """
 
-    val clauseContext = BlockRenderContext(lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true))
-    val lastStatContext = IfRenderContext(thenContext = clauseContext, elseContext = clauseContext)
+    val lastStatContext = BlockStatRenderContext2(uncertainReturn = true)
 
     doWrite(
       s"""  func1();
@@ -144,7 +143,7 @@ class BlockRendererImplTest extends UnitTestSuite {
          |""".stripMargin
     ).when(blockStatRenderer).renderLast(eqTree(q"if (x < 3) small() else large()"), eqTo(lastStatContext))
 
-    blockRenderer.render(block = block, context = BlockRenderContext(lastStatContext = lastStatContext))
+    blockRenderer.render(block = block, context = BlockRenderContext2(uncertainReturn = true))
 
     outputWriter.toString shouldBe
       s""" {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/CatchHandlerRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/CatchHandlerRendererImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, SimpleBlockStatRenderContext}
-import io.github.effiban.scala2java.core.matchers.BlockRenderContextMockitoMatcher.eqBlockRenderContext
+import io.github.effiban.scala2java.core.contexts.BlockRenderContext2
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.{Case, XtensionQuasiquoteCaseOrPattern, XtensionQuasiquoteTerm}
 
@@ -46,7 +46,7 @@ class CatchHandlerRendererImplTest extends UnitTestSuite {
         |""".stripMargin)
       .when(blockRenderer).render(
       block = eqTree(BlockOfCertainReturnStatement),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     catchHandlerRenderer.render(CatchCase)
@@ -61,7 +61,7 @@ class CatchHandlerRendererImplTest extends UnitTestSuite {
   test("traverse() when body has uncertainReturn=true") {
     val CatchCase = Case(pat = CatchArg, cond = None, body = BlockOfUncertainReturnStatement)
 
-    val context = BlockRenderContext(lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true))
+    val context = BlockRenderContext2(uncertainReturn = true)
 
     doWrite(RenderedCatchArg).when(catchArgumentRenderer).render(eqTree(CatchArg))
 
@@ -72,7 +72,7 @@ class CatchHandlerRendererImplTest extends UnitTestSuite {
         |""".stripMargin)
       .when(blockRenderer).render(
       block = eqTree(BlockOfUncertainReturnStatement),
-      context = eqBlockRenderContext(context)
+      context = eqTo(context)
     )
 
     catchHandlerRenderer.render(CatchCase, context)

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/DefaultTermRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/DefaultTermRendererImplTest.scala
@@ -1,7 +1,6 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, IfRenderContext, TermFunctionRenderContext, TryRenderContext}
-import io.github.effiban.scala2java.core.matchers.BlockRenderContextMockitoMatcher.eqBlockRenderContext
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, IfRenderContext2, TermFunctionRenderContext2, TryRenderContext2}
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
 import org.mockito.ArgumentMatchersSugar.eqTo
@@ -132,7 +131,7 @@ class DefaultTermRendererImplTest extends UnitTestSuite {
 
     defaultTermRenderer.render(block)
 
-    verify(blockRenderer).render(eqTree(block), eqBlockRenderContext(BlockRenderContext()))
+    verify(blockRenderer).render(eqTree(block), eqTo(BlockRenderContext2()))
   }
 
   test("render If") {
@@ -147,7 +146,7 @@ class DefaultTermRendererImplTest extends UnitTestSuite {
 
     defaultTermRenderer.render(termIf)
 
-    verify(ifRenderer).render(eqTree(termIf), eqTo(IfRenderContext()))
+    verify(ifRenderer).render(eqTree(termIf), eqTo(IfRenderContext2()))
   }
 
   test("render Match") {
@@ -177,7 +176,7 @@ class DefaultTermRendererImplTest extends UnitTestSuite {
 
     defaultTermRenderer.render(termTry)
 
-    verify(tryRenderer).render(eqTree(termTry), eqTo(TryRenderContext()))
+    verify(tryRenderer).render(eqTree(termTry), eqTo(TryRenderContext2()))
   }
 
   test("render TryWithHandler") {
@@ -190,7 +189,7 @@ class DefaultTermRendererImplTest extends UnitTestSuite {
 
     defaultTermRenderer.render(tryWithHandler)
 
-    verify(tryWithHandlerRenderer).render(eqTree(tryWithHandler), eqTo(TryRenderContext()))
+    verify(tryWithHandlerRenderer).render(eqTree(tryWithHandler), eqTo(TryRenderContext2()))
   }
 
   test("render Term.Function") {
@@ -198,7 +197,7 @@ class DefaultTermRendererImplTest extends UnitTestSuite {
 
     defaultTermRenderer.render(termFunction)
 
-    verify(termFunctionRenderer).render(eqTree(termFunction), eqTo(TermFunctionRenderContext()))
+    verify(termFunctionRenderer).render(eqTree(termFunction), eqTo(TermFunctionRenderContext2()))
   }
 
   test("render While") {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/FinallyRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/FinallyRendererImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.BlockRenderContext
-import io.github.effiban.scala2java.core.matchers.BlockRenderContextMockitoMatcher.eqBlockRenderContext
+import io.github.effiban.scala2java.core.contexts.BlockRenderContext2
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.XtensionQuasiquoteTerm
 
@@ -29,7 +29,7 @@ class FinallyRendererImplTest extends UnitTestSuite {
         |""".stripMargin)
       .when(blockRenderer).render(
       block = eqTree(FinallyBlock),
-      context = eqBlockRenderContext(BlockRenderContext()))
+      context = eqTo(BlockRenderContext2()))
 
     finallyRenderer.render(FinallyBlock)
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TermFunctionRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TermFunctionRendererImplTest.scala
@@ -1,7 +1,6 @@
 package io.github.effiban.scala2java.core.renderers
 
 import io.github.effiban.scala2java.core.contexts._
-import io.github.effiban.scala2java.core.matchers.BlockRenderContextMockitoMatcher.eqBlockRenderContext
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
@@ -87,7 +86,7 @@ class TermFunctionRendererImplTest extends UnitTestSuite {
         |  /* BODY */
         |}""".stripMargin
     ).when(blockRenderer).render(
-      block = eqTree(functionBody), context = eqBlockRenderContext(BlockRenderContext())
+      block = eqTree(functionBody), context = eqTo(BlockRenderContext2())
     )
 
     termFunctionRenderer.render(function)
@@ -108,7 +107,7 @@ class TermFunctionRendererImplTest extends UnitTestSuite {
     )
     val function = Term.Function(params = List(param), body = functionBody)
 
-    val bodyContext = BlockRenderContext(lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true))
+    val bodyContext = BlockRenderContext2(uncertainReturn = true)
 
     doWrite("val1")
       .when(termParamRenderer).render(termParam = eqTree(param), context = eqTo(TermParamRenderContext()))
@@ -118,10 +117,10 @@ class TermFunctionRendererImplTest extends UnitTestSuite {
         |  /* return? */ last;
         |}""".stripMargin
     ).when(blockRenderer).render(
-      block = eqTree(functionBody), context = eqBlockRenderContext(bodyContext)
+      block = eqTree(functionBody), context = eqTo(bodyContext)
     )
 
-    termFunctionRenderer.render(function, context = TermFunctionRenderContext(bodyContext))
+    termFunctionRenderer.render(function, context = TermFunctionRenderContext2(uncertainReturn = true))
 
     outputWriter.toString shouldBe
       """val1 ->  {
@@ -129,7 +128,7 @@ class TermFunctionRendererImplTest extends UnitTestSuite {
         |  /* return? */ last;
         |}""".stripMargin
   }
-  
+
   test("render with two args and one term") {
     val params = List(termParam("val1"), termParam("val2"))
     val functionBody = Term.Apply(Term.Name("doSomething"), List(Term.Name("val1"), Term.Name("val2")))

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TryWithHandlerRendererImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/renderers/TryWithHandlerRendererImplTest.scala
@@ -1,10 +1,10 @@
 package io.github.effiban.scala2java.core.renderers
 
-import io.github.effiban.scala2java.core.contexts.{BlockRenderContext, SimpleBlockStatRenderContext, TryRenderContext}
-import io.github.effiban.scala2java.core.matchers.BlockRenderContextMockitoMatcher.eqBlockRenderContext
+import io.github.effiban.scala2java.core.contexts.{BlockRenderContext2, TryRenderContext2}
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.{Term, XtensionQuasiquoteTerm}
 
@@ -36,7 +36,7 @@ class TryWithHandlerRendererImplTest extends UnitTestSuite {
         |  doSomething();
         |}
         |""".stripMargin)
-      .when(blockRenderer).render(block = eqTree(TryBlock),context = eqBlockRenderContext(BlockRenderContext()))
+      .when(blockRenderer).render(block = eqTree(TryBlock),context = eqTo(BlockRenderContext2()))
 
     tryWithHandlerRenderer.render(tryWithHandler)
 
@@ -61,7 +61,7 @@ class TryWithHandlerRendererImplTest extends UnitTestSuite {
         |  doSomething();
         |}
         |""".stripMargin)
-      .when(blockRenderer).render(block = eqTree(TryBlock), context = eqBlockRenderContext(BlockRenderContext()))
+      .when(blockRenderer).render(block = eqTree(TryBlock), context = eqTo(BlockRenderContext2()))
 
     doWrite(
       """finally {
@@ -83,15 +83,15 @@ class TryWithHandlerRendererImplTest extends UnitTestSuite {
         |""".stripMargin
   }
 
-  test("render with a 'finally', and 'expr' has uncertainReturn=true") {
+  test("render with a 'finally', when has uncertainReturn=true") {
     val tryWithHandler = Term.TryWithHandler(
       expr = TryBlock,
       catchp = CatchHandler,
       finallyp = Some(FinallyBlock)
     )
 
-    val exprContext = BlockRenderContext(lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true))
-    val tryContext = TryRenderContext(exprContext = exprContext, catchContexts = List(exprContext))
+    val exprContext = BlockRenderContext2(uncertainReturn = true)
+    val tryContext = TryRenderContext2(uncertainReturn = true)
 
     doWrite(
       """ {
@@ -99,7 +99,7 @@ class TryWithHandlerRendererImplTest extends UnitTestSuite {
         |}
         |""".stripMargin)
       .when(blockRenderer).render(
-      block = eqTree(TryBlock),context = eqBlockRenderContext(exprContext))
+      block = eqTree(TryBlock),context = eqTo(exprContext))
 
     doWrite(
       """finally {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnDefTraverserImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/traversers/DefnDefTraverserImplTest.scala
@@ -4,13 +4,11 @@ import io.github.effiban.scala2java.core.contexts._
 import io.github.effiban.scala2java.core.entities.Decision.{Uncertain, Yes}
 import io.github.effiban.scala2java.core.entities.{JavaModifier, JavaTreeType}
 import io.github.effiban.scala2java.core.matchers.BlockContextMatcher.eqBlockContext
-import io.github.effiban.scala2java.core.matchers.BlockRenderContextMockitoMatcher.eqBlockRenderContext
-import io.github.effiban.scala2java.core.matchers.BlockTraversalResultMockitoMatcher.eqBlockTraversalResult
 import io.github.effiban.scala2java.core.matchers.ModListTraversalResultMockitoMatcher.eqModListTraversalResult
 import io.github.effiban.scala2java.core.matchers.ModifiersContextMatcher.eqModifiersContext
 import io.github.effiban.scala2java.core.matchers.ModifiersRenderContextMatcher.eqModifiersRenderContext
 import io.github.effiban.scala2java.core.renderers._
-import io.github.effiban.scala2java.core.renderers.contextfactories.{BlockRenderContextFactory, ModifiersRenderContextFactory}
+import io.github.effiban.scala2java.core.renderers.contextfactories.ModifiersRenderContextFactory
 import io.github.effiban.scala2java.core.stubbers.OutputWriterStubber.doWrite
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.testtrees.TypeNames
@@ -29,7 +27,6 @@ import scala.meta.{Defn, Init, Mod, Name, Term, Type, XtensionQuasiquoteTermPara
 class DefnDefTraverserImplTest extends UnitTestSuite {
 
   private val MethodName = Term.Name("myMethod")
-  private val ClassName = Term.Name("MyClass")
 
   private val TheAnnot = Mod.Annot(
     Init(tpe = Type.Name("MyAnnotation"), name = Name.Anonymous(), argss = List())
@@ -76,7 +73,6 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
   private val termParamTraverser = mock[TermParamTraverser]
   private val termParamListRenderer = mock[TermParamListRenderer]
   private val blockWrappingTermTraverser = mock[BlockWrappingTermTraverser]
-  private val blockRenderContextFactory = mock[BlockRenderContextFactory]
   private val blockRenderer = mock[BlockRenderer]
   private val termTypeInferrer = mock[TermTypeInferrer]
   private val defnDefTransformer = mock[DefnDefTransformer]
@@ -93,7 +89,6 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
     termParamTraverser,
     termParamListRenderer,
     blockWrappingTermTraverser,
-    blockRenderContextFactory,
     blockRenderer,
     termTypeInferrer,
     defnDefTransformer)
@@ -142,14 +137,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext(shouldReturnValue = Yes))
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -206,14 +200,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext())
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -276,14 +269,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext())
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -339,15 +331,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext(shouldReturnValue = Uncertain))
     )
-    val blockRenderContext = BlockRenderContext(lastStatContext = SimpleBlockStatRenderContext(uncertainReturn = true))
-    doReturn(blockRenderContext).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(blockRenderContext)
+      context = eqTo(BlockRenderContext2(uncertainReturn = true))
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -405,14 +395,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext(shouldReturnValue = Yes))
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -470,14 +459,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(body),
       context = eqBlockContext(BlockContext(shouldReturnValue = Yes))
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(body),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -534,14 +522,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext(shouldReturnValue = Yes))
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))
@@ -600,14 +587,13 @@ class DefnDefTraverserImplTest extends UnitTestSuite {
       .when(blockWrappingTermTraverser).traverse(eqTree(Statement1),
       context = eqBlockContext(BlockContext(shouldReturnValue = Yes))
     )
-    doReturn(BlockRenderContext()).when(blockRenderContextFactory)(eqBlockTraversalResult(blockTraversalResult))
     doWrite(
       """ {
         |  /* BODY */
         |}
         |""".stripMargin)
       .when(blockRenderer).render(block = eqTree(block),
-      context = eqBlockRenderContext(BlockRenderContext())
+      context = eqTo(BlockRenderContext2())
     )
 
     defnDefTraverser.traverse(InitialDefnDef, DefnDefContext(javaScope = javaScope))


### PR DESCRIPTION
Simplify the logic of the 'uncertain return' hint which is presented when a method return type is missing and cannot be inferred by the tool.
From now on the renderers will decide whether this is needed, using the given types and without any inference.
This is slightly less accurate than before - but anyway it is only a hint, and spares a lot(!) of cumbersome code for passing the information from the traversers to the renderers