### PR TITLE
Support `Term.Select` type inference when the qualifier is parameterized with formal params

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionCreator.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionCreator.scala
@@ -13,4 +13,9 @@ private[reflection] object ScalaReflectionCreator {
         tpe.asInstanceOf[U#Type]
     })
   }
+
+  def createTypeTagOf(tpe: universe.Type, typeArgs: List[universe.Type]): TypeTag[Nothing] = {
+    val appliedTypeInstance = appliedType(tpe, typeArgs: _*)
+    createTypeTagOf(appliedTypeInstance)
+  }
 }

--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTransformer.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTransformer.scala
@@ -1,13 +1,11 @@
 package io.github.effiban.scala2java.core.reflection
 
 import io.github.effiban.scala2java.core.entities.TypeSelects.ScalaAny
-import io.github.effiban.scala2java.core.reflection.ScalaReflectionCreator.createTypeTagOf
 import io.github.effiban.scala2java.core.reflection.ScalaReflectionExtractor.{dealiasedClassSymbolOf, finalResultTypeArgsOf, finalResultTypeFullnameOf, finalResultTypeOf}
 import io.github.effiban.scala2java.core.reflection.ScalaReflectionInternalClassifier.isSingletonType
 import io.github.effiban.scala2java.core.reflection.ScalaReflectionInternalLookup.{findInnerClassSymbolOf, findModuleSymbolOf}
 
 import scala.meta.{Term, Type, XtensionParseInputLike}
-import scala.reflect.internal.Flags
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe._
 
@@ -45,21 +43,6 @@ private[reflection] object ScalaReflectionTransformer {
     case typeSelect: Type.Select => toClassSymbol(typeSelect)
     case Type.Project(tpe, name) => innerClassSymbolOf(tpe, name)
     case _ => None
-  }
-
-  def toTypeTag(smTypeRef: Type.Ref, smTypeArgs: List[Type]): Option[TypeTag[_]] = {
-    val maybeBaseSymbol = toClassSymbol(smTypeRef)
-    maybeBaseSymbol.map(baseSymbol => {
-      val typeArgs = smTypeArgs.map(arg => toClassSymbol(arg).map(_.toType).getOrElse(NoType))
-      val appliedTypeInstance = appliedType(baseSymbol.toType, typeArgs: _*)
-      createTypeTagOf(appliedTypeInstance)
-    })
-  }
-
-  def asScalaMetaTypeNameToType(typeSymbolToType: Map[TypeSymbol, universe.Type]): Map[Type.Name, Type] = {
-    typeSymbolToType.map {
-      case (typeSymbol, typeArg) => (Type.Name(typeSymbol.name.toString), toScalaMetaType(typeArg).getOrElse(ScalaAny))
-    }
   }
 
   private def toScalaMetaTypeRefFromClass(symbol: Symbol): Option[Type.Ref] = {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrerTest.scala
@@ -60,6 +60,16 @@ class ScalaReflectionTypeInferrerTest extends UnitTestSuite {
     inferredType.value.structure shouldBe t"scala.Int".structure
   }
 
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[AA, BB, CC].x' " +
+    "should return 'AA'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"AA", t"BB", t"CC"),
+      q"x"
+    )
+    inferredType.value.structure shouldBe t"AA".structure
+  }
+
   test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].y' " +
     "should return '(scala.Int, scala.Long)'") {
     val inferredType = inferScalaMetaTypeOf(


### PR DESCRIPTION
See https://github.com/effiban/scala2java/pull/1125.
In this PR handling qualifiers parameterized by **formal** params.
Since they cannot be turned in to a `TypeTag` directly, using a trick:
For each formal param, mapping a dummy 'placeholder' class to it and creating a `TypeTag` from that.
Once the params have been resolved, replacing the placeholders with the original types.
Since this trick works also with the actual params, doing it always to avoid code complexity.