### PR TITLE
When a template extends an empty type, mark it as used only if non-trivial

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/cleanup/IsTemplateAncestorUsedByEmptiness.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/cleanup/IsTemplateAncestorUsedByEmptiness.scala
@@ -1,6 +1,6 @@
 package io.github.effiban.scala2java.core.cleanup
 
-import io.github.effiban.scala2java.core.reflection.ScalaReflectionUtils.typeExistsAndIsEmpty
+import io.github.effiban.scala2java.core.reflection.ScalaReflectionUtils.isNonTrivialEmptyType
 
 import scala.meta.{Template, Type}
 
@@ -11,5 +11,5 @@ import scala.meta.{Template, Type}
  */
 object IsTemplateAncestorUsedByEmptiness extends IsTemplateAncestorUsed {
 
-  def apply(template: Template, ancestorType: Type.Ref): Boolean = typeExistsAndIsEmpty(ancestorType)
+  def apply(template: Template, ancestorType: Type.Ref): Boolean = isNonTrivialEmptyType(ancestorType)
 }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/cleanup/IsTemplateAncestorUsedByEmptinessTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/cleanup/IsTemplateAncestorUsedByEmptinessTest.scala
@@ -29,6 +29,17 @@ class IsTemplateAncestorUsedByEmptinessTest extends UnitTestSuite {
     apply(cls.templ, t"io.github.effiban.scala2java.core.cleanup.IsTemplateAncestorUsedByEmptinessTest#EmptyTrait") shouldBe true
   }
 
+  test("apply for class extending java.io.Serializable should return false") {
+    val cls =
+      q"""
+      class A extends java.io.Serializable {
+        val x = 3
+      }
+      """
+
+    apply(cls.templ, t"java.io.Serializable") shouldBe false
+  }
+
   test("apply for class extending non-empty class should return false") {
     val cls =
       q"""

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionUtilsTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionUtilsTest.scala
@@ -157,28 +157,32 @@ class ScalaReflectionUtilsTest extends UnitTestSuite {
     isTypeMemberOf(RuntimeMirror.staticPackage("scala.collection.immutable"), Type.Name("bla")) shouldBe false
   }
 
-  test("typeExistsAndIsEmpty() for a type which exists and is empty, should return true") {
-    typeExistsAndIsEmpty(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#EmptyTrait") shouldBe true
+  test("isNonTrivialEmptyType() for a type which exists and is empty, should return true") {
+    isNonTrivialEmptyType(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#EmptyTrait") shouldBe true
   }
 
-  test("typeExistsAndIsEmpty() for a type which has a non-trivial parent and nothing else, should return false") {
-    typeExistsAndIsEmpty(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithNonTrivialParentOnly") shouldBe false
+  test("isNonTrivialEmptyType() for a type which has a non-trivial parent and nothing else, should return false") {
+    isNonTrivialEmptyType(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithNonTrivialParentOnly") shouldBe false
   }
 
-  test("typeExistsAndIsEmpty() for a type which has a non-default constructor and nothing else, should return false") {
-    typeExistsAndIsEmpty(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithNonDefaultCtorOnly") shouldBe false
+  test("isNonTrivialEmptyType() for a type which has a non-default constructor and nothing else, should return false") {
+    isNonTrivialEmptyType(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithNonDefaultCtorOnly") shouldBe false
   }
 
-  test("typeExistsAndIsEmpty() for a type which has no parents and default ctor. but has data members, should return false") {
-    typeExistsAndIsEmpty(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithDataMembersOnly") shouldBe false
+  test("isNonTrivialEmptyType() for a type which has no parents and default ctor. but has data members, should return false") {
+    isNonTrivialEmptyType(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithDataMembersOnly") shouldBe false
   }
 
-  test("typeExistsAndIsEmpty() for a type which has no parents and default ctor. but has methods, should return false") {
-    typeExistsAndIsEmpty(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithMethodsOnly") shouldBe false
+  test("isNonTrivialEmptyType() for a type which has no parents and default ctor. but has methods, should return false") {
+    isNonTrivialEmptyType(t"io.github.effiban.scala2java.core.reflection.ScalaReflectionUtilsTest#ClassWithMethodsOnly") shouldBe false
   }
 
-  test("typeExistsAndIsEmpty() for a type which has a constructor and members, should return false") {
-    typeExistsAndIsEmpty(t"scala.concurrent.duration.FiniteDuration") shouldBe false
+  test("isNonTrivialEmptyType() for a type which has a constructor and members, should return false") {
+    isNonTrivialEmptyType(t"scala.concurrent.duration.FiniteDuration") shouldBe false
+  }
+
+  test("isNonTrivialEmptyType() for 'Serializable', should return false") {
+    isNonTrivialEmptyType(t"java.io.Serializable") shouldBe false
   }
 
   trait EmptyTrait


### PR DESCRIPTION
The tool employs logic to check of the parents of a template are still being used, after the translation tp Java. 
Until now, any empty parent was considered as a 'marker' type that is part of the application's business logic so it cannot be removed. 

However `java.io.Serializable` is a special case. This is because in Scala 2.x many framework classes and traits are marked with `Serializable`, although it is not always mandatory for the corresponding Java types. 
Even though `Serializable` is not really a trivial interface, it is not used often nowadays, and so it is assumed for the purpose of this tool that we can always ignore a `Serializable` which is inherited from a Scala type and remove it in the Java version - and transfer responsibility to the user to check and see if it needs to be added back, in those uncommon cases where it does. 