### PR TITLE
Qualify `java.lang` types explicitly at start of flow

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/Scala2JavaTranslator.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/Scala2JavaTranslator.scala
@@ -49,7 +49,8 @@ object Scala2JavaTranslator {
             new SemanticDesugarers().sourceDesugarer.desugar,
             new ScalaTreeTraversers().sourceTraverser.traverse,
             SourceImportAdder.addTo,
-            SourceUnqualifier.unqualify
+            SourceUnqualifier.unqualify,
+            SourceImportRemover.removeJavaLangFrom
           )
         ).andThen(Enrichers.sourceEnricher.enrich)
         .andThen(enrichedSource => renderJava(enrichedSource, scalaPath, maybeOutputJavaBasePath))

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/PkgImportRemover.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/PkgImportRemover.scala
@@ -1,24 +1,37 @@
 package io.github.effiban.scala2java.core.importmanipulation
 
+import io.github.effiban.scala2java.core.entities.TermSelects.JavaLang
+
+import scala.annotation.unused
 import scala.meta.{Import, Importer, Pkg, Stat}
 
 trait PkgImportRemover {
   def removeUnusedFrom(pkg: Pkg): Pkg
+
+  def removeJavaLangFrom(pkg: Pkg): Pkg
 }
 
 private[importmanipulation] class PkgImportRemoverImpl(statsByImportSplitter: StatsByImportSplitter, treeImporterUsed: TreeImporterUsed)
   extends PkgImportRemover {
 
-  override def removeUnusedFrom(pkg: Pkg): Pkg = {
+  override def removeUnusedFrom(pkg: Pkg): Pkg = removeFrom(pkg, isImporterUsed)
+
+  override def removeJavaLangFrom(pkg: Pkg): Pkg = removeFrom(pkg, isNotJavaLangImporter)
+
+  private def removeFrom(pkg: Pkg, isImporterRequired: (Importer, List[Stat]) => Boolean) = {
     val (initialImporters, nonImports) = statsByImportSplitter.split(pkg.stats)
-    val finalImports = initialImporters.filter(importer => importerUsed(importer, nonImports))
+    val finalImports = initialImporters.filter(importer => isImporterRequired(importer, nonImports))
       .map(importer => Import(List(importer)))
 
     pkg.copy(stats = finalImports ++ nonImports)
   }
 
-  def importerUsed(importer: Importer, nonImports: List[Stat]): Boolean = {
+  private def isImporterUsed(importer: Importer, nonImports: List[Stat]): Boolean = {
     nonImports.exists(nonImport => treeImporterUsed(nonImport, importer))
+  }
+
+  private def isNotJavaLangImporter(importer: Importer, @unused ignored: List[Stat]): Boolean = {
+    importer.ref.structure != JavaLang.structure
   }
 }
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/SourceImportRemover.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/importmanipulation/SourceImportRemover.scala
@@ -4,6 +4,8 @@ import scala.meta.{Pkg, Source}
 
 trait SourceImportRemover {
   def removeUnusedFrom(source: Source): Source
+
+  def removeJavaLangFrom(source: Source): Source
 }
 
 private[importmanipulation] class SourceImportRemoverImpl(pkgImportRemover: PkgImportRemover) extends SourceImportRemover {
@@ -11,10 +13,13 @@ private[importmanipulation] class SourceImportRemoverImpl(pkgImportRemover: PkgI
   override def removeUnusedFrom(source: Source): Source = {
     source.transform {
       case pkg: Pkg => pkgImportRemover.removeUnusedFrom(pkg)
-    } match {
-      case transformedSource: Source => transformedSource
-      case other => throw new IllegalStateException(s"The transformed source should also be a Source but it is: $other")
-    }
+    }.asInstanceOf[Source]
+  }
+
+  override def removeJavaLangFrom(source: Source): Source = {
+    source.transform {
+      case pkg: Pkg => pkgImportRemover.removeJavaLangFrom(pkg)
+    }.asInstanceOf[Source]
   }
 }
 

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/SourceImportRemoverImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/importmanipulation/SourceImportRemoverImplTest.scala
@@ -86,4 +86,79 @@ class SourceImportRemoverImplTest extends UnitTestSuite {
     sourceImportRemover.removeUnusedFrom(initialSource).structure shouldBe expectedFinalSource.structure
   }
 
+  test("removeJavaLangFrom() when has no packages should return unchanged") {
+    val source = Source(List(q"val x: Int = 3"))
+
+    sourceImportRemover.removeJavaLangFrom(source).structure shouldBe source.structure
+  }
+
+  test("removeJavaLangFrom() when has packages should return a Source containing the packages with removed imports") {
+    val initialPkg1 =
+      q"""
+      package pkg1 {
+        import java.lang.A
+
+        trait Trait1 { val x: c.D }
+      }
+      """
+
+    val initialPkg2 =
+      q"""
+      package pkg2 {
+        import java.lang.B
+
+        trait Trait2 { val y: g.H }
+      }
+      """
+
+    val initialSource =
+      source"""
+      package pkg1 {
+        import java.lang.A
+
+        trait Trait1 { val x: c.D }
+      }
+      package pkg2 {
+        import java.lang.B
+
+        trait Trait2 { val y: g.H }
+      }
+      """
+
+    val expectedFinalPkg1 =
+      q"""
+      package pkg1 {
+
+        trait Trait1 { val x: c.D }
+      }
+      """
+
+    val expectedFinalPkg2 =
+      q"""
+      package pkg2 {
+
+        trait Trait2 { val y: g.H }
+      }
+      """
+
+    val expectedFinalSource =
+      source"""
+      package pkg1 {
+
+        trait Trait1 { val x: c.D }
+      }
+      package pkg2 {
+
+        trait Trait2 { val y: g.H }
+      }
+      """
+
+    doAnswer((pkg: Pkg) => pkg match {
+      case aPkg if aPkg.structure == initialPkg1.structure => expectedFinalPkg1
+      case aPkg if aPkg.structure == initialPkg2.structure => expectedFinalPkg2
+      case aPkg => throw new IllegalStateException(s"No final Pkg has been stubbed for initial Pkg $aPkg")
+    }).when(pkgImportRemover).removeJavaLangFrom(any[Pkg])
+
+    sourceImportRemover.removeJavaLangFrom(initialSource).structure shouldBe expectedFinalSource.structure
+  }
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/qualifiers/CoreTypeNameQualifierTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/qualifiers/CoreTypeNameQualifierTest.scala
@@ -36,6 +36,7 @@ class CoreTypeNameQualifierTest extends UnitTestSuite {
     (t"Function", ScalaFunction),
     (t"Fractional", ScalaFractional),
     (t"IllegalArgumentException", ScalaIllegalArgumentException),
+    (t"IllegalStateException", t"java.lang.IllegalStateException"),
     (t"Int", ScalaInt),
     (t"IndexedSeq", ScalaIndexedSeq),
     (t"IndexOutOfBoundsException", ScalaIndexOutOfBoundsException),


### PR DESCRIPTION
To increase robustness, qualifyiing the `java.lang` types (just like the terms) explicitly even though they are implicitly qualified as such in both Scala and Java.
This is to avoid any clashes that could misidentify the real types before the transformation phase from Scala to Java types.