### PR TITLE
Support `Term.Select` type inference when the qualifier is parameterized with a formal param - part 2

### DIFF
--- a/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionInternalLookup.scala
+++ b/scala2java-core/src/main/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionInternalLookup.scala
@@ -51,9 +51,9 @@ private[reflection] object ScalaReflectionInternalLookup {
   def resolveAncestorTypeParamToTypeArg(ancestorTypeTag: TypeTag[_], typeTag: TypeTag[_]): Map[TypeSymbol, Type] = {
     val theSelfAndBaseTypeTags = findSelfAndBaseTypeTagsOf(typeTag)
     theSelfAndBaseTypeTags.find(_.tpe.typeSymbol == ancestorTypeTag.tpe.typeSymbol) match {
-      case Some(ownerTypeTag) => ancestorTypeTag.tpe.typeParams.indices
-        .slice(0, ownerTypeTag.tpe.typeArgs.size)
-        .map(idx => (ancestorTypeTag.tpe.typeParams(idx), ownerTypeTag.tpe.typeArgs(idx)))
+      case Some(appliedAncestorTypeTag) => ancestorTypeTag.tpe.typeParams.indices
+        .slice(0, appliedAncestorTypeTag.tpe.typeArgs.size)
+        .map(idx => (ancestorTypeTag.tpe.typeParams(idx), appliedAncestorTypeTag.tpe.typeArgs(idx)))
         .map { case (typeParam: TypeSymbol, typeArg) => (typeParam, typeArg) }
         .toMap
       case None => Map.empty

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrerTest.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/ScalaReflectionTypeInferrerTest.scala
@@ -70,6 +70,16 @@ class ScalaReflectionTypeInferrerTest extends UnitTestSuite {
     inferredType.value.structure shouldBe t"AA".structure
   }
 
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[List[AA], BB, CC].x' " +
+    "should return 'AA'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"List[AA]", t"BB", t"CC"),
+      q"x"
+    )
+    inferredType.value.structure shouldBe t"List[AA]".structure
+  }
+
   test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].y' " +
     "should return '(scala.Int, scala.Long)'") {
     val inferredType = inferScalaMetaTypeOf(
@@ -110,6 +120,16 @@ class ScalaReflectionTypeInferrerTest extends UnitTestSuite {
     inferredType.value.structure shouldBe t"scala.collection.immutable.List[scala.collection.immutable.List[scala.Int]]".structure
   }
 
+  test("inferScalaMetaTypeOf() for 'TestParameterizedClassWithDataMembersOnly[AA, BB, CC].v' " +
+    "should return 'scala.collection.immutable.List[scala.collection.immutable.List[scala.Int]]'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestParameterizedClassWithDataMembersOnly",
+      List(t"AA", t"BB", t"CC"),
+      q"v"
+    )
+    inferredType.value.structure shouldBe t"scala.collection.immutable.List[scala.collection.immutable.List[AA]]".structure
+  }
+
   test("inferScalaMetaTypeOf() for 'TestChildParameterizedClassWithDataMembersOnly[scala.Int, scala.Long, java.lang.String].x' " +
     "should return 'scala.Int'") {
     val inferredType = inferScalaMetaTypeOf(
@@ -128,6 +148,26 @@ class ScalaReflectionTypeInferrerTest extends UnitTestSuite {
       q"y"
     )
     inferredType.value.structure shouldBe t"(scala.Int, scala.Long)".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestChildParameterizedClassWithDataMembersOnly2[scala.Int, scala.Long, java.lang.String].x' " +
+    "should return 'scala.collection.immutable.List[scala.Int]'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestChildParameterizedClassWithDataMembersOnly2",
+      List(t"scala.Int", t"scala.Long", t"java.lang.String"),
+      q"x"
+    )
+    inferredType.value.structure shouldBe t"scala.collection.immutable.List[scala.Int]".structure
+  }
+
+  test("inferScalaMetaTypeOf() for 'TestChildParameterizedClassWithDataMembersOnly2[AA, BB, CC].x' " +
+    "should return 'scala.collection.immutable.List[AA]'") {
+    val inferredType = inferScalaMetaTypeOf(
+      t"io.github.effiban.scala2java.core.reflection.TestChildParameterizedClassWithDataMembersOnly2",
+      List(t"AA", t"BB", t"CC"),
+      q"x"
+    )
+    inferredType.value.structure shouldBe t"scala.collection.immutable.List[AA]".structure
   }
 
   class TestInnerClassWithDataMembersOnly {

--- a/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/TestParameterizedClassWithDataMembersOnly.scala
+++ b/scala2java-core/src/test/scala/io/github/effiban/scala2java/core/reflection/TestParameterizedClassWithDataMembersOnly.scala
@@ -9,3 +9,5 @@ sealed class TestParameterizedClassWithDataMembersOnly[A, B, C] {
 }
 
 class TestChildParameterizedClassWithDataMembersOnly[A2, B2, C2] extends TestParameterizedClassWithDataMembersOnly[A2, B2, C2]
+
+class TestChildParameterizedClassWithDataMembersOnly2[A2, B2, C2] extends TestParameterizedClassWithDataMembersOnly[List[A2], B2, C2]


### PR DESCRIPTION
See [part 1](https://github.com/effiban/scala2java/pull/1126).
In this PR, fixing the logic to handle more complex cases with nested params