### PR TITLE
Full support for adding imports of qualified Java names near end of flow

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TermSelectImporterGenerator.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TermSelectImporterGenerator.scala
@@ -1,0 +1,31 @@
+package io.github.effiban.scala2java.core.importmanipulation
+
+import scala.meta.{Importer, Term, XtensionQuasiquoteTerm}
+
+trait TermSelectImporterGenerator {
+  def generate(termSelect: Term.Select): Option[Importer]
+}
+
+private[importmanipulation] class TermSelectImporterGeneratorImpl(qualifiedNameImporterGenerator: QualifiedNameImporterGenerator)
+  extends TermSelectImporterGenerator {
+
+  override def generate(termSelect: Term.Select): Option[Importer] = termSelect.parent match {
+    case Some(_: Term.Apply) | Some(_: Term.ApplyType) => None
+    case _ => generateInner(termSelect)
+  }
+
+  private def generateInner(termSelect: Term.Select): Option[Importer] = termSelect match {
+    case q"scala.Array" => None
+    case Term.Select(qual: Term.Ref, name) if qual.isPath => generateForStaticField(qual, name).orElse(generateForType(qual, name))
+    case _ => None
+  }
+
+  private def generateForStaticField(qual: Term.Ref, name: Term.Name): Option[Importer] =
+    qualifiedNameImporterGenerator.generateForStaticField(qual, name.value)
+
+  private def generateForType(qual: Term.Ref, name: Term.Name): Option[Importer] =
+    qualifiedNameImporterGenerator.generateForType(qual, name.value)
+}
+
+object TermSelectImporterGenerator extends TermSelectImporterGeneratorImpl(QualifiedNameImporterGenerator)
+

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TreeImporterGenerator.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TreeImporterGenerator.scala
@@ -1,13 +1,14 @@
 package io.github.effiban.scala2java.core.importmanipulation
 
 import scala.collection.mutable
-import scala.meta.{Importer, Term, Traverser, Tree, Type}
+import scala.meta.{Importer, Pkg, Term, Traverser, Tree, Type}
 
 trait TreeImporterGenerator {
   def generate(tree: Tree): List[Importer]
 }
 
 private[importmanipulation] class TreeImporterGeneratorImpl(termApplyImporterGenerator: TermApplyImporterGenerator,
+                                                            termSelectImporterGenerator: TermSelectImporterGenerator,
                                                             typeSelectImporterGenerator: TypeSelectImporterGenerator) extends TreeImporterGenerator {
 
   override def generate(tree: Tree): List[Importer] = {
@@ -21,16 +22,34 @@ private[importmanipulation] class TreeImporterGeneratorImpl(termApplyImporterGen
     val importersBuilder: mutable.Builder[Importer, List[Importer]] = List.newBuilder[Importer]
 
     override def apply(tree: Tree): Unit = tree match {
-      case termApply: Term.Apply => importersBuilder ++= termApplyImporterGenerator.generate(termApply)
-      case _: Term.Select => // TODO handle standalone qualified names when relevant, with reflection
+      case _: Importer | _: Pkg =>
+      case termApply: Term.Apply => generateForTermApply(termApply)
+      case termSelect: Term.Select => generateForTermSelect(termSelect)
       case typeSelect: Type.Select => importersBuilder ++= typeSelectImporterGenerator.generate(typeSelect)
       case _: Type.Project => // TODO
       case _ => super.apply(tree)
+    }
+
+    private def generateForTermApply(termApply: Term.Apply): Unit = {
+      termApplyImporterGenerator.generate(termApply) match {
+        case Some(importer) =>
+          importersBuilder += importer
+          super.apply(termApply.args)
+        case None => super.apply(termApply)
+      }
+    }
+
+    private def generateForTermSelect(termSelect: Term.Select): Unit = {
+      termSelectImporterGenerator.generate(termSelect) match {
+        case Some(importer) => importersBuilder += importer
+        case None => super.apply(termSelect)
+      }
     }
   }
 }
 
 object TreeImporterGenerator extends TreeImporterGeneratorImpl(
   TermApplyImporterGenerator,
+  TermSelectImporterGenerator,
   TypeSelectImporterGenerator
 )

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/TermApplyImporterGeneratorTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/TermApplyImporterGeneratorTest.scala
@@ -1,21 +1,50 @@
 package io.github.effiban.scala2java.core.importmanipulation
 
-import io.github.effiban.scala2java.core.importmanipulation.TermApplyImporterGenerator.generate
 import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.CombinedMatchers.eqTreeList
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import org.mockito.ArgumentMatchersSugar.eqTo
 
 import scala.meta.{XtensionQuasiquoteImporter, XtensionQuasiquoteTerm}
 
 class TermApplyImporterGeneratorTest extends UnitTestSuite {
 
-  test("generate() for 'java.util.List.of()' should return the corresponding Importer") {
-    generate(q"java.util.List.of()").value.structure shouldBe importer"java.util.List.of".structure
+  private val qualifiedNameImporterGenerator = mock[QualifiedNameImporterGenerator]
+
+  private val termApplyImporterGenerator = new TermApplyImporterGeneratorImpl(qualifiedNameImporterGenerator)
+
+  test("generate() for 'A.b(3)' when identified by the inner generator as a Java static method call, should return the result of the inner generator") {
+    val importer = importer"A.b"
+    when(qualifiedNameImporterGenerator.generateForStaticMethod(eqTree(q"A"), eqTo("b"), eqTreeList(List(q"3")))).thenReturn(Some(importer))
+    termApplyImporterGenerator.generate(q"A.b(3)").value.structure shouldBe importer.structure
   }
 
-  test("generate() for 'java.util.Optional.empty()' should return the corresponding Importer") {
-    generate(q"java.util.Optional.empty()").value.structure shouldBe importer"java.util.Optional.empty".structure
+  test("generate() for 'A.B.c(3)' when identified by the inner generator as a Java static method call, should return the result of the inner generator") {
+    val importer = importer"A.B.c"
+    when(qualifiedNameImporterGenerator.generateForStaticMethod(eqTree(q"A.B"), eqTo("c"), eqTreeList(List(q"3")))).thenReturn(Some(importer))
+    termApplyImporterGenerator.generate(q"A.B.c(3)").value.structure shouldBe importer.structure
   }
 
-  test("generate() for 'a.foo()' should return None") {
-    generate(q"a.foo()") shouldBe None
+  test("generate() for 'A.b(3)' when not identified by the inner generator as a Java static method call, should return None") {
+    when(qualifiedNameImporterGenerator.generateForStaticMethod(eqTree(q"A"), eqTo("b"), eqTreeList(List(q"3")))).thenReturn(None)
+    termApplyImporterGenerator.generate(q"A.b(3)") shouldBe None
+  }
+
+  test("generate() for 'A.b(3).C.D(4)' should not call the inner generator and should return None") {
+    termApplyImporterGenerator.generate(q"A.b(3).C.D(4)") shouldBe None
+
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
+  }
+
+  test("generate() for 'func(2)' should not call the inner generator and should return None") {
+    termApplyImporterGenerator.generate(q"func(2)") shouldBe None
+
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
+  }
+
+  test("generate() for 'scala.Array.apply(2)' should not call the inner generator and should return None") {
+    termApplyImporterGenerator.generate(q"scala.Array.apply(2)") shouldBe None
+
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
   }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/TermSelectImporterGeneratorImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/TermSelectImporterGeneratorImplTest.scala
@@ -1,0 +1,94 @@
+package io.github.effiban.scala2java.core.importmanipulation
+
+import io.github.effiban.scala2java.core.entities.TermSelects.ScalaArray
+import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
+import io.github.effiban.scala2java.test.utils.matchers.TreeMatcher.eqTree
+import org.mockito.ArgumentMatchersSugar.eqTo
+
+import scala.meta.{Term, XtensionQuasiquoteImporter, XtensionQuasiquoteTerm}
+
+class TermSelectImporterGeneratorImplTest extends UnitTestSuite {
+
+  private val qualifiedNameImporterGenerator = mock[QualifiedNameImporterGenerator]
+
+  private val termSelectImporterGenerator = new TermSelectImporterGeneratorImpl(qualifiedNameImporterGenerator)
+
+  test("generate() for 'A.b' when identified by the inner generator as a Java static field, should return the result of the inner generator") {
+    val termSelect = q"A.b"
+    val expectedImporter = importer"A.b"
+
+    when(qualifiedNameImporterGenerator.generateForStaticField(eqTree(q"A"), eqTo("b"))).thenReturn(Some(expectedImporter))
+
+    termSelectImporterGenerator.generate(termSelect).value.structure shouldBe expectedImporter.structure
+  }
+
+  test("generate() for 'A.B.c' when identified by the inner generator as a Java static field, should return the result of the inner generator") {
+    val termSelect = q"A.B.c"
+    val expectedImporter = importer"A.B.c"
+
+    when(qualifiedNameImporterGenerator.generateForStaticField(eqTree(q"A.B"), eqTo("c"))).thenReturn(Some(expectedImporter))
+
+    termSelectImporterGenerator.generate(termSelect).value.structure shouldBe expectedImporter.structure
+  }
+
+  test("generate() for 'A.B' when identified by the inner generator as a Java type, should return the result of the inner generator") {
+    val termSelect = q"A.B"
+    val expectedImporter = importer"A.B"
+
+    when(qualifiedNameImporterGenerator.generateForStaticField(eqTree(q"A"), eqTo("B"))).thenReturn(None)
+    when(qualifiedNameImporterGenerator.generateForType(eqTree(q"A"), eqTo("B"))).thenReturn(Some(expectedImporter))
+
+    termSelectImporterGenerator.generate(termSelect).value.structure shouldBe expectedImporter.structure
+  }
+
+  test("generate() for 'A.B.C' when identified by the inner generator as a Java type, should return the result of the inner generator") {
+    val termSelect = q"A.B.C"
+    val expectedImporter = importer"A.B.C"
+
+    when(qualifiedNameImporterGenerator.generateForStaticField(eqTree(q"A.B"), eqTo("C"))).thenReturn(None)
+    when(qualifiedNameImporterGenerator.generateForType(eqTree(q"A.B"), eqTo("C"))).thenReturn(Some(expectedImporter))
+
+    termSelectImporterGenerator.generate(termSelect).value.structure shouldBe expectedImporter.structure
+  }
+
+  test("generate() for 'A.b' when not identified by the inner generator as static field or a type, should return None") {
+    val termSelect = q"A.b"
+
+    when(qualifiedNameImporterGenerator.generateForStaticField(eqTree(q"A"), eqTo("b"))).thenReturn(None)
+    when(qualifiedNameImporterGenerator.generateForType(eqTree(q"A"), eqTo("b"))).thenReturn(None)
+
+    termSelectImporterGenerator.generate(termSelect) shouldBe None
+  }
+
+  test("generate() for 'a.b(3)' should not call the inner generator and should return None") {
+    val termApply = q"a.b(3)"
+    val termSelect = termApply.fun.asInstanceOf[Term.Select]
+
+    termSelectImporterGenerator.generate(termSelect) shouldBe None
+    
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
+  }
+
+  test("generate() for a qualified name in a Term.ApplyType should not call the inner generator and should return None") {
+    val termApplyType = q"a.b[C]"
+    val termSelect = termApplyType.fun.asInstanceOf[Term.Select]
+
+    termSelectImporterGenerator.generate(termSelect) shouldBe None
+
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
+  }
+
+  test("generate() for a qualified name that is not a path should not call the inner generator and should return None") {
+    val termSelect = q"(a.calculate(b)).c.d"
+
+    termSelectImporterGenerator.generate(termSelect) shouldBe None
+
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
+  }
+
+  test("generate() for a Scala Array should not call the inner generator and should return None") {
+    termSelectImporterGenerator.generate(ScalaArray) shouldBe None
+    
+    verifyNoMoreInteractions(qualifiedNameImporterGenerator)
+  }
+}


### PR DESCRIPTION
Until now the support was limited to specific hard-coded static method calls, and now it is extended to any qualified name which can be found in the classpath, including:
- Qualified static fields
- Qualified types (supported before but only when defined as a Scala `Type.Select`. Now they are also handled when appearing in an expression, where the Java interpretation is different)
- Qualified static methods