### PR TITLE
Support the rendering of the `Init` of an anonymous class

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TemplateRenderer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/TemplateRenderer.scala
@@ -27,12 +27,13 @@ private[renderers] class TemplateRendererImpl(initListRenderer: => InitListRende
 
   private def renderTemplateInits(inits: List[Init], context: TemplateRenderContext): Unit = {
     if (inits.nonEmpty) {
-      val inheritanceKeyword = context.maybeInheritanceKeyword
-        .getOrElse(throw new IllegalStateException("The template contains inits but no Java inheritance keyword was specified"))
       write(" ")
-      writeKeyword(inheritanceKeyword)
-      write(" ")
-      initListRenderer.render(inits, InitRenderContext(ignoreArgs = true))
+      context.maybeInheritanceKeyword.foreach(inheritanceKeyword => {
+        writeKeyword(inheritanceKeyword)
+        write(" ")
+      })
+      val initContext = InitRenderContext(ignoreArgs = !context.renderInitArgs, renderEmpty = context.renderInitArgs)
+      initListRenderer.render(inits, initContext)
     }
   }
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/contexts/TemplateRenderContext.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/renderers/contexts/TemplateRenderContext.scala
@@ -5,5 +5,6 @@ import io.github.effiban.scala2java.core.entities.JavaKeyword
 import scala.meta.Name
 
 case class TemplateRenderContext(maybeInheritanceKeyword: Option[JavaKeyword] = None,
+                                 renderInitArgs: Boolean = false,
                                  permittedSubTypeNames: List[Name] = Nil,
                                  bodyContext: TemplateBodyRenderContext = TemplateBodyRenderContext())


### PR DESCRIPTION
The second pre-requisite for restoring support for anonymous classes.
Unlike a regular class, the `Init` (parent) of an anonymous class should be rendered without an inheritance keyword.
In addition its parent (in Java) requires empty parens, unlike the regular class parent which requires nothing at all.