### PR TITLE
Ignore extra files in integration test dirs without failing

### DIFF
--- a/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/runner/IntegrationTestRunner.scala
+++ b/scala2java-test-utils/src/main/scala/io/github/effiban/scala2java/test/utils/integration/runner/IntegrationTestRunner.scala
@@ -186,7 +186,7 @@ trait IntegrationTestRunner
 
   private def toPathPair(paths: List[Path]): Option[PathPair] = {
     val pathMap = paths.map(path => (extractFileExtension(path), path)).toMap
-    if (pathMap.keys.toSet == Set(FileExtensions.Scala, JavaTestExtension)) {
+    if (Set(FileExtensions.Scala, JavaTestExtension).subsetOf(pathMap.keySet)) {
       Some(PathPair(scalaPath = pathMap(FileExtensions.Scala), javaPath = pathMap(JavaTestExtension)))
     } else {
       None


### PR DESCRIPTION
The integration test framework assumes there will be exactly two test files in each folder - a Scala file and corresponding Java file.
However sometimes the OS might add hidden files to a dir, e.g. Mac will do this when the Finder is opened - to optimize the UI display of the folder.
In such cases we have no reason to mark this folder as invalid and lose the tests - so I changed the logic to check for **at least** the 2 files needed. 