### PR TITLE
Infer an enclosing template even if the template has no parent

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/InnermostEnclosingTemplateInferrer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/InnermostEnclosingTemplateInferrer.scala
@@ -18,7 +18,7 @@ object InnermostEnclosingTemplateInferrer extends InnermostEnclosingTemplateInfe
     (tree, tree.parent, maybeEnclosingMemberName) match {
       case (template: Template, Some(parent: Member), Some(enclosingMemberName))
         if enclosingMemberName == parent.name.value => Some(template)
-      case (template: Template, Some(_), None) => Some(template)
+      case (template: Template, _, None) => Some(template)
       case (_, Some(parent), maybeEncMemName) => inferInner(parent, maybeEncMemName)
       case _ => None
     }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/InnermostEnclosingTemplateInferrerImplTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/typeinference/InnermostEnclosingTemplateInferrerImplTest.scala
@@ -4,7 +4,7 @@ import io.github.effiban.scala2java.core.testsuites.UnitTestSuite
 import io.github.effiban.scala2java.core.typeinference.InnermostEnclosingTemplateInferrer.infer
 
 import scala.meta.Term.Block
-import scala.meta.{Defn, XtensionQuasiquoteTerm}
+import scala.meta.{Defn, XtensionQuasiquoteTemplate, XtensionQuasiquoteTerm}
 
 class InnermostEnclosingTemplateInferrerImplTest extends UnitTestSuite {
 
@@ -82,6 +82,19 @@ class InnermostEnclosingTemplateInferrerImplTest extends UnitTestSuite {
     val e = classD.templ.stats.head
 
     infer(e).value.structure shouldBe classD.templ.structure
+  }
+
+  test("infer for Defn.Val of template without a parent class, should return the template") {
+    val template =
+      template"""
+      A {
+        val e: scala.Int = 3
+      }
+      """
+
+    val e = template.stats.head
+
+    infer(e).value.structure shouldBe template.structure
   }
 
   test("infer for Defn.Val inside a Defn.Def with enclosing member name, should return the corresponding class template") {


### PR DESCRIPTION
A template might have no parent during the phase of qualification, whenm the template inits are qualified right before the children, and then the template object they see has lost its original parent.
However we must still be able to search and find the template from a child tree, so we can qualify the child properly.
Therefore we must be able to ignore the temporarily missing parent of the template (class/trait/object) and not treat it as invalid. 