### PR TITLE
In 'remove unused Scala imports' phase, keep imports used by qualified names

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TermSelectImporterMatcher.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TermSelectImporterMatcher.scala
@@ -13,7 +13,6 @@ object TermSelectImporterMatcher extends TermSelectImporterMatcher {
   }
 
   private def qualMatchesRef(termSelect: Term.Select, importer: Importer) = {
-    // TODO support partial match (when full importer is a prefix of qual)
     termSelect.qual.structure == importer.ref.structure
   }
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TreeImporterUsed.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/TreeImporterUsed.scala
@@ -18,7 +18,7 @@ private[importmanipulation] class TreeImporterUsedImpl(termNameImporterMatcher: 
     var inUse = false
 
     override def apply(tree: Tree): Unit = tree match {
-      case _: Term.Select => //TODO support match by qualifier prefix
+      case termSelect: Term.Select => apply(termSelect.qual)
       case termName: Term.Name => checkTermName(termName)
       case _: Type.Select => //TODO support match by qualifier prefix
       case _: Type.Project => //TODO support match by qualifier prefix

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/TreeImporterUsedImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/TreeImporterUsedImplTest.scala
@@ -44,6 +44,36 @@ class TreeImporterUsedImplTest extends UnitTestSuite {
     treeImporterUsed(theObject, importer) shouldBe true
   }
 
+  test("apply() for a Object when has a partially-matching matching nested Term.Select should return true") {
+    val theObject =
+      q"""
+      object A {
+        final var x = C.foo
+      }
+      """
+
+    val importer = importer"B.C"
+
+    doReturn(Some(importer)).when(termNameImporterMatcher).findMatch(eqTree(q"C"), eqTree(importer))
+
+    treeImporterUsed(theObject, importer) shouldBe true
+  }
+
+  test("apply() for a Object when has a non-matching matching nested Term.Select should return false") {
+    val theObject =
+      q"""
+      object A {
+        final var x = C.foo
+      }
+      """
+
+    val importer = importer"B.D"
+
+    doReturn(None).when(termNameImporterMatcher).findMatch(eqTree(q"C"), eqTree(importer))
+
+    treeImporterUsed(theObject, importer) shouldBe false
+  }
+
   test("apply() for an Object when has no matching nested trees should return false") {
     val theObject =
       q"""


### PR DESCRIPTION
Until now, only imports of `Term.Name`-s were retained