### PR TITLE
Support `Term.Select` type inference when qualifier parameterized with actual param

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionInternalLookup.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionInternalLookup.scala
@@ -47,4 +47,16 @@ private[reflection] object ScalaReflectionInternalLookup {
     // Convert each supertype into a TypeTag and extract its type arguments
     baseTypes.map(createTypeTagOf)
   }
+
+  def resolveAncestorTypeParamToTypeArg(ancestorTypeTag: TypeTag[_], typeTag: TypeTag[_]): Map[TypeSymbol, Type] = {
+    val theSelfAndBaseTypeTags = findSelfAndBaseTypeTagsOf(typeTag)
+    theSelfAndBaseTypeTags.find(_.tpe.typeSymbol == ancestorTypeTag.tpe.typeSymbol) match {
+      case Some(ownerTypeTag) => ancestorTypeTag.tpe.typeParams.indices
+        .slice(0, ownerTypeTag.tpe.typeArgs.size)
+        .map(idx => (ancestorTypeTag.tpe.typeParams(idx), ownerTypeTag.tpe.typeArgs(idx)))
+        .map { case (typeParam: TypeSymbol, typeArg) => (typeParam, typeArg) }
+        .toMap
+      case None => Map.empty
+    }
+  }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrer.scala
@@ -1,11 +1,14 @@
 package io.github.effiban.scala2java.core.reflection
 
+import io.github.effiban.scala2java.core.entities.TreeKeyedMap
+import io.github.effiban.scala2java.core.entities.TypeSelects.ScalaAny
 import io.github.effiban.scala2java.core.reflection.ScalaReflectionClassifier.isTrivialClassFullName
 import io.github.effiban.scala2java.core.reflection.ScalaReflectionCreator.createTypeTagOf
-import io.github.effiban.scala2java.core.reflection.ScalaReflectionInternalLookup.{findModuleSymbolOf, findSelfAndBaseTypeTagsOf}
-import io.github.effiban.scala2java.core.reflection.ScalaReflectionTransformer.{toClassSymbol, toScalaMetaType}
+import io.github.effiban.scala2java.core.reflection.ScalaReflectionInternalLookup.{findModuleSymbolOf, findSelfAndBaseTypeTagsOf, resolveAncestorTypeParamToTypeArg}
+import io.github.effiban.scala2java.core.reflection.ScalaReflectionTransformer.{asScalaMetaTypeNameToType, toClassSymbol, toScalaMetaType, toTypeTag}
 
-import scala.meta.{Term, Type}
+import scala.meta.transversers.Transformer
+import scala.meta.{Term, Tree, Type}
 import scala.reflect.runtime.universe._
 
 trait ScalaReflectionTypeInferrer {
@@ -13,6 +16,8 @@ trait ScalaReflectionTypeInferrer {
   def inferScalaMetaTypeOf(qual: Term.Ref, name: Term.Name): Option[Type]
 
   def inferScalaMetaTypeOf(qual: Type.Ref, name: Term.Name): Option[Type]
+
+  def inferScalaMetaTypeOf(qual: Type.Ref, qualArgs: List[Type], name: Term.Name): Option[Type]
 }
 
 object ScalaReflectionTypeInferrer extends ScalaReflectionTypeInferrer {
@@ -27,6 +32,25 @@ object ScalaReflectionTypeInferrer extends ScalaReflectionTypeInferrer {
   def inferScalaMetaTypeOf(qual: Type.Ref, name: Term.Name): Option[Type] = {
     toClassSymbol(qual) match {
       case Some(cls) => inferScalaMetaTypeOf(cls, name)
+      case _ => None
+    }
+  }
+
+  def inferScalaMetaTypeOf(qual: Type.Ref, qualArgs: List[Type], name: Term.Name): Option[Type] = {
+    toClassSymbol(qual) match {
+      case Some(qualCls) => qualCls.info.member(TermName(name.value)) match {
+        case NoSymbol => None
+        case member =>
+          val maybeQualTypeTag = toTypeTag(qual, qualArgs)
+          maybeQualTypeTag.flatMap(qualTypeTag => {
+            val owner = member.owner
+            val ownerTypeTag = createTypeTagOf(owner.typeSignature)
+            val ownerTypeParamToQualTypeArg = resolveAncestorTypeParamToTypeArg(ownerTypeTag, qualTypeTag)
+            val smOwnerTypeParamToQualTypeArg = asScalaMetaTypeNameToType(ownerTypeParamToQualTypeArg)
+            val maybeSMMemberType = toScalaMetaType(member.typeSignature)
+            maybeSMMemberType.map(replaceScalaMetaTypeParamsWithTypeArgs(_, smOwnerTypeParamToQualTypeArg))
+          })
+      }
       case _ => None
     }
   }
@@ -47,6 +71,21 @@ object ScalaReflectionTypeInferrer extends ScalaReflectionTypeInferrer {
       case _ :: baseTag :: _ => toScalaMetaType(baseTag.tpe)
       case _ => Some(smTypeSingleton)
     }
+  }
+
+  private[reflection] def replaceScalaMetaTypeParamsWithTypeArgs(tpe: Type,
+                                                                 typeParamToTypeArg: Map[Type.Name, Type]): Type = {
+    new Transformer {
+      override def apply(aTree: Tree): Tree = {
+        aTree match {
+          case tpe@(_: Type.Select | _: Type.Project) => tpe
+          case typeName: Type.Name => TreeKeyedMap.get(typeParamToTypeArg, typeName)
+            .getOrElse(ScalaAny)
+          case other => super.apply(other)
+        }
+      }
+    }.apply(tpe)
+      .asInstanceOf[Type]
   }
 }
 

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/InternalSelectTypeInferrer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/typeinference/InternalSelectTypeInferrer.scala
@@ -36,6 +36,7 @@ private[typeinference] class InternalSelectTypeInferrerImpl(applyReturnTypeInfer
     (termSelect.qual, inferenceContext.maybeQualType, termSelect.name) match {
       case (qual: Term.Ref, None, name) => inferScalaMetaTypeOf(qual, name)
       case (_, Some(qualType: Type.Ref), name) => inferScalaMetaTypeOf(qualType, name)
+      case (_, Some(Type.Apply(qualType: Type.Ref, args)), name) => inferScalaMetaTypeOf(qualType, args, name)
       case _ => None
     }
   }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrerTest.scala
@@ -50,6 +50,76 @@ class ScalaReflectionTypeInferrerTest extends UnitTestSuite {
       t"scala.collection.immutable.List[scala.Long]".structure
   }
 
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].x' " +
+    "should return 'scala.Int'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"x"
+    )
+    inferredType.value.structure shouldBe t"scala.Int".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].y' " +
+    "should return '(scala.Int, scala.Long)'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"y"
+    )
+    inferredType.value.structure shouldBe t"(scala.Int, scala.Long)".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].z' " +
+    "should return '(scala.Int, scala.Long, java.lang.String) => java.lang.String'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"z"
+    )
+    inferredType.value.structure shouldBe t"(scala.Int, scala.Long, java.lang.String) => java.lang.String".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].w' " +
+    "should return 'scala.collection.immutable.List[scala.Int]'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"w"
+    )
+    inferredType.value.structure shouldBe t"scala.collection.immutable.List[scala.Int]".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].v' " +
+    "should return 'scala.collection.immutable.List[scala.collection.immutable.List[scala.Int]]'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"v"
+    )
+    inferredType.value.structure shouldBe t"scala.collection.immutable.List[scala.collection.immutable.List[scala.Int]]".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestChildParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].x' " +
+    "should return 'scala.Int'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestChildParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"x"
+    )
+    inferredType.value.structure shouldBe t"scala.Int".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestChildParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].y' " +
+    "should return '(scala.Int, scala.Long)'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestChildParameterizedClassWithDataMembersOnly",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"y"
+    )
+    inferredType.value.structure shouldBe t"(scala.Int, scala.Long)".structure
+  }
+
   class TestInnerClassWithDataMembersOnly {
     val x: Int = 3
   }

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/TestParameterizedClassWithDataMembersOnly.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/TestParameterizedClassWithDataMembersOnly.scala
@@ -1,0 +1,11 @@
+package io.github.effiban.scala2java.core.reflection
+
+sealed class TestParameterizedClassWithDataMembersOnly[A, B, C] {
+  var x: A = _
+  var y: (A, B) = _
+  var z: (A, B, C) => C = _
+  var w: List[A] = _
+  var v: List[List[A]] = _
+}
+
+class TestChildParameterizedClassWithDataMembersOnly[A2, B2, C2] extends TestParameterizedClassWithDataMembersOnly[A2, B2, C2]


### PR DESCRIPTION
When inferring a `Term.Select` with a parameterized qualifier, it gets more complicated since the parameter needs to be resolved against its formal definition, because the member might also be parameterized.
In addition the formal definition might be in an ancestor, so we need to follow the chain of inheritance up to the original definition.
This is done by creating a `TypeTag` for the qualifier type, and using reflection to look up the hierarchy and find the matching param types. 

There is still a limitation in this solution - if the qualifier parameter is a _formal param too_, it won't work since we cannot create a `TypeTag` for it.
This will be handled in the next PR with a trick using dummy placeholder types.